### PR TITLE
Fixed arxiv categories order

### DIFF
--- a/dags/aps/parser.py
+++ b/dags/aps/parser.py
@@ -109,7 +109,7 @@ class APSParser(IParser):
         return parsed_affiliations
 
     def _get_field_categories(self, article):
-        categories = [
+        return [
             {
                 "term": term.get("label"),
                 "scheme": "APS",
@@ -119,7 +119,6 @@ class APSParser(IParser):
                 article, "classificationSchemes.subjectAreas", default=""
             )
         ]
-        return sorted(categories, key=lambda x: x["term"])
 
     def _build_files_data(self, article):
         doi = get_value(article, "identifiers.doi")

--- a/dags/common/enricher.py
+++ b/dags/common/enricher.py
@@ -55,8 +55,11 @@ class Enricher(object):
             node.attrib["term"]
             for node in entry.findall("./w3:category", namespaces=xml_namespaces)
         ]
+        for (index, secondary_category) in enumerate(secondary_categories):
+            if secondary_category == primary_category:
+                secondary_categories.pop(index)
 
-        return list(set([primary_category] + secondary_categories))
+        return list([primary_category] + secondary_categories)
 
     @backoff.on_exception(
         backoff.expo, requests.exceptions.RequestException, max_time=60, max_tries=3

--- a/tests/units/common/test_enricher.py
+++ b/tests/units/common/test_enricher.py
@@ -24,7 +24,7 @@ def test_get_arxiv_categories_arxiv_id(
         text=arxiv_output_content,
     )
     assertListEqual(
-        ["hep-ph", "hep-th"], enricher._get_arxiv_categories(arxiv_id="0000.00000")
+        ["hep-ph", "astro-ph.HE", "astro-ph.IM", "hep-ex"], enricher._get_arxiv_categories(arxiv_id="0000.00000")
     )
 
 
@@ -36,5 +36,5 @@ def test_get_arxiv_categories_title(
         text=arxiv_output_content,
     )
     assertListEqual(
-        ["hep-ph", "hep-th"], enricher._get_arxiv_categories(title="test title")
+        ["hep-ph", "astro-ph.HE", "astro-ph.IM", "hep-ex"], enricher._get_arxiv_categories(title="test title")
     )

--- a/tests/units/common/test_enricher/arxiv_output.xml
+++ b/tests/units/common/test_enricher/arxiv_output.xml
@@ -29,8 +29,10 @@
         <arxiv:comment xmlns:arxiv="http://arxiv.org/schemas/atom">47 pages, no figures</arxiv:comment>
         <link href="http://arxiv.org/abs/2112.01211v1" rel="alternate" type="text/html" />
         <link title="pdf" href="http://arxiv.org/pdf/2112.01211v1" rel="related" type="application/pdf" />
-        <arxiv:primary_category xmlns:arxiv="http://arxiv.org/schemas/atom" term="hep-th" scheme="http://arxiv.org/schemas/atom" />
-        <category term="hep-th" scheme="http://arxiv.org/schemas/atom" />
+        <arxiv:primary_category xmlns:arxiv="http://arxiv.org/schemas/atom" term="hep-ph" scheme="http://arxiv.org/schemas/atom" />
         <category term="hep-ph" scheme="http://arxiv.org/schemas/atom" />
+        <category term="astro-ph.HE" scheme="http://arxiv.org/schemas/atom" />
+        <category term="astro-ph.IM" scheme="http://arxiv.org/schemas/atom" />
+        <category term="hep-ex" scheme="http://arxiv.org/schemas/atom" />
     </entry>
 </feed>


### PR DESCRIPTION
* Changed logic of removing duplications in the list of categories (not using set anymore)
* Channged arxiv test input to more complex one
* Changed tests accordingly
* Removed unnecessary sorting
* ref: 'https://github.com/cern-sis/issues-scoap3/issues/79'