### PR TITLE
APS parsing

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -23,9 +23,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
+          pip install --no-cache-dir --upgrade setuptools
+          pip install --no-cache-dir --upgrade wheel
           pip install -r requirements-airflow.txt -r requirements.txt -r requirements-test.txt
-
       - name: Create S3 Buckets
         run: make buckets
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ENV AIRFLOW_UID=501
 COPY requirements.txt ./requirements.txt
 COPY requirements-test.txt ./requirements-test.txt
 COPY dags ./dags
-
+RUN pip install --upgrade pip &&\
+    pip install --no-cache-dir --upgrade setuptools &&\
+    pip install --no-cache-dir --upgrade wheel &&\
+    pip install --no-cache-dir --user -r requirements.txt -r requirements-test.txt
 USER airflow
-RUN pip install --no-cache-dir --user -r requirements.txt -r requirements-test.txt
+

--- a/dags/aps/parser.py
+++ b/dags/aps/parser.py
@@ -1,0 +1,135 @@
+import re
+
+from common.parsing.json_extractors import CustomExtractor, NestedValueExtractor
+from common.parsing.parser import IParser
+from inspire_utils.record import get_value
+from structlog import get_logger
+
+
+class APSParser(IParser):
+    def __init__(self) -> None:
+        self.logger = get_logger().bind(class_name=type(self).__name__)
+        article_type_mapping = {
+            "article": "article",
+            "erratum": "erratum",
+            "editorial": "editorial",
+            "retraction": "retraction",
+            "essay": "other",
+            "comment": "other",
+            "letter-to-editor": "other",
+            "rapid": "other",
+            "brief": "other",
+            "reply": "other",
+            "announcement": "other",
+            "nobel": "other",
+        }
+
+        extractors = [
+            NestedValueExtractor("dois", json_path="identifiers.doi"),
+            NestedValueExtractor(
+                "journal_doctype",
+                json_path="articleType",
+                extra_function=lambda x: article_type_mapping[x],
+            ),
+            NestedValueExtractor("page_nr", json_path="numPages"),
+            NestedValueExtractor(
+                "arxiv_eprints",
+                json_path="identifiers.arxiv",
+                extra_function=lambda x: {
+                    "value": re.sub("arxiv:", "", x, flags=re.IGNORECASE)
+                },
+            ),
+            NestedValueExtractor("abstract", json_path="abstract.value"),
+            NestedValueExtractor("title", json_path="title.value"),
+            CustomExtractor("authors", self._form_authors),
+            NestedValueExtractor("journal_title", json_path="journal.name"),
+            NestedValueExtractor("journal_issue", json_path="issue.number"),
+            NestedValueExtractor("journal_volume", json_path="volume.number"),
+            NestedValueExtractor(
+                "journal_year", json_path="date", extra_function=lambda x: int(x[:4])
+            ),
+            NestedValueExtractor("date_published", json_path="date"),
+            NestedValueExtractor(
+                "copyright_holder",
+                json_path="rights.copyrightHolders",
+                extra_function=lambda x: x[0]["name"],
+            ),
+            NestedValueExtractor("copyright_year", json_path="rights.copyrightYear"),
+            NestedValueExtractor(
+                "copyright_statement", json_path="rights.rightsStatement"
+            ),
+            NestedValueExtractor(
+                "licenses",
+                json_path="rights.licenses",
+                extra_function=lambda x: x[0]["url"],
+            ),
+            NestedValueExtractor("collections", json_path="HEP.Citeable.Published"),
+            CustomExtractor("field_categories", self._get_field_categories),
+            CustomExtractor("extra_data", self._build_files_data),
+        ]
+
+        super().__init__(extractors)
+
+    def _form_authors(self, article):
+        authors = article["authors"]
+        return {
+            "authors": [
+                {
+                    "full_name": author["name"],
+                    "given_names": author["firstname"],
+                    "surname": author["surname"],
+                    "affiliations": self._get_affiliations(
+                        article, author["affiliationIds"]
+                    ),
+                }
+                for author in authors
+                if author["type"] == "Person"
+            ]
+        }
+
+    def _get_affiliations(self, article, affiliationIds):
+        parsed_affiliations = [
+            {
+                "value": affiliation["name"],
+                "organization": (",").join(affiliation["name"].split(",")[:-1]),
+                "country": affiliation["name"].split(", ")[-1:],
+            }
+            for affiliation in article["affiliations"]
+            if affiliation["id"] in affiliationIds
+        ]
+        return parsed_affiliations
+
+    def _get_field_categories(self, article):
+        return [
+            {
+                "term": term.get("label"),
+                "scheme": "APS",
+                "source": "",
+            }
+            for term in get_value(
+                article, "classificationSchemes.subjectAreas", default=""
+            )
+        ]
+
+    def _build_files_data(self, article):
+        doi = get_value(article, "identifiers.doi")
+        return {
+            "files": [
+                {
+                    "url": "http://harvest.aps.org/v2/journals/articles/{0}".format(
+                        doi
+                    ),
+                    "headers": {"Accept": "application/pdf"},
+                    "name": "{0}.pdf".format(doi),
+                    "filetype": "pdf",
+                },
+                {
+                    "url": "http://harvest.aps.org/v2/journals/articles/{0}".format(
+                        doi
+                    ),
+                    "headers": {"Accept": "text/xml"},
+                    "name": "{0}.xml".format(doi),
+                    "filetype": "xml",
+                },
+            ]
+        }

--- a/dags/common/parsing/json_extractors.py
+++ b/dags/common/parsing/json_extractors.py
@@ -1,0 +1,30 @@
+from common.parsing.extractor import IExtractor
+from inspire_utils.record import get_value
+
+
+class NestedValueExtractor(IExtractor):
+    def __init__(
+        self,
+        destination,
+        json_path,
+        required=True,
+        extra_function=lambda s: s,
+    ) -> None:
+        super().__init__(destination)
+        self.destination = destination
+        self.json_path = json_path
+        self.required = required
+        self.extra_function = extra_function
+
+    def extract(self, article: dict):
+        return self.extra_function(get_value(article, self.json_path, default=""))
+
+
+class CustomExtractor(IExtractor):
+    def __init__(self, destination, extraction_function) -> None:
+        super().__init__(destination)
+        self.destination = destination
+        self.extraction_function = extraction_function
+
+    def extract(self, article: dict):
+        return self.extraction_function(article)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,6 @@ PyYAML==6.0
 furl==2.1.3
 structlog==21.5.0
 bleach==4.1.0
+inspire-utils==3.0.25
 backoff==2.0.1
+psycopg2==2.9.3

--- a/tests/units/aps/data/json_response_content.json
+++ b/tests/units/aps/data/json_response_content.json
@@ -1,0 +1,283 @@
+{
+  "data": [
+    {
+      "abstract": {
+        "value": "<p>We propose and theoretically analyze the use of coherent population trapping of a single diamond nitrogen-vacancy (NV) center for continuous real-time sensing. The formation of the dark state in coherent population trapping prevents optical emissions from the NV center. Fluctuating magnetic fields, however, can kick the NV center out of the dark state, leading to a sequence of single-photon emissions. A time series of the photon counts detected can be used for magnetic field estimations, even when the average photon count per update time interval is much smaller than 1. For a theoretical demonstration, the nuclear spin bath in a diamond lattice is used as a model fluctuating magnetic environment. For fluctuations with known statistical properties, such as an Ornstein-Uhlenbeck process, Bayesian inference-based estimators can lead to an estimation variance that approaches the classical Cramer-Rao lower bound and can update dynamical information in real time with the detection of just a single photon. Real-time sensing using coherent population trapping adds a powerful tool to the emerging technology of quantum sensing.</p>",
+        "format": "html"
+      },
+      "articleType": "article",
+      "authors": [
+        {
+          "type": "Person",
+          "name": "Shu-Hao Wu",
+          "firstname": "Shu-Hao",
+          "surname": "Wu",
+          "affiliationIds": ["a1"]
+        },
+        {
+          "type": "Person",
+          "name": "Ethan Turner",
+          "firstname": "Ethan",
+          "surname": "Turner",
+          "affiliationIds": ["a1"]
+        },
+        {
+          "type": "Person",
+          "name": "Hailin Wang",
+          "firstname": "Hailin",
+          "surname": "Wang",
+          "affiliationIds": ["a1"]
+        }
+      ],
+      "affiliations": [
+        {
+          "name": "Department of Physics, University of Oregon, Eugene, Oregon 97403, USA",
+          "id": "a1"
+        }
+      ],
+      "date": "2021-04-12",
+      "fundings": [
+        {
+          "funderId": "http://dx.doi.org/10.13039/100000183",
+          "funderName": "Army Research Office",
+          "awards": ["W911NF-18-1-0218"]
+        }
+      ],
+      "type": "article",
+      "metadata_last_modified_at": "2021-04-12T14:02:31+0000",
+      "last_modified_at": "2021-04-12T14:02:31+0000",
+      "id": "10.1103/PhysRevA.103.042607",
+      "identifiers": {
+        "doi": "10.1103/PhysRevA.103.042607",
+        "arxiv": "arXiv:2102.07212"
+      },
+      "issue": {
+        "number": "4"
+      },
+      "pageStart": "042607",
+      "hasArticleId": true,
+      "numPages": 10,
+      "classificationSchemes": {
+        "physh": {
+          "concepts": [
+            {
+              "id": "65920eff-f184-41cd-9ec0-b33bb0679565",
+              "facet": {
+                "id": "f45b3c40-959c-4e90-ba0e-38232980802a"
+              },
+              "primary": false
+            },
+            {
+              "id": "2c0e953d-44fd-4611-bfb0-3e39cfb9374a",
+              "facet": {
+                "id": "bdb1ef91-b776-4e36-8f8f-3e93666bac1e"
+              },
+              "primary": false
+            },
+            {
+              "id": "1fa8daba-8a48-4d9f-ada9-03a9d3259ca3",
+              "facet": {
+                "id": "bdb1ef91-b776-4e36-8f8f-3e93666bac1e"
+              },
+              "primary": false
+            },
+            {
+              "id": "9b6aaf50-04bd-4aaa-b4c3-d6fa9b7f7303",
+              "facet": {
+                "id": "bdb1ef91-b776-4e36-8f8f-3e93666bac1e"
+              },
+              "primary": true
+            },
+            {
+              "id": "632f74d1-d16b-4b92-a295-b24729a93d8d",
+              "facet": {
+                "id": "bdb1ef91-b776-4e36-8f8f-3e93666bac1e"
+              },
+              "primary": false
+            }
+          ],
+          "disciplines": [
+            "510fc218-8774-4547-ab09-fc6cef0c9a03",
+            "8ab3d2b7-b50b-460e-b086-8990cfcbd350",
+            "a48f173e-6459-4642-a711-a6e731807625"
+          ]
+        }
+      },
+      "publisher": {
+        "name": "APS"
+      },
+      "rights": {
+        "rightsStatement": "©2021 American Physical Society",
+        "copyrightYear": 2021,
+        "copyrightHolders": [
+          {
+            "name": "American Physical Society"
+          }
+        ],
+        "creativeCommons": false,
+        "licenses": [
+          {
+            "url": "http://link.aps.org/licenses/aps-default-license"
+          }
+        ]
+      },
+      "journal": {
+        "id": "PRA",
+        "abbreviatedName": "Phys. Rev. A",
+        "name": "Physical Review A"
+      },
+      "title": {
+        "value": "Continuous real-time sensing with a nitrogen-vacancy center via coherent population trapping",
+        "format": "html"
+      },
+      "tocSection": {
+        "label": "Quantum technologies"
+      },
+      "volume": {
+        "number": "103"
+      }
+    },
+    {
+      "abstract": {
+        "value": "<p>Recent advances in ultracold atoms in optical lattices and developments in surface science have allowed for the creation of artificial lattices as well as the control of many-body interactions. Such systems provide new settings to investigate interaction-driven instabilities and nontrivial topology. In this paper, we explore the interplay between molecular electric dipoles on a two-dimensional triangular lattice with fermions hopping on the dual decorated honeycomb lattice which hosts Dirac and flat band states. We show that short-range dipole-dipole interaction can lead to ordering into various stripe and vortex crystal ground states. We study these ordered states and their thermal transitions as a function of the interaction range using simulated annealing and Monte Carlo methods. For the special case of zero-wave-vector ferrodipolar order, incorporating dipole-electron interactions and integrating out the electrons leads to a six-state clock model for the dipole ordering. Finally, we discuss the impact of the various dipole orders on the electronic band structure and the local tunneling density of states. Our work may be relevant to studies of “molecular graphene”—CO molecules arranged on the Cu(111) surface—which have been explored using scanning tunneling spectroscopy, as well as ultracold molecule-fermion mixtures in optical lattices.</p>",
+        "format": "html"
+      },
+      "articleType": "article",
+      "authors": [
+        {
+          "type": "Person",
+          "name": "Nazim Boudjada",
+          "firstname": "Nazim",
+          "surname": "Boudjada",
+          "affiliationIds": ["a1"]
+        },
+        {
+          "type": "Person",
+          "name": "Finn Lasse Buessen",
+          "firstname": "Finn Lasse",
+          "surname": "Buessen",
+          "affiliationIds": ["a1"]
+        },
+        {
+          "type": "Person",
+          "name": "Arun Paramekanti",
+          "firstname": "Arun",
+          "surname": "Paramekanti",
+          "affiliationIds": ["a1"]
+        }
+      ],
+      "affiliations": [
+        {
+          "name": "Department of Physics, University of Toronto, Toronto, Ontario, Canada M5S1A7",
+          "id": "a1"
+        }
+      ],
+      "notes": [
+        {
+          "format": "html",
+          "value": "<p>arunp@physics.utoronto.ca</p>",
+          "label": "*",
+          "id": "n1",
+          "type": "contrib"
+        }
+      ],
+      "date": "2021-04-12",
+      "fundings": [
+        {
+          "funderId": "http://dx.doi.org/10.13039/501100000038",
+          "funderName": "Natural Sciences and Engineering Research Council of Canada",
+          "awards": []
+        }
+      ],
+      "type": "article",
+      "metadata_last_modified_at": "2021-04-12T14:02:31+0000",
+      "last_modified_at": "2021-04-12T14:02:30+0000",
+      "id": "10.1103/PhysRevB.103.165408",
+      "identifiers": {
+        "doi": "10.1103/PhysRevB.103.165408",
+        "arxiv": "arXiv:2012.07847"
+      },
+      "issue": {
+        "number": "16"
+      },
+      "pageStart": "165408",
+      "hasArticleId": true,
+      "numPages": 11,
+      "classificationSchemes": {
+        "physh": {
+          "concepts": [
+            {
+              "id": "eb9bd2e1-eedd-4bd0-997d-58b44ffa3ebb",
+              "facet": {
+                "id": "233a6cd0-b7fe-491b-b5fd-85fd6b2a7c79"
+              },
+              "primary": false
+            },
+            {
+              "id": "7b1d5a31-bb4e-4b73-ae62-1c68e9c6006e",
+              "facet": {
+                "id": "f45b3c40-959c-4e90-ba0e-38232980802a"
+              },
+              "primary": false
+            },
+            {
+              "id": "273474b6-f607-4b62-b5b6-8de8bca28814",
+              "facet": {
+                "id": "f45b3c40-959c-4e90-ba0e-38232980802a"
+              },
+              "primary": false
+            },
+            {
+              "id": "0030808d-6a1a-4ce5-974a-748b5ef3eeba",
+              "facet": {
+                "id": "bdb1ef91-b776-4e36-8f8f-3e93666bac1e"
+              },
+              "primary": false
+            },
+            {
+              "id": "979074fa-fadd-4ebe-acf1-0a9c92fb1848",
+              "facet": {
+                "id": "bdb1ef91-b776-4e36-8f8f-3e93666bac1e"
+              },
+              "primary": true
+            }
+          ],
+          "disciplines": ["a48f173e-6459-4642-a711-a6e731807625"]
+        }
+      },
+      "publisher": {
+        "name": "APS"
+      },
+      "rights": {
+        "rightsStatement": "©2021 American Physical Society",
+        "copyrightYear": 2021,
+        "copyrightHolders": [
+          {
+            "name": "American Physical Society"
+          }
+        ],
+        "creativeCommons": false,
+        "licenses": [
+          {
+            "url": "http://link.aps.org/licenses/aps-default-license"
+          }
+        ]
+      },
+      "journal": {
+        "id": "PRB",
+        "abbreviatedName": "Phys. Rev. B",
+        "name": "Physical Review B"
+      },
+      "title": {
+        "value": "Molecular dipoles in designer honeycomb lattices",
+        "format": "html"
+      },
+      "tocSection": {
+        "label": "Surface physics, nanoscale physics, low-dimensional systems"
+      },
+      "volume": {
+        "number": "103"
+      }
+    }
+  ]
+}

--- a/tests/units/aps/test_aps_parser.py
+++ b/tests/units/aps/test_aps_parser.py
@@ -1,0 +1,229 @@
+import json
+
+import pytest
+from aps.parser import APSParser
+
+
+@pytest.fixture(scope="module")
+def parser():
+    return APSParser()
+
+
+@pytest.fixture
+def articles(shared_datadir):
+    json_response = (shared_datadir / "json_response_content.json").read_text()
+    return [article for article in json.loads(json_response)["data"]]
+
+
+@pytest.fixture()
+def parsed_articles(parser, articles):
+    return [parser._publisher_specific_parsing(article) for article in articles]
+
+
+@pytest.mark.parametrize(
+    "expected, key",
+    [
+        pytest.param(
+            ["10.1103/PhysRevA.103.042607", "10.1103/PhysRevB.103.165408"],
+            "dois",
+            id="test_dois",
+        ),
+        pytest.param(["article", "article"], "journal_doctype", id="test_articleType"),
+        pytest.param([10, 11], "page_nr", id="test_page_nr"),
+        pytest.param(
+            [{"value": "2102.07212"}, {"value": "2012.07847"}],
+            "arxiv_eprints",
+            id="test_arxiv_eprints",
+        ),
+        pytest.param(
+            [
+                "<p>We propose and theoretically analyze the use of coherent population trapping of a single diamond nitrogen-vacancy (NV) center for continuous real-time sensing. The formation of the dark state in coherent population trapping prevents optical emissions from the NV center. Fluctuating magnetic fields, however, can kick the NV center out of the dark state, leading to a sequence of single-photon emissions. A time series of the photon counts detected can be used for magnetic field estimations, even when the average photon count per update time interval is much smaller than 1. For a theoretical demonstration, the nuclear spin bath in a diamond lattice is used as a model fluctuating magnetic environment. For fluctuations with known statistical properties, such as an Ornstein-Uhlenbeck process, Bayesian inference-based estimators can lead to an estimation variance that approaches the classical Cramer-Rao lower bound and can update dynamical information in real time with the detection of just a single photon. Real-time sensing using coherent population trapping adds a powerful tool to the emerging technology of quantum sensing.</p>",
+                "<p>Recent advances in ultracold atoms in optical lattices and developments in surface science have allowed for the creation of artificial lattices as well as the control of many-body interactions. Such systems provide new settings to investigate interaction-driven instabilities and nontrivial topology. In this paper, we explore the interplay between molecular electric dipoles on a two-dimensional triangular lattice with fermions hopping on the dual decorated honeycomb lattice which hosts Dirac and flat band states. We show that short-range dipole-dipole interaction can lead to ordering into various stripe and vortex crystal ground states. We study these ordered states and their thermal transitions as a function of the interaction range using simulated annealing and Monte Carlo methods. For the special case of zero-wave-vector ferrodipolar order, incorporating dipole-electron interactions and integrating out the electrons leads to a six-state clock model for the dipole ordering. Finally, we discuss the impact of the various dipole orders on the electronic band structure and the local tunneling density of states. Our work may be relevant to studies of “molecular graphene”—CO molecules arranged on the Cu(111) surface—which have been explored using scanning tunneling spectroscopy, as well as ultracold molecule-fermion mixtures in optical lattices.</p>",
+            ],
+            "abstract",
+            id="test_abstract",
+        ),
+        pytest.param(
+            [
+                "Continuous real-time sensing with a nitrogen-vacancy center via coherent population trapping",
+                "Molecular dipoles in designer honeycomb lattices",
+            ],
+            "title",
+            id="test_title",
+        ),
+        pytest.param([10, 11], "page_nr", id="test_page_nr"),
+        pytest.param(
+            [
+                {
+                    "authors": [
+                        {
+                            "full_name": "Shu-Hao Wu",
+                            "given_names": "Shu-Hao",
+                            "surname": "Wu",
+                            "affiliations": [
+                                {
+                                    "value": "Department of Physics, University of Oregon, Eugene, Oregon 97403, USA",
+                                    "organization": "Department of Physics, University of Oregon, Eugene, Oregon 97403",
+                                    "country": ["USA"],
+                                }
+                            ],
+                        },
+                        {
+                            "full_name": "Ethan Turner",
+                            "given_names": "Ethan",
+                            "surname": "Turner",
+                            "affiliations": [
+                                {
+                                    "value": "Department of Physics, University of Oregon, Eugene, Oregon 97403, USA",
+                                    "organization": "Department of Physics, University of Oregon, Eugene, Oregon 97403",
+                                    "country": ["USA"],
+                                }
+                            ],
+                        },
+                        {
+                            "full_name": "Hailin Wang",
+                            "given_names": "Hailin",
+                            "surname": "Wang",
+                            "affiliations": [
+                                {
+                                    "value": "Department of Physics, University of Oregon, Eugene, Oregon 97403, USA",
+                                    "organization": "Department of Physics, University of Oregon, Eugene, Oregon 97403",
+                                    "country": ["USA"],
+                                }
+                            ],
+                        },
+                    ]
+                },
+                {
+                    "authors": [
+                        {
+                            "full_name": "Nazim Boudjada",
+                            "given_names": "Nazim",
+                            "surname": "Boudjada",
+                            "affiliations": [
+                                {
+                                    "value": "Department of Physics, University of Toronto, Toronto, Ontario, Canada M5S1A7",
+                                    "organization": "Department of Physics, University of Toronto, Toronto, Ontario",
+                                    "country": ["Canada M5S1A7"],
+                                }
+                            ],
+                        },
+                        {
+                            "full_name": "Finn Lasse Buessen",
+                            "given_names": "Finn Lasse",
+                            "surname": "Buessen",
+                            "affiliations": [
+                                {
+                                    "value": "Department of Physics, University of Toronto, Toronto, Ontario, Canada M5S1A7",
+                                    "organization": "Department of Physics, University of Toronto, Toronto, Ontario",
+                                    "country": ["Canada M5S1A7"],
+                                }
+                            ],
+                        },
+                        {
+                            "full_name": "Arun Paramekanti",
+                            "given_names": "Arun",
+                            "surname": "Paramekanti",
+                            "affiliations": [
+                                {
+                                    "value": "Department of Physics, University of Toronto, Toronto, Ontario, Canada M5S1A7",
+                                    "organization": "Department of Physics, University of Toronto, Toronto, Ontario",
+                                    "country": ["Canada M5S1A7"],
+                                }
+                            ],
+                        },
+                    ]
+                },
+            ],
+            "authors",
+            id="test_authors",
+        ),
+        pytest.param(
+            ["Physical Review A", "Physical Review B"],
+            "journal_title",
+            id="test_journal_title",
+        ),
+        pytest.param(["4", "16"], "journal_issue", id="test_journal_issue"),
+        pytest.param(["103", "103"], "journal_volume", id="test_journal_volume"),
+        pytest.param([2021, 2021], "journal_year", id="test_journal_year"),
+        pytest.param(
+            ["2021-04-12", "2021-04-12"], "date_published", id="test_date_published"
+        ),
+        pytest.param(
+            ["American Physical Society", "American Physical Society"],
+            "copyright_holder",
+            id="test_copyright_holderd",
+        ),
+        pytest.param(
+            ["2021-04-12", "2021-04-12"], "date_published", id="test_date_published"
+        ),
+        pytest.param([2021, 2021], "copyright_year", id="test_copyright_year"),
+        pytest.param(
+            ["©2021 American Physical Society", "©2021 American Physical Society"],
+            "copyright_statement",
+            id="test_copyright_statement",
+        ),
+        pytest.param(
+            [
+                "http://link.aps.org/licenses/aps-default-license",
+                "http://link.aps.org/licenses/aps-default-license",
+            ],
+            "licenses",
+            id="test_licenses",
+        ),
+        pytest.param([[], []], "field_categories", id="test_field_categories"),
+        pytest.param(
+            [
+                {
+                    "files": [
+                        {
+                            "url": "http://harvest.aps.org/v2/journals/articles/{0}".format(
+                                "10.1103/PhysRevA.103.042607"
+                            ),
+                            "headers": {"Accept": "application/pdf"},
+                            "name": "{0}.pdf".format("10.1103/PhysRevA.103.042607"),
+                            "filetype": "pdf",
+                        },
+                        {
+                            "url": "http://harvest.aps.org/v2/journals/articles/{0}".format(
+                                "10.1103/PhysRevA.103.042607"
+                            ),
+                            "headers": {"Accept": "text/xml"},
+                            "name": "{0}.xml".format("10.1103/PhysRevA.103.042607"),
+                            "filetype": "xml",
+                        },
+                    ]
+                },
+                {
+                    "files": [
+                        {
+                            "url": "http://harvest.aps.org/v2/journals/articles/{0}".format(
+                                "10.1103/PhysRevB.103.165408"
+                            ),
+                            "headers": {"Accept": "application/pdf"},
+                            "name": "{0}.pdf".format("10.1103/PhysRevB.103.165408"),
+                            "filetype": "pdf",
+                        },
+                        {
+                            "url": "http://harvest.aps.org/v2/journals/articles/{0}".format(
+                                "10.1103/PhysRevB.103.165408"
+                            ),
+                            "headers": {"Accept": "text/xml"},
+                            "name": "{0}.xml".format("10.1103/PhysRevB.103.165408"),
+                            "filetype": "xml",
+                        },
+                    ]
+                },
+            ],
+            "extra_data",
+            id="test_extra_data",
+        ),
+    ],
+)
+def test_aps_parsing(parsed_articles, expected, key):
+    for (
+        expected_value,
+        article,
+    ) in zip(expected, parsed_articles):
+        assert key in article
+        assert article[key] == expected_value


### PR DESCRIPTION
some fields are different from Springer output. 
* APS JSON doesn't have collaboration, should I add it from the affiliations organization?
*  In the old code, the authors' structure was different. Now I adapted to Springer one).
* APS has one more field- **field_categories**. What should I do with it? keep it, parse it into a different format? 