### PR TITLE
workflows: IOP parser fix

### DIFF
--- a/dags/aps/parser.py
+++ b/dags/aps/parser.py
@@ -143,10 +143,9 @@ class APSParser(IParser):
             licenses = []
             for right in rights:
                 url = right["url"]
-                url_parts = url.split("/")
-                clean_url_parts = list(filter(bool, url_parts))
-                version = clean_url_parts.pop()
-                license_type = clean_url_parts.pop()
+                clean_url_parts = list(filter(bool, url.split("/")))
+                version = clean_url_parts[-1]
+                license_type = clean_url_parts[-2]
                 licenses.append(
                     construct_license(
                         url=url, license_type=license_type.upper(), version=version

--- a/dags/common/parsing/parser.py
+++ b/dags/common/parsing/parser.py
@@ -67,7 +67,13 @@ class IParser:
                 "date_published": fix_publication_date(get("date_published")),
                 "related_article_doi": list_to_value_dict(get("related_article_doi")),
                 "free_keywords": pipe_functions(
-                    [lambda x: map(clean_whitespace_characters, x), free_keywords],
+                    [
+                        lambda keywords: map(
+                            clean_whitespace_characters,
+                            [keyword for keyword in keywords],
+                        ),
+                        free_keywords,
+                    ],
                     get("free_keywords"),
                 ),
                 "classification_numbers": classification_numbers(

--- a/dags/common/parsing/xml_extractors.py
+++ b/dags/common/parsing/xml_extractors.py
@@ -56,9 +56,9 @@ class AttributeExtractor(IExtractor):
         self.required = required
 
     def extract(self, article: ET.Element):
-        value = self.extra_function(article.find(self.source).get(self.attribute))
-        if value:
-            return value
+        value = article.find(self.source)
+        if value is not None:
+            return self.extra_function(value.get(self.attribute))
         if self.required and value is None:
             raise RequiredFieldNotFoundExtractionError(self.source)
         return self.default_value
@@ -76,7 +76,7 @@ class CustomExtractor(IExtractor):
 
     def extract(self, article: ET.Element):
         value = self.extraction_function(article)
-        if value:
+        if value is not None:
             return value
         if self.required and value is None:
             raise RequiredFieldNotFoundExtractionError(self.source)

--- a/dags/iop/iop_process_file.py
+++ b/dags/iop/iop_process_file.py
@@ -1,12 +1,63 @@
+import base64
+import xml.etree.ElementTree as ET
+
 import airflow
+import requests
 from airflow.decorators import dag, task
+from common.enhancer import Enhancer
+from common.enricher import Enricher
+from inspire_utils.record import get_value
+from iop.parser import IOPParser
+from jsonschema import validate
+
+
+def iop_parse_file(**kwargs):
+    encoded_xml = get_value(kwargs, "params.file", default={})
+    xml_bytes = base64.b64decode(encoded_xml)
+    xml = ET.fromstring(xml_bytes.decode("utf-8"))
+
+    parser = IOPParser()
+    parsed = parser.parse(xml)
+    if encoded_xml:
+        return parsed
+    raise Exception("There was no 'file' parameter. Exiting run.")
+
+
+def enhance_iop(parsed_file):
+    return Enhancer()("IOP", parsed_file)
+
+
+def enrich_iop(enhanced_file):
+    return Enricher()(enhanced_file)
+
+
+def iop_validate_record(enriched_file):
+    schema = requests.get(enriched_file["$schema"]).json()
+    validate(enriched_file, schema)
 
 
 @dag(start_date=airflow.utils.dates.days_ago(0))
 def iop_process_file():
     @task()
-    def start():
-        pass
+    def parse_file(**kwargs):
+        return iop_parse_file(**kwargs)
+
+    @task()
+    def enchance(parsed_file):
+        return parsed_file and enhance_iop(parsed_file)
+
+    @task()
+    def enrich(enhanced_file):
+        return enhanced_file and enrich_iop(enhanced_file)
+
+    @task()
+    def validate_record(enriched_file):
+        return enriched_file and iop_validate_record(enriched_file)
+
+    parsed_file = parse_file()
+    enhanced_file = enchance(parsed_file)
+    enriched_file = enrich(enhanced_file)
+    validate_record(enriched_file)
 
 
-dag_for_iop_files_processing = iop_process_file()
+dag_taskflow = iop_process_file()

--- a/dags/iop/parser.py
+++ b/dags/iop/parser.py
@@ -1,0 +1,261 @@
+import datetime
+import re
+import xml.etree.ElementTree as ET
+
+from common.parsing.parser import IParser
+from common.parsing.xml_extractors import AttributeExtractor, CustomExtractor
+from hindawi.xml_extractors import HindawiTextExtractor as TextExtractor
+from structlog import get_logger
+
+# FIXME used Hindawi xml extractor, because it has mathlib string handling
+
+
+class IOPParser(IParser):
+    def __init__(self) -> None:
+        self.logger = get_logger().bind(class_name=type(self).__name__)
+        self.article_type_mapping = {
+            "research-article": "article",
+            "corrected-article": "article",
+            "original-article": "article",
+            "correction": "corrigendum",
+            "addendum": "addendum",
+            "editorial": "editorial",
+        }
+        extractors = [
+            TextExtractor(
+                destination="dois",
+                source="front/article-meta/article-id/[@pub-id-type='doi']",
+                extra_function=lambda x: [x],
+                default_value=[],
+            ),
+            CustomExtractor(
+                destination="journal_doctype",
+                extraction_function=self._get_journal_doctype,
+                default_value="",
+            ),
+            CustomExtractor(
+                destination="related_article_doi",
+                extraction_function=self._get_related_article_doi,
+                default_value=[],
+            ),
+            CustomExtractor(
+                destination="arxiv_eprints",
+                extraction_function=self._get_arxiv_eprints,
+                default_value=[],
+            ),
+            AttributeExtractor(
+                destination="page_nr",
+                source="front/article-meta/counts/page-count",
+                attribute="count",
+                extra_function=lambda x: [int(x)],
+                default_value=[0],
+            ),
+            TextExtractor(
+                destination="abstract",
+                source="front/article-meta/abstract/p",
+                extra_function=lambda x: x,
+                default_value="",
+            ),
+            TextExtractor(
+                destination="title",
+                source="front/article-meta/title-group/article-title",
+                extra_function=lambda x: " ".join(x.split()),
+                default_value="",
+            ),
+            TextExtractor(
+                destination="subtitle",
+                required=False,
+                source="front/article-meta/subtitle",
+                extra_function=lambda x: " ".join(x.split()),
+                default_value="",
+            ),
+            CustomExtractor(
+                destination="authors",
+                extraction_function=self._get_affiliations,
+                default_value=[],
+            ),
+            CustomExtractor(
+                destination="date_published",
+                extraction_function=self._get_date_published,
+                default_value="2000-00-00",
+            ),
+            CustomExtractor(
+                destination="publication_info",
+                extraction_function=self._get_publication_info,
+                required=True,
+                default_value=[],
+            ),
+            CustomExtractor(
+                destination="date_published",
+                extraction_function=self._get_date_published,
+                default_value="2000-00-00",
+            ),
+            TextExtractor(
+                destination="copyright_holder",
+                source="front/article-meta/permissions/copyright-holder",
+                required=False,  # copyright is required
+                extra_function=lambda x: x,
+                default_value="",
+            ),
+            TextExtractor(
+                destination="copyright_year",
+                source="front/article-meta/permissions/copyright-year",
+                extra_function=lambda x: x,
+                default_value=0,
+            ),
+            TextExtractor(
+                destination="copyright_statement",
+                source="front/article-meta/permissions/copyright-statement",
+                extra_function=lambda x: x,
+                default_value="",
+            ),
+            CustomExtractor(
+                destination="license",
+                extraction_function=self._get_license,
+                required=True,
+                default_value=[],
+            ),
+        ]
+        super().__init__(extractors)
+
+    def _get_journal_doctype(self, article: ET.Element):
+        raw_journal_doctype = article.find(
+            ".",
+        ).get("article-type")
+        journal_doctype = self.article_type_mapping[raw_journal_doctype]
+        if "other" in journal_doctype:
+            doi = article.find("front/article-meta/article-id/[@pub-id-type='doi']")
+            if doi is not None:
+                self.logger.msg(
+                    f"There are unmapped article types for article {doi.text} with types {raw_journal_doctype}"
+                )
+        return journal_doctype
+
+    def _get_related_article_doi(self, article):
+        journal_doctype = self._get_journal_doctype(article)
+        if journal_doctype in ["correction", "addendum"]:
+            self.logger.msg("Adding related_article_doi.")
+            return article.find("./related-article[@ext-link-type='doi']/@href")
+
+    def _get_arxiv_eprints(self, article):
+        arxiv_eprints = []
+        arxivs_value = article.find(
+            "front/article-meta/custom-meta-group/custom-meta/meta-value"
+        )
+        if arxivs_value is not None:
+            pattern = re.compile(r"(arxiv:|v[0-9]$)", flags=re.I)
+            arxiv_eprints.append({"value": pattern.sub("", arxivs_value.text.lower())})
+        return arxiv_eprints
+
+    def _get_institutions(self, article, reffered_id):
+        return article.findall(
+            f"front/article-meta/contrib-group/aff[@id='{reffered_id.get('rid')}']/institution"
+        )
+
+    def _get_countries(self, article, reffered_id):
+        return article.findall(
+            f"front/article-meta/contrib-group/aff[@id='{reffered_id.get('rid')}']/country"
+        )
+
+    def _get_affiliation_values(self, institutions, countries):
+        return [
+            {
+                "value": ",".join([institution.text, country.text]),
+                "country": country.text,
+            }
+            for institution, country in zip(institutions, countries)
+        ]
+
+    def _get_affiliations(self, article):
+        contrib_types = article.findall(
+            "front/article-meta/contrib-group/contrib[@contrib-type='author']"
+        )
+        authors = []
+        for contrib_type in contrib_types:
+            surname = contrib_type.find("name/surname").text
+            given_names = contrib_type.find("name/given-names").text
+            reffered_id = contrib_type.find("xref[@ref-type='aff']")
+            if reffered_id is None:
+                continue
+            institutions = self._get_institutions(article, reffered_id)
+            countries = self._get_countries(article, reffered_id)
+            affiliations = self._get_affiliation_values(institutions, countries)
+            author = {
+                "surname": surname,
+                "given_names": given_names,
+                "affiliations": affiliations,
+            }
+            authors.append(author)
+        return authors
+
+    def _get_date(self, date):
+        return datetime.date(
+            day=int(date.find("day").text),
+            month=int(date.find("month").text),
+            year=int(date.find("year").text),
+        ).isoformat()
+
+    def _get_date_published(self, article):
+        date = (
+            article.find("front/article-meta/history/date[@date-type='published']")
+            or article.find("front/article-meta/history/date[@date-type='epub']")
+            or article.find("front/article-meta/history/pub-date[@pub-type='ppub']")
+            or article.find("front/article-meta/pub-date")
+        )
+        if date:
+            return self._get_date(date)
+        return datetime.date.today().isoformat()
+
+    def _get_journal_year(self, article):
+        date = self._get_date_published(article)
+        dt = datetime.datetime.strptime(date, "%Y-%m-%d")
+        return dt.year
+
+    def _construct_license(self, url, license_type, version):
+        if url and license_type and version:
+            return {
+                "url": url,
+                "license": f"CC-{license_type}-{version}",
+            }
+
+    def _get_license(self, article: ET.Element):
+        licenses = []
+        license_texts = article.findall(
+            "front/article-meta/permissions/license/license-p/ext-link"
+        )
+        urls = article.findall("front/article-meta/permissions/license")
+        license_urls = [
+            url.attrib["{http://www.w3.org/1999/xlink}href"] for url in urls
+        ]
+        for license_url, license_text in zip(license_urls, license_texts):
+            if license_url:
+                url_parts = license_url.split("/")
+                clean_url_parts = list(filter(bool, url_parts))
+                version = clean_url_parts.pop()
+                license_type = clean_url_parts.pop()
+                licenses.append(
+                    self._construct_license(license_url, license_type.upper(), version)
+                )
+            elif license_text.text:
+                licenses.append(license_text.text)
+        return licenses
+
+    def _get_publication_info(self, article):
+        journal_title = article.find(
+            "front/journal-meta/journal-title-group/journal-title",
+        )
+        journal_volume = article.find(
+            "front/article-meta/volume",
+        )
+        journal_year = self._get_journal_year(article)
+        journal_issue = article.find("front/article-meta/issue")
+        journal_artid = article.find("front/article-meta/elocation-id")
+        return [
+            {
+                "journal_title": journal_title is not None and journal_title.text,
+                "journal_volume": journal_volume is not None and journal_volume.text,
+                "journal_year": journal_year,
+                "journal_issue": journal_issue is not None and journal_issue.text,
+                "journal_artid": journal_artid is not None and journal_artid.text,
+            }
+        ]

--- a/tests/integration/iop/test_iop_repository.py
+++ b/tests/integration/iop/test_iop_repository.py
@@ -6,8 +6,6 @@ from iop.repository import IOPRepository
 
 
 class S3BucketResultObj:
-    key: str
-
     def __init__(self, key) -> None:
         self.key = key
 

--- a/tests/integration/iop/test_pull_ftp.py
+++ b/tests/integration/iop/test_pull_ftp.py
@@ -1,0 +1,66 @@
+import datetime
+
+import pytest
+from airflow import DAG
+from airflow.models import DagBag
+from airflow.models.dagrun import DagRun
+from airflow.utils.state import DagRunState
+from busypie import SECOND, wait
+from common.pull_ftp import migrate_from_ftp, trigger_file_processing
+from iop.repository import IOPRepository
+from iop.sftp_service import IOPSFTPService
+from structlog import get_logger
+
+DAG_NAME = "iop_pull_ftp"
+
+
+@pytest.fixture
+def dag():
+    dagbag = DagBag(dag_folder="dags/", include_examples=False)
+    assert dagbag.import_errors.get(f"dags/{DAG_NAME}.py") is None
+    return dagbag.get_dag(dag_id=DAG_NAME)
+
+
+def test_dag_loaded(dag: DAG):
+    assert dag is not None
+    assert len(dag.tasks) == 2
+
+
+def test_dag_run(dag: DAG):
+    repo = IOPRepository()
+    repo.delete_all()
+    assert len(repo.find_all()) == 0
+    id = datetime.datetime.utcnow().strftime(
+        "test_iop_dag_pull_ftp_%Y-%m-%dT%H:%M:%S.%f"
+    )
+    dagrun = dag.create_dagrun(DagRunState.QUEUED, run_id=id)
+    wait().at_most(60, SECOND).until(lambda: __test_dagrun_state(dagrun))
+    assert len(repo.find_all()) == 11
+
+
+def test_dag_migrate_from_FTP():
+    repo = IOPRepository()
+    repo.delete_all()
+    assert len(repo.find_all()) == 0
+    migrate_from_ftp(
+        IOPSFTPService(),
+        repo,
+        get_logger().bind(class_name="test_logger"),
+        **{"params": {}},
+    )
+    assert len(repo.find_all()) == 11
+
+
+def test_dag_trigger_file_processing():
+    repo = IOPRepository()
+    assert list(map(lambda x: x["xml"], repo.find_all())) == trigger_file_processing(
+        "iop", repo, get_logger().bind(class_name="test_logger")
+    )
+
+
+def __test_dagrun_state(dagrun: DagRun):
+    dagrun.update_state()
+    return (
+        not dagrun.get_state() == DagRunState.QUEUED
+        and not dagrun.get_state() == DagRunState.RUNNING
+    )

--- a/tests/units/common/parsing/test_parser/input.json
+++ b/tests/units/common/parsing/test_parser/input.json
@@ -42,7 +42,7 @@
   ],
   "collections": ["Test Collection"],
   "control_field": ["Test control field"],
-  "free_keywords": ["Test free 1", "Test free 2"],
+  "free_keywords": ["Test free 1", "Test free  2   "],
   "thesis_supervisor": [
     {
       "surname": "Test Surname",

--- a/tests/units/hindawi/test_hindawi_text_extractor.py
+++ b/tests/units/hindawi/test_hindawi_text_extractor.py
@@ -1,0 +1,56 @@
+import xml.etree.ElementTree as ET
+
+from common.parsing.xml_extractors import RequiredFieldNotFoundExtractionError
+from hindawi.xml_extractors import HindawiTextExtractor
+from pytest import fixture, raises
+
+
+@fixture
+def hindawi_doi_extractor():
+    prefixes = {
+        "marc": "http://www.loc.gov/MARC21/slim",
+        "ns0": "http://www.openarchives.org/OAI/2.0/",
+        "ns1": "http://www.loc.gov/MARC21/slim",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+    }
+    return HindawiTextExtractor(
+        source="ns0:metadata/ns1:record/ns0:datafield/[@tag='024']/ns0:subfield/[@code='a']",
+        destination="dois",
+        prefixes=prefixes,
+    )
+
+
+@fixture
+def articles(shared_datadir):
+    articles = []
+    files = ["example1.xml", "example2.xml"]
+
+    for file in files:
+        with open(shared_datadir / file) as file:
+            articles.append(ET.fromstring(file.read()))
+    return articles
+
+
+def test_parsed_articles(hindawi_doi_extractor, articles):
+    parsed_articles = [hindawi_doi_extractor.extract(article) for article in articles]
+    assert parsed_articles == ["10.1155/2019/3465159", "10.1155/2022/5287693"]
+
+
+@fixture
+def hindawi_not_excitant_field_extractor():
+    prefixes = {
+        "marc": "http://www.loc.gov/MARC21/slim",
+        "ns0": "http://www.openarchives.org/OAI/2.0/",
+        "ns1": "http://www.loc.gov/MARC21/slim",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+    }
+    return HindawiTextExtractor(
+        source="ns0:metadata/ns1:record/ns0:datafield/[@tag='024']/ns0:subfield/[@code='nothing']",
+        destination="nothing",
+        prefixes=prefixes,
+    )
+
+
+def test_parsed_articles_with_error(hindawi_not_excitant_field_extractor, articles):
+    with raises(RequiredFieldNotFoundExtractionError):
+        [hindawi_not_excitant_field_extractor.extract(article) for article in articles]

--- a/tests/units/iop/data/example1.xml
+++ b/tests/units/iop/data/example1.xml
@@ -1,0 +1,2916 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" xml:lang="en">
+	<front>
+		<journal-meta>
+			<journal-id journal-id-type="publisher-id">cpc</journal-id>
+			<journal-title-group>
+				<journal-title xml:lang="en">Chinese Physics C</journal-title>
+			</journal-title-group>
+			<issn pub-type="ppub">1674-1137</issn>
+			<publisher>
+				<publisher-name>Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</publisher-name>
+			</publisher>
+		</journal-meta>
+		<article-meta>
+			<article-id pub-id-type="publisher-id">cpc_46_8_085001</article-id>
+			<article-id pub-id-type="doi">10.1088/1674-1137/ac66cc</article-id>
+			<article-id pub-id-type="manuscript">ac66cc</article-id>
+			<article-categories>
+				<subj-group subj-group-type="display-article-type">
+					<subject>Paper</subject>
+				</subj-group>
+				<subj-group subj-group-type="section">
+					<subject>Particle and nuclear astrophysics and cosmology</subject>
+				</subj-group>
+			</article-categories>
+			<title-group>
+				<article-title>
+					Measurement of muon-induced neutron yield at the China Jinping Underground Laboratory
+					<xref ref-type="fn" rid="cpc_46_8_085001_fn1">*</xref>
+					<fn id="cpc_46_8_085001_fn1">
+						<label>*</label>
+						<p>Supported in part by the National Natural Science Foundation of China (11620101004, 11475093, 12127808), the Key Laboratory of Particle &amp; Radiation Imaging (TsinghuaUniversity), the CAS Center for Excellence in Particle Physics (CCEPP), and Guangdong Basic and Applied Basic Research Foundation (2019A1515012216). Portion of this work performed at Brookhaven National Laboratory is supported in part by the United States Department of Energy (DE-SC0012704)</p>
+					</fn>
+				</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Zhao</surname>
+						<given-names>Lin</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>赵</surname>
+						<given-names>林</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Luo</surname>
+						<given-names>Wentai</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>骆</surname>
+						<given-names>文泰</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation06">6</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Bathe-Peters</surname>
+						<given-names>Lars</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation04">4</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Chen</surname>
+						<given-names>Shaomin</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>陈</surname>
+						<given-names>少敏</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+					<xref ref-type="aff" rid="affiliation03">3</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Chouaki</surname>
+						<given-names>Mourad</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation05">5</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Dou</surname>
+						<given-names>Wei</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>窦</surname>
+						<given-names>威</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Guo</surname>
+						<given-names>Lei</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>郭</surname>
+						<given-names>磊</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Guo</surname>
+						<given-names>Ziyi</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>郭</surname>
+						<given-names>子溢</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Hussain</surname>
+						<given-names>Ghulam</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Li</surname>
+						<given-names>Jinjing</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>李</surname>
+						<given-names>进京</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Liang</surname>
+						<given-names>Ye</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>梁</surname>
+						<given-names>晔</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Liu</surname>
+						<given-names>Qian</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>刘</surname>
+						<given-names>倩</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation06">6</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Luo</surname>
+						<given-names>Guang</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>罗</surname>
+						<given-names>光</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation07">7</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Qi</surname>
+						<given-names>Ming</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>祁</surname>
+						<given-names>鸣</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation08">8</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Shao</surname>
+						<given-names>Wenhui</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>邵</surname>
+						<given-names>文辉</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Tang</surname>
+						<given-names>Jian</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>唐</surname>
+						<given-names>健</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation07">7</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Wan</surname>
+						<given-names>Linyan</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>万</surname>
+						<given-names>林焱</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Wang</surname>
+						<given-names>Zhe</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>王</surname>
+						<given-names>喆</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+					<xref ref-type="aff" rid="affiliation03">3</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Wu</surname>
+						<given-names>Yiyang</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>武</surname>
+						<given-names>益阳</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Xu</surname>
+						<given-names>Benda</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>续</surname>
+						<given-names>本达</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+					<xref ref-type="aff" rid="affiliation03">3</xref>
+					<email>orv@tsinghua.edu.cn</email>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Xu</surname>
+						<given-names>Tong</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>徐</surname>
+						<given-names>彤</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Xu</surname>
+						<given-names>Weiran</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>徐</surname>
+						<given-names>蔚然</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Yang</surname>
+						<given-names>Yuzi</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>杨</surname>
+						<given-names>玉梓</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Yeh</surname>
+						<given-names>Minfang</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation09">9</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Zhang</surname>
+						<given-names>Aiqiang</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>张</surname>
+						<given-names>爱强</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Zhang</surname>
+						<given-names>Bin</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>张</surname>
+						<given-names>彬</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname />
+						<given-names>(JNE collaboration)</given-names>
+					</name>
+				</contrib>
+				<aff id="affiliation01">
+					<label>1</label>
+
+					<institution xlink:type="simple">Department of Engineering Physics, Tsinghua University</institution>
+					, Beijing 100084,
+					<country>China</country>
+				</aff>
+				<aff id="affiliation02">
+					<label>2</label>
+
+					<institution xlink:type="simple">Center for High Energy Physics, Tsinghua University</institution>
+					, Beijing 100084,
+					<country>China</country>
+				</aff>
+				<aff id="affiliation03">
+					<label>3</label>
+
+					<institution xlink:type="simple">Key Laboratory of Particle &amp; Radiation Imaging (Tsinghua University)</institution>
+					, Ministry of Education,
+					<country>China</country>
+				</aff>
+				<aff id="affiliation04">
+					<label>4</label>
+
+					<institution xlink:type="simple">Institut für Physik, Technische Universität Berlin</institution>
+					, Berlin 10623,
+					<country>Germany</country>
+				</aff>
+				<aff id="affiliation05">
+					<label>5</label>
+
+					<institution xlink:type="simple">École Polytechnique Fédérale de Lausanne</institution>
+					, Lausanne 1015,
+					<country>Switzerland</country>
+				</aff>
+				<aff id="affiliation06">
+					<label>6</label>
+
+					<institution xlink:type="simple">School of Physical Sciences, University of Chinese Academy of Sciences</institution>
+					, Beijing 100049,
+					<country>China</country>
+				</aff>
+				<aff id="affiliation07">
+					<label>7</label>
+
+					<institution xlink:type="simple">School of Physics, Sun Yat-Sen University</institution>
+					, Guangzhou 510275,
+					<country>China</country>
+				</aff>
+				<aff id="affiliation08">
+					<label>8</label>
+
+					<institution xlink:type="simple">School of Physics, Nanjing University</institution>
+					, Nanjing 210093,
+					<country>China</country>
+				</aff>
+				<aff id="affiliation09">
+					<label>9</label>
+
+					<institution xlink:type="simple">Brookhaven National Laboratory, Upton</institution>
+					, New York 11973,
+					<country>USA</country>
+				</aff>
+			</contrib-group>
+			<pub-date pub-type="ppub">
+				<day>01</day>
+				<month>8</month>
+				<year>2022</year>
+			</pub-date>
+			<pub-date pub-type="open-access">
+				<day>1</day>
+				<month>6</month>
+				<year>2022</year>
+			</pub-date>
+			<volume>46</volume>
+			<issue>8</issue>
+			<elocation-id content-type="artnum">085001</elocation-id>
+			<history>
+				<date date-type="received">
+					<day>10</day>
+					<month>8</month>
+					<year>2021</year>
+				</date>
+				<date date-type="published-online">
+					<day>1</day>
+					<month>6</month>
+					<year>2022</year>
+				</date>
+				<date date-type="oa-requested">
+					<day>10</day>
+					<month>8</month>
+					<year>2021</year>
+				</date>
+			</history>
+			<permissions>
+				<copyright-statement>© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</copyright-statement>
+				<copyright-year>2022</copyright-year>
+				<license license-type="cc-by" xlink:href="http://creativecommons.org/licenses/by/3.0/" xlink:type="simple">
+					<license-p>
+						<graphic content-type="online" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_ccby.tif" xlink:type="simple" />
+						Content from this work may be used under the terms of the
+						<ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/3.0" xlink:type="simple">Creative Commons Attribution 3.0 licence</ext-link>
+						. Any further distribution of this work must maintain attribution to the author(s) and the title of the work, journal citation and DOI. Article funded by SCOAP
+						<sup>3</sup>
+						and published under licence by Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+					</license-p>
+				</license>
+			</permissions>
+			<self-uri content-type="pdf" xlink:href="cpc_46_8_085001.pdf" xlink:type="simple" />
+			<abstract>
+				<title>Abstract</title>
+				<p>
+					Solar, terrestrial, and supernova neutrino experiments are subject to muon-induced radioactive background. The China Jinping Underground Laboratory (CJPL), with its unique advantage of a 2400 m rock coverage and long distance from nuclear power plants, is ideal for MeV-scale neutrino experiments. Using a 1-ton prototype detector of the Jinping Neutrino Experiment (JNE), we detected 343 high-energy cosmic-ray muons and (7.86
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \pm $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M1.jpg" xlink:type="simple" />
+					</inline-formula>
+					3.97) muon-induced neutrons from an 820.28-day dataset at the first phase of CJPL (CJPL-I). Based on the muon-induced neutrons, we measured the corresponding muon-induced neutron yield in a liquid scintillator to be
+					<inline-formula>
+						<tex-math>
+							<?CDATA $(3.44 \pm 1.86_{\rm stat.}\pm $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M2.jpg" xlink:type="simple" />
+					</inline-formula>
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 0.76_{\rm syst.})\times 10^{-4}$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M2-1.jpg" xlink:type="simple" />
+					</inline-formula>
+					μ
+					<sup>−1</sup>
+					g
+					<sup>−1</sup>
+					cm
+					<sup>2</sup>
+					at an average muon energy of 340 GeV. We provided the first study for such neutron background at CJPL. A global fit including this measurement shows a power-law coefficient of (0.75
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \pm $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M3.jpg" xlink:type="simple" />
+					</inline-formula>
+					0.02) for the dependence of the neutron yield at the liquid scintillator on muon energy.
+				</p>
+			</abstract>
+			<kwd-group kwd-group-type="author">
+				<kwd>Underground laboratory</kwd>
+				<kwd>neutrino detector</kwd>
+				<kwd>cosmic-ray muon</kwd>
+				<kwd>neutron yield</kwd>
+				<kwd>liquid scintillator</kwd>
+			</kwd-group>
+			<kwd-group kwd-group-type="author-pacs">
+				<kwd>95.85.Ry</kwd>
+				<kwd>29.40.Mc</kwd>
+				<kwd>95.55.Vj</kwd>
+			</kwd-group>
+			<funding-group>
+				<open-access>
+					<p content-type="scoap3">
+						Article funded by SCOAP
+						<sup>3</sup>
+					</p>
+				</open-access>
+			</funding-group>
+			<counts>
+				<page-count count="9" />
+			</counts>
+			<custom-meta-group>
+				<custom-meta xlink:type="simple">
+					<meta-name>arxivppt</meta-name>
+					<meta-value>2108.04010</meta-value>
+				</custom-meta>
+			</custom-meta-group>
+		</article-meta>
+	</front>
+	<body>
+		<sec id="cpc_46_8_085001_s01">
+			<label>I.</label>
+			<title>INTRODUCTION</title>
+			<p>Cosmic-ray muons, produced by the interaction of primary high-energy cosmic rays with the Earth's atmosphere, have a powerful penetrating ability. When such muons pass through mountain rocks and detector materials, they create neutrons. The neutrons are the main source of environmental radiations for underground low-background experiments. They are produced in two ways. The direct production includes muon-nucleus spallation, quasielastic scattering, and negative muon capture by the nucleus. The indirect one is from the muon-initiated electromagnetic and hadronic showers. The knowledge of cosmic-ray muon-induced neutrons is crucial for the search of rare events associated with neutrino interactions, neutrino-less double-beta decay, and weakly interacting massive particles (WIMPs) in underground low-background experiments.</p>
+			<p>
+				In 2000, the CERN Super Proton Synchrotron (SPS) studied the production of the muon-induced neutrons using an artificial muon beam [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib1">1</xref>
+				]. The cosmic-ray muon-induced neutrons generated in a liquid scintillator (LS) in underground detectors have also been studied by CUBE [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib2">2</xref>
+				], Daya Bay [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib3">3</xref>
+				], Aberdeen Tunnel [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib4">4</xref>
+				], ASD [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib5">5</xref>
+				–
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib7">7</xref>
+				], KamLAND [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib8">8</xref>
+				], LVD [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib9">9</xref>
+				], Borexino [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib10">10</xref>
+				], LSD [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib11">11</xref>
+				], and many others [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib5">5</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib12">12</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib13">13</xref>
+				]. A power-law is used to describe the dependence of a neutron yield in an LS on the average muon energy, but measurements up to a few hundreds of GeV are rare.
+			</p>
+			<p>
+				Located in Sichuan Province, China, CJPL is one of the deepest underground laboratories in the world [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib14">14</xref>
+				]. With its unique advantage of a 2400 m rock coverage [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib15">15</xref>
+				] and ~1000 km distance from commercial nuclear power plants, CJPL is ideal for rare-event experiments, such as dark matter searches [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib16">16</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib17">17</xref>
+				] and neutrino physics.
+			</p>
+			<p>
+				The proposed Jinping Neutrino experiment (JNE) [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib18">18</xref>
+				] can serve as an ideal observatory for MeV-scale solar, terrestrial [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib19">19</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib20">20</xref>
+				], and supernova [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib21">21</xref>
+				] neutrinos.
+			</p>
+			<p>
+				This paper reports on a measurement of the cosmic-ray muon-induced neutron yield in the LS with an average muon energy of 340 GeV [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib22">22</xref>
+				] using a 1-ton prototype detector of the JNE. The dataset contains 820.28 live days from 31 July 2017 to 27 September 2020. Together with other experiments, this analysis and result contribute to the understanding of the relationship between muon energy and muon-induced neutron yield up to several hundred GeV.
+			</p>
+		</sec>
+		<sec id="cpc_46_8_085001_s02">
+			<label>II.</label>
+			<title>PROTOTYPE DETECTOR AND PERFORMANCE</title>
+			<p>
+				The 1-ton prototype detector was constructed in early 2017 to study new neutrino detection techniques and underground backgrounds [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib23">23</xref>
+				].
+			</p>
+			<p>
+				<xref ref-type="fig" rid="cpc_46_8_085001_f1">Figure 1</xref>
+				shows a schematic diagram of the prototype detector, which measures 2 m in height and diameter. The outermost part is a 5 cm thick lead wall to reduce the environmental background. The innermost part is a 0.645 m radius acrylic spherical vessel containing a 1 t LS [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib24">24</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib25">25</xref>
+				]. It consists of linear alkylbenzene (LAB, the molecular formula is
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \rm C_{18}H_{30} $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M4.jpg" xlink:type="simple" />
+				</inline-formula>
+				), 0.07 g/l of 2,5-diphenyloxazole (PPO), and 13 mg/l of the wavelength shifter 1,4-bis (2-methylstyryl)-benzene (bis-MSB). Thirty 8-inch Hamamatsu R5912 photomultiplier tubes (PMT) outside the acrylic vessel are used to detect light signals. The PMT gains are maintained at
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sim 10^7 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M5.jpg" xlink:type="simple" />
+				</inline-formula>
+				by adjusting the high voltage power supplies. A pure water layer between the acrylic sphere and the stainless steel tank serves as passive shielding to suppress the environmental radioactive background.
+			</p>
+			<fig id="cpc_46_8_085001_f1" orientation="portrait" position="float">
+				<label>Fig. 1</label>
+				<caption id="cpc_46_8_085001_fc1">
+					<p>(color online) Schematic diagram of the 1-ton prototype detector for the Jinping Neutrino Experiment.</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_8_085001_f1_eps" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f1.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_8_085001_f1_online" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f1.jpg" xlink:type="simple" />
+			</fig>
+			<p>
+				The electronics system collects and processes the light signal detected by the PMTs. It consists of 4 CAEN V1751 flash ADC boards and one CAEN V1495 logical trigger module. The V1751 board has eight 10-bit ADC channels with 1 V dynamic ranges and 1 GHz sampling rates. All the PMT signals are digitized in the V1751 boards and then fed into the V1495 boards for logical judgment. We set the PMT-hit discriminator to 10 mV, and lowered it to 5 mV in phase E after a better understanding of PE charge distribution. A trigger is issued when more than 25 PMTs are fired simultaneously in a 125 ns window. We later lowered the threshold to 10 PMTs in phase G to efficiently detect the events affected by total internal reflections of the acrylic-water boundary. The data acquisition system records 1024 ns-sized voltage waveforms of the fired PMTs. For experimental studies, the trigger conditions changed several times.
+				<xref ref-type="table" rid="cpc_46_8_085001_t1">Table 1</xref>
+				provides the details to define each phase.
+			</p>
+			<table-wrap id="cpc_46_8_085001_t1" orientation="portrait" position="float">
+				<label>Table 1</label>
+				<caption id="cpc_46_8_085001_tc1">
+					<p>Running stages and the trigger condition, light yield, and energy scale of each stage of the prototype detector.</p>
+				</caption>
+				<table>
+					<thead>
+						<tr>
+							<th align="center" colspan="1" rowspan="1" valign="middle">DAQ phase</th>
+							<th align="center" colspan="1" rowspan="1" valign="middle">Start</th>
+							<th align="center" colspan="1" rowspan="1" valign="middle">End</th>
+							<th align="center" colspan="1" rowspan="1" valign="middle">
+								Live
+								<break />
+								time/d
+							</th>
+							<th align="center" colspan="1" rowspan="1" valign="middle">
+								Trigger threshold/
+								<break />
+								(number of hit PMTs)
+							</th>
+							<th align="center" colspan="1" rowspan="1" valign="middle">
+								Window/
+								<break />
+								ns
+							</th>
+							<th align="center" colspan="1" rowspan="1" valign="middle">
+								Threshold/
+								<break />
+								mV
+							</th>
+							<th align="center" colspan="1" rowspan="1" valign="middle">
+								Light yield/
+								<break />
+								(photons/MeV)
+							</th>
+							<th align="center" colspan="1" rowspan="1" valign="middle">
+								Energy scale/
+								<break />
+								(p.e.s/MeV)
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td align="center" colspan="1" rowspan="1" valign="middle">A–D</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">2017.07.31</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">2018.10.14</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">392.02</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">25</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">1024</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">10</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">4010</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">61.07±0.69</td>
+						</tr>
+						<tr>
+							<td align="center" colspan="1" rowspan="1" valign="middle">E–F</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">2018.10.15</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">2019.06.29</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">238.45</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">25</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">1024</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">5</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">4010</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">61.07±0.69</td>
+						</tr>
+						<tr>
+							<td align="center" colspan="1" rowspan="1" valign="middle">G</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">2019.06.30</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">2019.07.14</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">12.60</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">10</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">600</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">5</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">4010</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">61.07±0.69</td>
+						</tr>
+						<tr>
+							<td align="center" colspan="1" rowspan="1" valign="middle">H</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">2019.07.15</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">2019.07.22</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">6.61</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">10</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">600</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">5</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">5687</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">88.20±0.49</td>
+						</tr>
+						<tr>
+							<td align="center" colspan="1" rowspan="1" valign="middle">I–J</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">2019.08.15</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">2020.09.27</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">170.60</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">10</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">600</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">5</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">6445</td>
+							<td align="center" colspan="1" rowspan="1" valign="middle">99.85±0.50</td>
+						</tr>
+					</tbody>
+				</table>
+			</table-wrap>
+			<p>
+				We performed a nitrogen purging and sealing experiment on 14 July 2019 to study the laboratory radon leakage into the detector. Meanwhile, we expected that this operation could also remove the oxygen in the LS to reduce the quenching effect, improving the light yield and consequently the energy scale in photo-electrons (p.e.) per MeV. Before the nitrogen purging and sealing, the light yield was measured to be 4010 photons per MeV [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib25">25</xref>
+				]. This number later increased to 6445.
+			</p>
+			<p>The 1-ton prototype detector began collecting data on 31 July 2017. Owing to a laboratory maintenance, the entire experiment eventually stopped running on 27 September 2020. We first determined a list of good runs that were neither for pedestal calibration nor detector maintenance. We discarded apparent noise by examining the event rate, single PMT trigger rate, PMT baseline, and baseline fluctuation. The live time after the data quality check was 820.28 days.</p>
+		</sec>
+		<sec id="cpc_46_8_085001_s03">
+			<label>III.</label>
+			<title>CALIBRATION</title>
+			<p>We performed several PMT gain and energy scale calibrations for the detector based on the PMT dark noise (DN) and the decay products of radioactive isotopes in the LS. No dedicated artificial isotopes were deployed because the use of characteristic gamma ray peaks from the contamination to calibrate the small prototype detector was sufficient.</p>
+			<p>
+				The thermal electron emission from the PMT photocathode caused the major DN, and they mimicked actual single photoelectron emissions. Since an event time window was 1024 ns wide and the triggered position was between 150 to 600 ns, we selected the DN events from 0 to 150 ns for each PMT. We then fitted the DN charge distribution with a realistic PMT response function [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib26">26</xref>
+				] to obtain the gain value for each PMT.
+				<xref ref-type="fig" rid="cpc_46_8_085001_f2">Figure 2</xref>
+				(a) shows an example of the DN charge spectrum.
+			</p>
+			<fig id="cpc_46_8_085001_f2" orientation="portrait" position="float">
+				<label>Fig. 2</label>
+				<caption id="cpc_46_8_085001_fc2">
+					<p>
+						(color online) Fit example of DN charge spectrum of a PMT (a) and p.e. charge spectrum in one run
+						<bold>(b)</bold>
+						, in which we used three exponential functions to describe the background in three regions.
+					</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_8_085001_f2_eps" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f2.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_8_085001_f2_online" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f2.jpg" xlink:type="simple" />
+			</fig>
+			<p>
+				With the gain value for each PMT of each run, we processed all the data and obtained the total charge for each triggered event.
+				<xref ref-type="fig" rid="cpc_46_8_085001_f2">Figure 2</xref>
+				(b) shows a charge distribution in one run. We extracted the monoenergetic gamma signals emitted by the radioactive isotopes
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ ^{40}\rm K $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M11.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ ^{208}\rm Tl $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M12.jpg" xlink:type="simple" />
+				</inline-formula>
+				.
+			</p>
+			<p>
+				By scaling the MC simulation
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ ^{40}\rm K $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M13.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ ^{208}\rm Tl $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M14.jpg" xlink:type="simple" />
+				</inline-formula>
+				gammas to the data, we estimated the light yields and energy scales in each DAQ phase (
+				<xref ref-type="table" rid="cpc_46_8_085001_t1">Table 1</xref>
+				). They increased together owing to oxygen removal by nitrogen purging in July 2019. Three sources of energy scale uncertainty were identified: the inconsistency between the
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ ^{40}\rm K $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M15.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ ^{208}\rm Tl $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M16.jpg" xlink:type="simple" />
+				</inline-formula>
+				scales and their fitting errors (1.5%), background shape uncertainty as shown in
+				<xref ref-type="fig" rid="cpc_46_8_085001_f2">Fig. 2</xref>
+				(b) (2.34%), and the PMT gain variation with time (2.84%). All three contributions produced a light yield uncertainty of 4%.
+			</p>
+		</sec>
+		<sec id="cpc_46_8_085001_s04">
+			<label>IV.</label>
+			<title>SIMULATION</title>
+			<p>
+				The muon-induced neutron yield refers to the number of neutrons produced by each muon per unit path length and density of the material. Some neutrons produced in the LS escape without being observed, while some detected neutrons are induced by muons traversing other detector components and the rock outside the detector. Considering the above processes, the corrections of the number of muon-induced neutrons in this analysis were estimated by a study based on Geant4 simulation [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib27">27</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib28">28</xref>
+				]. We determined the average path length of muons through the LS using the Geant4 simulation with the input of muon angular reconstruction result [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib22">22</xref>
+				]. In the following, we discuss several important aspects of the simulation.
+			</p>
+			<sec id="cpc_46_8_085001_s04-01">
+				<label>A.</label>
+				<title>Muon simulation in mountain</title>
+				<p>
+					We used the Geant4-based simulation package by Guo
+					<italic toggle="yes">et al</italic>
+					. [
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib22">22</xref>
+					] to simulate the muon penetration in the mountain rock to predict various underground muon characteristic profiles. This simulation used Geant4's own standard electromagnetic and muon-nucleus processes. The Jinping mountain terrain data were obtained from the NASA SRTM3 dataset [
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib29">29</xref>
+					] with a rock density of 2.8 g/cm
+					<sup>3</sup>
+					[
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib30">30</xref>
+					]. The composition of the rock in the simulation utilized the values from the abundance of elements in Earth's crust (percentage by weight) [
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib31">31</xref>
+					]: oxygen (46.1%), silicon (28.2%), aluminum (8.2%), and iron (5.6%). Gaisser's formula [
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib32">32</xref>
+					,
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib33">33</xref>
+					] reasonably describes the muon flux at sea level. We adopted the modified version from the Daya Bay Collaboration [
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib34">34</xref>
+					] for this simulation as it has a better flux description for low energy. It features large zenith angle ranges by parameterizing the kinetic energy
+					<italic toggle="yes">E</italic>
+					and zenith angle
+					<italic toggle="yes">θ</italic>
+					of cosmic-ray muons.
+					<xref ref-type="fig" rid="cpc_46_8_085001_f3">Figure 3</xref>
+					shows the simulated angular distribution of underground muons.
+				</p>
+				<fig id="cpc_46_8_085001_f3" orientation="portrait" position="float">
+					<label>Fig. 3</label>
+					<caption id="cpc_46_8_085001_fc3">
+						<p>
+							(color online) Angular distribution of the muon and muon-induced neutron. These two figures show the azimuth angular distributions of the muon (
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \phi_{\mu} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M17.jpg" xlink:type="simple" />
+							</inline-formula>
+							) and neutron (
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \phi_{n} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M18.jpg" xlink:type="simple" />
+							</inline-formula>
+							), the zenith angular distribution of the muon (
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \theta_{\mu} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M19.jpg" xlink:type="simple" />
+							</inline-formula>
+							) and neutron (
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \theta_{n} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M20.jpg" xlink:type="simple" />
+							</inline-formula>
+							), and the angular distribution of the neutron relative to the muon (
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \theta_{n}' $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M21.jpg" xlink:type="simple" />
+							</inline-formula>
+							) according to Eq. (2). All variables are in the laboratory frame.
+						</p>
+					</caption>
+					<graphic content-type="print" id="cpc_46_8_085001_f3_eps" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f3.eps" xlink:type="simple" />
+					<graphic content-type="online" id="cpc_46_8_085001_f3_online" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f3.jpg" xlink:type="simple" />
+				</fig>
+			</sec>
+			<sec id="cpc_46_8_085001_s04-02">
+				<label>B.</label>
+				<title>Detector and neutron simulation</title>
+				<p>We used Geant4 to generate the incident muon sample and neutrons along the muon's track. The details of the simulated neutrons and their interactions with matter inside the detector are described in this section.</p>
+				<p>
+					The detector simulation package was a Geant4-based framework. We adopted the same underground muon energy spectrum and angular distribution as [
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib22">22</xref>
+					] to estimate the neutron detection efficiency, and we used a set of empirical formulas from [
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib35">35</xref>
+					] to generate the neutrons induced by muons. The induced neutron spectrum as a function of the mean energy of muon
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ E_{\mu} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M22.jpg" xlink:type="simple" />
+					</inline-formula>
+					in GeV is given by
+				</p>
+				<p>
+					<disp-formula>
+						<label>1</label>
+						<tex-math id="cpc_46_8_085001_E1">
+							<?CDATA $ \frac{\mathrm{d}N}{\mathrm{d}E_{ n}}\propto\frac{{\rm e}^{-7E_{ n}}}{E_{ n}}+\left(0.52-0.58{\rm e}^{-0.0099E_{\mu}}\right){\rm e}^{-2E_n}, $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E1.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where both
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ E_\mu $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M23.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ E_n $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M24.jpg" xlink:type="simple" />
+					</inline-formula>
+					are in GeV. The neutron zenith angular
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \cos\theta $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M25.jpg" xlink:type="simple" />
+					</inline-formula>
+					distribution with respect to the muon is
+				</p>
+				<p>
+					<disp-formula>
+						<label>2</label>
+						<tex-math id="cpc_46_8_085001_E2">
+							<?CDATA $ \frac{\mathrm{d}N}{\mathrm{d}\cos\theta}\propto\frac{1}{(1-\cos\theta)^{0.6}+0.699E_{\mu}^{-0.136}}. $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E2.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					We assumed that the induced neutron azimuth angular
+					<italic toggle="yes">ϕ</italic>
+					distribution relative to the parent muon is uniform.
+					<xref ref-type="fig" rid="cpc_46_8_085001_f3">Figure 3</xref>
+					shows the angular distributions of muons and neutrons according to Eq. (2).
+				</p>
+			</sec>
+		</sec>
+		<sec id="cpc_46_8_085001_s05">
+			<label>V.</label>
+			<title>NEUTRON YIELD</title>
+			<sec id="cpc_46_8_085001_s05-01">
+				<label>A.</label>
+				<title>Principle</title>
+				<p>
+					In this analysis, we selected muon events to search for the associated neutrons. The neutron yield (
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Y_{n} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M26.jpg" xlink:type="simple" />
+					</inline-formula>
+					) in the LS can be expressed as
+				</p>
+				<p>
+					<disp-formula>
+						<label>3</label>
+						<tex-math id="cpc_46_8_085001_E3">
+							<?CDATA $ Y_{n} = \dfrac{N_{n, \rm LS}}{N_{\mu}L\rho}, $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E3.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N_{n, \rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M27.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the number of neutrons produced by the muons that traverse the LS target,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N_{\mu} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M28.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the number of these muons,
+					<italic toggle="yes">L</italic>
+					is the average track length of muons in the LS, and
+					<italic toggle="yes">ρ</italic>
+					is the density, which was measured to be 0.86
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \rm g/cm^{3} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M29.jpg" xlink:type="simple" />
+					</inline-formula>
+					.
+				</p>
+				<p>
+					Out of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N_{n, \rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M30.jpg" xlink:type="simple" />
+					</inline-formula>
+					neutrons,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N'_{n, \rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M31.jpg" xlink:type="simple" />
+					</inline-formula>
+					neutrons are triggered with the efficiency
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \varepsilon_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M32.jpg" xlink:type="simple" />
+					</inline-formula>
+					:
+				</p>
+				<p>
+					<disp-formula>
+						<label>4</label>
+						<tex-math id="cpc_46_8_085001_E4">
+							<?CDATA $ N_{n, \rm LS}=\frac{N'_{n, \rm LS}}{\varepsilon_{\rm LS}}. $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E4.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N'_{n, \rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M33.jpg" xlink:type="simple" />
+					</inline-formula>
+					includes two contributions: neutrons eventually captured in the LS and those escaping to other detector parts but still producing sufficient photons to become triggered.
+				</p>
+				<p>Because the detected neutrons could emanate from all the detector components and the rock outside the detector, we define the total number of detected neutrons as</p>
+				<p>
+					<disp-formula>
+						<label>5</label>
+						<tex-math id="cpc_46_8_085001_E5">
+							<?CDATA $ N'_{n} = \sum\limits_{i} N'_{n, i}, $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E5.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ {i} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M34.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the index of the materials, including the LS, water, iron tank, lead, and rock.
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N'_{n, \rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M35.jpg" xlink:type="simple" />
+					</inline-formula>
+					is given by
+				</p>
+				<p>
+					<disp-formula>
+						<label>6</label>
+						<tex-math id="cpc_46_8_085001_E6">
+							<?CDATA $ N'_{n, \rm LS}=\xi_{\rm LS} N'_{n}, $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E6.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \xi_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M36.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the fraction of detected neutrons generated in the LS.
+				</p>
+				<p>According to Eqs. (3), (4), and (6), the muon-induced neutron yield is finally expressed as</p>
+				<p>
+					<disp-formula>
+						<label>7</label>
+						<tex-math id="cpc_46_8_085001_E7">
+							<?CDATA $ Y_{n} = \dfrac{\xi_{\rm LS} N'_{n}/\varepsilon_{\rm LS}}{N_{\mu}L\rho}. $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E7.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>The following sections present the selection criteria for the muon-induced neutrons and the determination of all the quantities shown in Eq. (7).</p>
+			</sec>
+			<sec id="cpc_46_8_085001_s05-02">
+				<label>B.</label>
+				<title>Muon event selection and flux</title>
+				<p>
+					We required a minimum energy deposit of 98 MeV for each muon event. We cut out the electronics noise and flasher events by requiring the ratio of the maximum p.e. among the PMTs to the total p.e. in each event, denoted by
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ r_{\rm max} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M37.jpg" xlink:type="simple" />
+					</inline-formula>
+					, to be less than 0.15.
+					<xref ref-type="fig" rid="cpc_46_8_085001_f4">Figure 4</xref>
+					shows a two-dimensional distribution of the deposited energy
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ E_{\rm dep} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M38.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ r_{\rm max} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M39.jpg" xlink:type="simple" />
+					</inline-formula>
+					. There were 343 high-energy cosmic-ray muons, i.e.,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N_{\mu} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M40.jpg" xlink:type="simple" />
+					</inline-formula>
+					in Eq. (7). Using the same method as Ref. [
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib22">22</xref>
+					] and an enlarged exposure, we updated the muon flux of CJPL-I to
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \rm (3.61\pm 0.19_{stat.}\pm 0.10_{sys.})\times 10^{-10}cm^{-2}s^{-1} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M41.jpg" xlink:type="simple" />
+					</inline-formula>
+					.
+				</p>
+				<fig id="cpc_46_8_085001_f4" orientation="portrait" position="float">
+					<label>Fig. 4</label>
+					<caption id="cpc_46_8_085001_fc4">
+						<p>
+							(color online) Scatter plot of deposited energy and
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ r_{\rm max} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M42.jpg" xlink:type="simple" />
+							</inline-formula>
+							; the black dots represent the muon events from the MC simulation, and the red dots represent the muon candidates selected from the experimental data. Three hundred forty-three selected muon events spread in the region of
+							<inline-formula>
+								<tex-math>
+									<?CDATA $E_{\rm dep} \gt{98} \;{\rm MeV}$?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M43.jpg" xlink:type="simple" />
+							</inline-formula>
+							and
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ r_{\rm max}\lt{0.15} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M44.jpg" xlink:type="simple" />
+							</inline-formula>
+							, while flasher and electronic noise events had larger
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ r_{\rm max} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M45.jpg" xlink:type="simple" />
+							</inline-formula>
+							and relatively smaller
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ E_{\rm dep} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M46.jpg" xlink:type="simple" />
+							</inline-formula>
+							values. We also removed low energy events that may contain indistinguishable radioactive background, shower, and noise events.
+						</p>
+					</caption>
+					<graphic content-type="print" id="cpc_46_8_085001_f4_eps" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f4.eps" xlink:type="simple" />
+					<graphic content-type="online" id="cpc_46_8_085001_f4_online" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f4.jpg" xlink:type="simple" />
+				</fig>
+			</sec>
+			<sec id="cpc_46_8_085001_s05-03">
+				<label>C.</label>
+				<title>Neutron event selection</title>
+				<p>
+					We selected events for the neutron capture on hydrogen following a tagged parent muon. The neutron capture time
+					<italic toggle="yes">t</italic>
+					distribution follows
+				</p>
+				<p>
+					<disp-formula>
+						<label>8</label>
+						<tex-math id="cpc_46_8_085001_E8">
+							<?CDATA $ P(t)\propto {\rm e}^{-t/\tau_{n}}, $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E8.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \tau_{n}=216$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M47.jpg" xlink:type="simple" />
+					</inline-formula>
+					µs is the mean neutron capture time. It was calculated using the LS's elemental composition and the thermal neutron capture cross-sections from [
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib36">36</xref>
+					] at the detector temperature.
+				</p>
+				<p>
+					To avoid electronics-induced baseline distortions, we define the signal window to start from 20 µs after the muon's passage and end at 1020 µs to cover neutron capture time, shown in
+					<xref ref-type="fig" rid="cpc_46_8_085001_f5">Fig. 5</xref>
+					as "data." The "backgroud" in
+					<xref ref-type="fig" rid="cpc_46_8_085001_f5">Fig. 5</xref>
+					is scaled from the
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 1020 \lt \Delta {T} \lt 5001020 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M48.jpg" xlink:type="simple" />
+					</inline-formula>
+					µs time sideband window following the parent muons. A 2.2 MeV peak was evident in the energy spectrum, but it did not occur in the background. Three peaks were observed in the background energy spectrum. The two at approximately 0 and 1.5 MeV were due to the trigger condition changes. In phases A-F, the 25-PMT threshold was just below 1.5 MeV. The one at approximately 2.6 MeV was owing to the radioactive
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ {\rm ^{208}Tl} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M49.jpg" xlink:type="simple" />
+					</inline-formula>
+					background. We evaluated the number of muon-induced neutrons
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N'_{n} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M50.jpg" xlink:type="simple" />
+					</inline-formula>
+					with an unbinned maximum likelihood fit incorporating both the neutron-like event energy and time to the parent muon in this analysis.
+				</p>
+				<fig id="cpc_46_8_085001_f5" orientation="portrait" position="float">
+					<label>Fig. 5</label>
+					<caption id="cpc_46_8_085001_fc5">
+						<p>
+							(color online) Fit of energy (a) and time (b) spectra of neutron capture. The data points were captured from events in the
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ 20\lt\Delta {T}\lt{1020} \;$?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M51.jpg" xlink:type="simple" />
+							</inline-formula>
+							μs window after the muon. Background distributions are scaled from time sideband data. The neutron signal energy spectrum was estimated using Monte Carlo detector simulation. The dataset was a simple addition of the low and high threshold periods.
+						</p>
+					</caption>
+					<graphic content-type="print" id="cpc_46_8_085001_f5_eps" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f5.eps" xlink:type="simple" />
+					<graphic content-type="online" id="cpc_46_8_085001_f5_online" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f5.jpg" xlink:type="simple" />
+				</fig>
+				<p>We describe the energy spectrum using the following probability density function:</p>
+				<p>
+					<disp-formula>
+						<label>9</label>
+						<tex-math id="cpc_46_8_085001_E9">
+							<?CDATA $ f(E)=(1-\omega)f_{\rm sig}+\omega f_{\rm bkg}, $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E9.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<italic toggle="yes">ω</italic>
+					is the ratio of the background rate to the total event rate in the signal time window
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 20 \lt \Delta {T} \lt 1020 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M52.jpg" xlink:type="simple" />
+					</inline-formula>
+					µs,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ f_{\rm bkg} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M53.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the background probability, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ f_{\rm sig} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M54.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the signal probability [
+					<xref ref-type="bibr" rid="cpc_46_8_085001_bib37">37</xref>
+					]:
+				</p>
+				<p>
+					<disp-formula>
+						<label>10</label>
+						<tex-math id="cpc_46_8_085001_E10">
+							<?CDATA $ f_{\rm sig}=\alpha\frac{1}{\sigma\sqrt{2\pi}}{\rm e}^{-{(E-\mu)^{2}}/({2\sigma^{2}})}+(1-\alpha)\frac{\lambda {\rm e}^{({\sigma^{2}\lambda^{2}+2\lambda E})/{2}}}{{\rm e}^{\lambda\mu}-1}f_{\rm erf}, $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E10.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>in which</p>
+				<p>
+					<disp-formula>
+						<label>11</label>
+						<tex-math id="cpc_46_8_085001_E11">
+							<?CDATA $ f_{\rm erf}={\rm erf}\left(\frac{\mu-E-\sigma^{2}\lambda}{\sqrt{2}\sigma}\right)-{\rm erf}\left(\frac{-E-\sigma^{2}\lambda}{\sqrt{2}\sigma}\right), $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E11.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<italic toggle="yes">μ</italic>
+					and
+					<italic toggle="yes">σ</italic>
+					are the mean and standard deviation of the expected 2.2 MeV neutron-hydrogen capture peak, respectively,
+					<italic toggle="yes">α</italic>
+					is the signal fraction,
+					<italic toggle="yes">λ</italic>
+					is the slope of the exponential tail caused by energy leak and edge effect, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \rm erf $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M55.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the Gaussian error function:
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ {\rm erf}(E)={2}/{\sqrt{\pi}}\int_{0}^{E} {\rm e}^{-t^{2}}{\rm d}t $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M56.jpg" xlink:type="simple" />
+					</inline-formula>
+					. Equation (10) describes the MC energy spectrum very well, and the parameters were determined from the MC energy spectrum. Since the detector ran in several different trigger conditions, the final MC energy spectrum was the average of those weighted by the live time for each DAQ phase.
+				</p>
+				<p>The time spectrum of neutron capture is described by</p>
+				<p>
+					<disp-formula>
+						<label>12</label>
+						<tex-math id="cpc_46_8_085001_E12">
+							<?CDATA $ N(t)=\frac{N'_{n}}{\tau_{n}}{\rm e}^{-(t-t_{\mu})/\tau_{n}}+N_{\rm bkg}, $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E12.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N'_{n} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M57.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the total number of neutron-capture events associated with the selected signal window, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N_{\rm bkg} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M58.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the background rate. Considering the selection of signal time window, we have the probability density function
+				</p>
+				<p>
+					<disp-formula>
+						<label>13</label>
+						<tex-math id="cpc_46_8_085001_E13">
+							<?CDATA $ f(t)=(1-\omega)f_{\rm sig}^{'}+\omega f_{\rm bkg}^{'}, $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E13.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>where,</p>
+				<p>
+					<disp-formula>
+						<label>14</label>
+						<tex-math id="cpc_46_8_085001_E14">
+							<?CDATA $ f_{\rm sig}^{'}=\frac{\dfrac{1}{\tau_{n}}{\rm e}^{-(t-t_{\mu})/\tau_{n}}}{\displaystyle\int_{20\ {\text{ µ}\rm s}}^{1020\ {{\text{ µ}\rm s}}}\dfrac{1}{\tau_{n}}{\rm e}^{-(t-t_{\mu})/\tau_{n}}{\rm d}t}, \\ $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E14.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>and</p>
+				<p>
+					<disp-formula>
+						<label>15</label>
+						<tex-math id="cpc_46_8_085001_E15">
+							<?CDATA $ f_{\rm bkg}^{'}=\frac{1}{\displaystyle\int_{20\ {\text{ µ} \rm s}}^{1020\ {\text{ µ}\rm s}}{\rm d}t}. $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E15.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>which are the normalized signal and background time spectra, respectively.</p>
+				<p>
+					We consider that the number of neutron-capture events follows a Poisson distribution with the expected value
+					<italic toggle="yes">ν</italic>
+					. Since the energy and time of neutron-capture events are independent, the 2-dimensional likelihood function is
+				</p>
+				<p>
+					<disp-formula>
+						<label>16</label>
+						<tex-math id="cpc_46_8_085001_E16">
+							<?CDATA $ \mathcal{L}=\frac{\nu^{m}}{m!}{\rm e}^{-\nu}\prod \limits_{i=1}^{m}\left[f(E_{i})f(t_{i})\right]. $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E16.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m = 39 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M59.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the number of neutron candidates in the signal window.
+				</p>
+				<p>
+					We divided the DAQ phases into two parts: the high threshold period and the low one, namely DAQ A–F and DAQ G–J. Analyzed separately, the numbers of muon-induced neutrons were observed to be
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 6.37 \pm3.46_{\rm stat.} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M60.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 1.49\pm1.93_{\rm stat.} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M61.jpg" xlink:type="simple" />
+					</inline-formula>
+					, respectively. The total number of muon-induced neutrons
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N'_{n} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M62.jpg" xlink:type="simple" />
+					</inline-formula>
+					was calculated as
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 7.86\pm3.97_{\rm stat.} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M63.jpg" xlink:type="simple" />
+					</inline-formula>
+					, which shows the observed neutrons with a statistical significance at the 2
+					<italic toggle="yes">σ</italic>
+					level.
+					<xref ref-type="fig" rid="cpc_46_8_085001_f5">Figure 5</xref>
+					shows the fit of energy (a) and time (b) spectra of neutron-capture events against the combined dataset of the two periods.
+				</p>
+				<p>
+					We estimated the systematic effect on the number of neutrons due to the uncertainties of the parameters obtained from MC simulation and the energy scale to be 0.64% and 0.81%. They provided a combined systematic uncertainty on
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N'_{n} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M64.jpg" xlink:type="simple" />
+					</inline-formula>
+					of 1.0%.
+				</p>
+			</sec>
+			<sec id="cpc_46_8_085001_s05-04">
+				<label>D.</label>
+				<title>
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \boldsymbol\varepsilon_{ \boldsymbol LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M65.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<italic toggle="yes">L</italic>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $\boldsymbol \xi_{ \boldsymbol LS}$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M66.jpg" xlink:type="simple" />
+					</inline-formula>
+				</title>
+				<p>
+					The MC simulation determined the neutron detection efficiency
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \varepsilon_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M67.jpg" xlink:type="simple" />
+					</inline-formula>
+					in Eq. (7) for each DAQ phase. Owing to the small volume of the LS region in this detector and the relatively large mean free path of muon-induced neutrons,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \varepsilon_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M68.jpg" xlink:type="simple" />
+					</inline-formula>
+					is dependent on the neutrons' distribution positions. We compared the neutrons produced along their parent muon's track and those uniformly generated in the LS region and evaluated a 6.65% contribution to the systematic uncertainty of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \varepsilon_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M69.jpg" xlink:type="simple" />
+					</inline-formula>
+					.
+					<xref ref-type="table" rid="cpc_46_8_085001_t2">Table 2</xref>
+					shows the result for each DAQ phase. We obtained the weighted average by the live time for
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \varepsilon_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M70.jpg" xlink:type="simple" />
+					</inline-formula>
+					used in Eq. (7).
+				</p>
+				<table-wrap id="cpc_46_8_085001_t2" orientation="portrait" position="float">
+					<label>Table 2</label>
+					<caption id="cpc_46_8_085001_tc2">
+						<p>
+							Detection efficiency
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \varepsilon_{\rm LS} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M71.jpg" xlink:type="simple" />
+							</inline-formula>
+							and fraction factor
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \xi_{\rm LS} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M72.jpg" xlink:type="simple" />
+							</inline-formula>
+							values in Eq. (7) for different DAQ phases.
+						</p>
+					</caption>
+					<table>
+						<thead>
+							<tr>
+								<th align="center" colspan="1" rowspan="1" valign="middle">DAQ phase</th>
+								<th align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $\varepsilon_{\rm LS }$?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M73.jpg" xlink:type="simple" />
+									</inline-formula>
+									(%)
+								</th>
+								<th align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $ \xi_{\rm LS} $?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M74.jpg" xlink:type="simple" />
+									</inline-formula>
+									(%)
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">A–D</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">40.65±2.70</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">74.01±12.53</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">E–F</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">40.74±2.71</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">72.67±12.24</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">G</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">53.54±3.56</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">67.86±11.25</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">H</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">55.17±3.67</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">61.79±10.09</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">I, J</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">56.42±3.75</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">61.36±9.86</td>
+							</tr>
+						</tbody>
+					</table>
+				</table-wrap>
+				<p>
+					The underground muon energy and angular spectra and muon selection criteria determined the distribution of
+					<italic toggle="yes">L</italic>
+					and its uncertainty. The average track length
+					<italic toggle="yes">L</italic>
+					of a muon passing the LS was estimated to be
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 108.01\pm 14.10 \rm \ cm $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M85.jpg" xlink:type="simple" />
+					</inline-formula>
+					from the MC simulation.
+				</p>
+				<p>
+					We calculated
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \xi_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M86.jpg" xlink:type="simple" />
+					</inline-formula>
+					by simulating the detected number of muon-induced neutrons in each component
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ N'_{n,i} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M87.jpg" xlink:type="simple" />
+					</inline-formula>
+					defined by Eqs. (3), (4), and (5).
+					<xref ref-type="table" rid="cpc_46_8_085001_t2">Table 2</xref>
+					shows the
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \xi_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M88.jpg" xlink:type="simple" />
+					</inline-formula>
+					value in each DAQ phase. We obtained the weighted average of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \xi_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M89.jpg" xlink:type="simple" />
+					</inline-formula>
+					for use in Eq. (7) using the live time.
+				</p>
+				<p>
+					As shown in
+					<xref ref-type="table" rid="cpc_46_8_085001_t2">Table 2</xref>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \varepsilon_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M90.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \xi_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M91.jpg" xlink:type="simple" />
+					</inline-formula>
+					varied with the trigger conditions and light yields of the detector.
+				</p>
+				<p>
+					Similar to
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \varepsilon_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M92.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \xi_{\rm LS} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M93.jpg" xlink:type="simple" />
+					</inline-formula>
+					, we defined the detection efficiency
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \varepsilon_{\rm Other} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M94.jpg" xlink:type="simple" />
+					</inline-formula>
+					and fraction of detected neutrons
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \xi_{\rm Other} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M95.jpg" xlink:type="simple" />
+					</inline-formula>
+					generated in other components, which include the water, acrylic vessel, iron tank, lead wall of the detector, and rock in the Jinping Mountain. They all can contribute to the detected neutrons.
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \varepsilon_{\rm Other} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M96.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \xi_{\rm Other} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M97.jpg" xlink:type="simple" />
+					</inline-formula>
+					are used to understand the contribution of detected neutrons from other components and the detector performance of neutron detection.
+					<xref ref-type="table" rid="cpc_46_8_085001_t3">Table 3</xref>
+					lists the
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \varepsilon_{\rm Other} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M98.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \xi_{\rm Other} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M99.jpg" xlink:type="simple" />
+					</inline-formula>
+					values for DAQ phases A–D, as an example. The sum of all the
+					<italic toggle="yes">ξ</italic>
+					values equals 100%.
+				</p>
+				<table-wrap id="cpc_46_8_085001_t3" orientation="portrait" position="float">
+					<label>Table 3</label>
+					<caption id="cpc_46_8_085001_tc3">
+						<p>
+							Efficiency
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \varepsilon_{_{\rm Other}} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M100.jpg" xlink:type="simple" />
+							</inline-formula>
+							and fraction factor
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \xi_{_{\rm Other}} $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_8_085001_M101.jpg" xlink:type="simple" />
+							</inline-formula>
+							value of all components for DAQ phases A-D.
+						</p>
+					</caption>
+					<table>
+						<thead>
+							<tr>
+								<th align="center" colspan="1" rowspan="1" valign="middle" />
+								<th align="center" colspan="1" rowspan="1" valign="middle">Water</th>
+								<th align="center" colspan="1" rowspan="1" valign="middle">Acrylic</th>
+								<th align="center" colspan="1" rowspan="1" valign="middle">Iron</th>
+								<th align="center" colspan="1" rowspan="1" valign="middle">Lead</th>
+								<th align="center" colspan="1" rowspan="1" valign="middle">Rock</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $ \varepsilon_{\rm Other} $?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M102.jpg" xlink:type="simple" />
+									</inline-formula>
+									(%)
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">4.89±0.33</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">18.79±1.25</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">0.58±0.04</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">0.50±0.03</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">0.073±0.005</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $ \xi_{\rm Other} $?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M108.jpg" xlink:type="simple" />
+									</inline-formula>
+									(%)
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">9.55±2.89</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">1.00±0.27</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">2.02±0.47</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">13.16±2.17</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">0.26±0.07</td>
+							</tr>
+						</tbody>
+					</table>
+				</table-wrap>
+			</sec>
+			<sec id="cpc_46_8_085001_s05-05">
+				<label>E.</label>
+				<title>Yield Result</title>
+				<p>
+					<xref ref-type="table" rid="cpc_46_8_085001_t4">Table 4</xref>
+					lists all the variables and uncertainties used in Eq. (7). We calculated the neutron yield in the LS of DAQ phases A–F to be
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Y_{n}=(4.84 \pm 2.63_{\rm stat.}\pm 1.08_{\rm syst.})\times 10^{-4} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M114.jpg" xlink:type="simple" />
+					</inline-formula>
+					μ
+					<sup>−1</sup>
+					g
+					<sup>−1</sup>
+					cm
+					<sup>2</sup>
+					, and DAQ phases G–J to be
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Y_{n}= (2.03 \pm 2.63_{\rm stat.}\pm 0.44_{\rm syst.})\times 10^{-4} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M115.jpg" xlink:type="simple" />
+					</inline-formula>
+					μ
+					<sup>−1</sup>
+					g
+					<sup>−1</sup>
+					cm
+					<sup>2</sup>
+					. These two measurements were statistically independent, but their systematical uncertainties were fully correlated. The combined neutron yield is
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Y_{n}=(3.44 \pm 1.86_{\rm stat.}\pm 0.76_{\rm syst.})\times 10^{-4} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M116.jpg" xlink:type="simple" />
+					</inline-formula>
+					μ
+					<sup>−1</sup>
+					g
+					<sup>−1</sup>
+					cm
+					<sup>2</sup>
+					. Owing to maintenance of the laboratory, the experiment has been shut down since September 2020, preventing an opportunity to accumulate more data to improve the statistical precision as desired. A corresponding upper limit of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 7.78\times 10^{-4} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_8_085001_M117.jpg" xlink:type="simple" />
+					</inline-formula>
+					μ
+					<sup>−1</sup>
+					g
+					<sup>−1</sup>
+					cm
+					<sup>2</sup>
+					at 99% C.L. was also indicated.
+				</p>
+				<table-wrap id="cpc_46_8_085001_t4" orientation="portrait" position="float">
+					<label>Table 4</label>
+					<caption id="cpc_46_8_085001_tc4">
+						<p>Parameters used in Eq. (7) to calculate the neutron yield in the LS.</p>
+					</caption>
+					<table>
+						<thead>
+							<tr>
+								<th align="center" colspan="1" rowspan="1" valign="middle">DAQ phase</th>
+								<th align="center" colspan="1" rowspan="1" valign="middle">Parameter</th>
+								<th align="center" colspan="1" rowspan="1" valign="middle">Value</th>
+								<th align="center" colspan="1" rowspan="1" valign="middle">
+									Statistical
+									<break />
+									uncertainty
+								</th>
+								<th align="center" colspan="1" rowspan="1" valign="middle">
+									Systematic
+									<break />
+									uncertainty
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td align="center" colspan="1" rowspan="6" valign="middle">A–F</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $ N'_{n} $?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M118.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">6.37</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">3.46</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">0.06</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $ N_{\mu} $?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M119.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">256</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $\varepsilon_{\rm LS } (\%)$?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M120.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">40.68</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">2.70</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $\xi_{\rm LS } (\%)$?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M121.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">73.50</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">12.42</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $\rho /(\rm g/cm^{3})$?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M122.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">0.86</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $L /\rm cm$?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M123.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">108.01</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">14.10</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="6" valign="middle">G–J</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $ N'_{n} $?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M124.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">1.49</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">1.93</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">0.01</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $ N_{\mu} $?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M125.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">87</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $\varepsilon_{\rm LS } (\%)$?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M126.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">56.19</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">3.73</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $\xi_{\rm LS} (\%)$?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M127.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">61.81</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">9.96</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $ \rho /(\rm g/cm^{3}) $?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M128.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">0.86</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="1" rowspan="1" valign="middle">
+									<inline-formula>
+										<tex-math>
+											<?CDATA $L /\rm cm$?>
+										</tex-math>
+										<inline-graphic xlink:href="cpc_46_8_085001_M129.jpg" xlink:type="simple" />
+									</inline-formula>
+								</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">108.01</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+								<td align="center" colspan="1" rowspan="1" valign="middle">14.10</td>
+							</tr>
+						</tbody>
+					</table>
+				</table-wrap>
+			</sec>
+		</sec>
+		<sec id="cpc_46_8_085001_s06">
+			<label>VI.</label>
+			<title>COMPARISON WITH OTHER EXPERIMENTS</title>
+			<p>
+				We compare the neutron yield measurements from different experiments in terms of the average muon energy, with various muon energies and angular distributions.
+				<xref ref-type="fig" rid="cpc_46_8_085001_f6">Figure 6</xref>
+				shows the measurement at CJPL and the results from CUBE [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib2">2</xref>
+				], Bezrukov
+				<italic toggle="yes">et al</italic>
+				. [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib12">12</xref>
+				], Palo Verde [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib13">13</xref>
+				], Daya Bay EH1 [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib3">3</xref>
+				], Daya Bay EH2 [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib3">3</xref>
+				], Aberdeen Tunnel [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib4">4</xref>
+				], Enikeev
+				<italic toggle="yes">et al</italic>
+				. [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib5">5</xref>
+				], ASD [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib5">5</xref>
+				–
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib7">7</xref>
+				], Daya Bay EH3 [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib3">3</xref>
+				], KamLAND [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib8">8</xref>
+				], LVD2011 [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib9">9</xref>
+				], Borexino [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib10">10</xref>
+				], and LSD [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib11">11</xref>
+				] as a function of average muon energy.
+			</p>
+			<fig id="cpc_46_8_085001_f6" orientation="portrait" position="float">
+				<label>Fig. 6</label>
+				<caption id="cpc_46_8_085001_fc6">
+					<p>
+						(color online) Muon-induced neutron yield as a function of average muon energy from Jinping compared with other experiments. The solid red line shows the power-law fit to all the experiments, the blue dashed line is the fit result from Daya Bay [
+						<xref ref-type="bibr" rid="cpc_46_8_085001_bib3">3</xref>
+						], and the black dashed line shows FLUKA-based predictions for the dependence of the neutron yield on muon energy from Ref. [
+						<xref ref-type="bibr" rid="cpc_46_8_085001_bib35">35</xref>
+						].
+					</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_8_085001_f6_eps" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f6.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_8_085001_f6_online" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_f6.jpg" xlink:type="simple" />
+			</fig>
+			<p>
+				Previous studies [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib35">35</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib38">38</xref>
+				–
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib40">40</xref>
+				] have shown that the yield follows a power law of average muon energy:
+			</p>
+			<p>
+				<disp-formula>
+					<label>17</label>
+					<tex-math id="cpc_46_8_085001_E17">
+						<?CDATA $ Y_{n}=aE_{\mu}^{b}. $?>
+					</tex-math>
+					<graphic orientation="portrait" position="float" xlink:href="cpc_46_8_085001_E17.jpg" xlink:type="simple" />
+				</disp-formula>
+			</p>
+			<p>
+				<xref ref-type="fig" rid="cpc_46_8_085001_f6">Figure 6</xref>
+				shows the result of a global power-law fit to the experimental measurements (solid red line), including the result from this study. The fit yields coefficients
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ a=(4.52\pm0.55)\times 10^{-6} $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M130.jpg" xlink:type="simple" />
+				</inline-formula>
+				μ
+				<sup>−1</sup>
+				mg
+				<sup>−1</sup>
+				cm
+				<sup>2</sup>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ b= (0.75\pm 0.02) $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M131.jpg" xlink:type="simple" />
+				</inline-formula>
+				. Compared with the power-law fit from Daya Bay, this fit was consistent within the permitted error range, but it did not contribute significantly to the global fit owing to a large uncertainty.
+			</p>
+			<p>
+				We noted that the MC simulation [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib35">35</xref>
+				] underestimates the data from LSD [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib11">11</xref>
+				] at a high energy. Mei and Hime [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib40">40</xref>
+				] attributed the deviation to the lack of experimental data for high-energy muon interactions with nuclei. However, the cross-section of muons calculated using the Bezrukov-Buagaev model [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib41">41</xref>
+				] and used in the simulation [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib35">35</xref>
+				] was consistent with the measurement by MACRO [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib42">42</xref>
+				] and ATLAS [
+				<xref ref-type="bibr" rid="cpc_46_8_085001_bib43">43</xref>
+				]. We expect the next hundred-ton JNE detector under construction to increase the exposure by at least 100 times, which will measure the neutron yield precisely to provide insights into the tension.
+			</p>
+		</sec>
+		<sec id="cpc_46_8_085001_s07">
+			<label>VII.</label>
+			<title>SUMMARY</title>
+			<p>
+				We studied the cosmic-ray data collected by the 1-ton prototype detector of JNE at CJPL-I. By analyzing the neutrons associated with the muons, we measured the neutron yield
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ (3.44 \pm 1.86_{\rm stat.}\pm 0.76_{\rm syst.})\times 10^{-4} $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M132.jpg" xlink:type="simple" />
+				</inline-formula>
+				μ
+				<sup>−1</sup>
+				g
+				<sup>−1</sup>
+				cm
+				<sup>2</sup>
+				at an average muon energy of 340 GeV, corresponding to an upper limit of
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Y_{n} \lt 7.78\times 10^{-4} $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_8_085001_M133.jpg" xlink:type="simple" />
+				</inline-formula>
+				μ
+				<sup>−1</sup>
+				g
+				<sup>−1</sup>
+				cm
+				<sup>2</sup>
+				at 99% C.L. A power-law fit of the neutron yield against average muon energy shows that our result is consistent with those of previous studies but lacks statistics to contribute significantly. With the next hundred-ton JNE detector under construction, we foresee a significantly more precise muon-induced neutron study in the near future.
+			</p>
+		</sec>
+		<sec id="cpc_46_8_085001_s08">
+			<title>ACKNOWLEDGEMENTS</title>
+			<p>
+				<italic toggle="yes">We thank the anonymous referees for their critical comments and insightful suggestions. We acknowledge Orrin Science Technology, Jingyifan Co., Ltd, and Donchamp Acrylic Co., Ltd, for their efforts in the engineering design and fabrication of the stainless steel and acrylic vessels. Many thanks to the CJPL administration and the Yalong River Hydropower Development Co., Ltd. for logistics and support.</italic>
+			</p>
+		</sec>
+	</body>
+	<back>
+		<ref-list>
+			<title>References</title>
+			<ref id="cpc_46_8_085001_bib1">
+				<label>[1]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Hagner</surname>
+							<given-names>Tanja</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Astroparticle Physics</source>
+					<year>2000</year>
+					<volume>14</volume>
+					<issue>1</issue>
+					<fpage>33</fpage>
+					<lpage>47</lpage>
+					<pub-id pub-id-type="doi">10.1016/S0927-6505(00)00103-1</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib2">
+				<label>[2]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						R. Hertenberger
+						<italic toggle="yes">et al</italic>
+						., Phys. Rev. C,
+						<bold>52</bold>
+						: 3449–3459, 1995
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib3">
+				<label>[3]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Peng An</surname>
+							<given-names>Feng</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Physical Review D</source>
+					<year>2018</year>
+					<volume>97</volume>
+					<issue>5</issue>
+					<fpage>052009</fpage>
+					<pub-id pub-id-type="doi">10.1103/PhysRevD.97.052009</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib4">
+				<label>[4]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						S. C. Blyth
+						<italic toggle="yes">et al</italic>
+						., Phys. Rev. D,
+						<bold>93,</bold>
+						072005, 2016
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib5">
+				<label>[5]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Enikeev</surname>
+							<given-names>RI</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Soviet Journal of Nuclear Physics</source>
+					<year>1987</year>
+					<volume>46</volume>
+					<issue>5</issue>
+					<fpage>883</fpage>
+					<lpage>889</lpage>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib6">
+				<label>[6]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>S. Malgin</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>G. Ryazhskaya</surname>
+							<given-names>O.</given-names>
+						</name>
+					</person-group>
+					<source>Physics of Atomic Nuclei</source>
+					<year>2008</year>
+					<volume>71</volume>
+					<issue>10</issue>
+					<fpage>1769</fpage>
+					<lpage>1781</lpage>
+					<pub-id pub-id-type="doi">10.1134/S1063778808100116</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib7">
+				<label>[7]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Yu. Agafonova</surname>
+							<given-names>N.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>S. Malgin</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<source>Physical Review D</source>
+					<year>2013</year>
+					<volume>87</volume>
+					<issue>11</issue>
+					<fpage>113013</fpage>
+					<pub-id pub-id-type="doi">10.1103/PhysRevD.87.113013</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib8">
+				<label>[8]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Abe</surname>
+							<given-names>S</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Physical Review C</source>
+					<year>2010</year>
+					<volume>81</volume>
+					<issue>2</issue>
+					<fpage>025807</fpage>
+					<pub-id pub-id-type="doi">10.1103/PhysRevC.81.025807</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib9">
+				<label>[9]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						R Persiani
+						<italic toggle="yes">et al</italic>
+						.
+						<italic toggle="yes">Measurement of the muon-induced neutron yield in liquid scintillator and stainless steel at LNGS with the LVD experiment</italic>
+						. In AIP Conference Proceedings, volume 1549, pages 235–238. American Institute of Physics, 2013
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib10">
+				<label>[10]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Bellini</surname>
+							<given-names>G</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Journal of Cosmology and Astroparticle Physics</source>
+					<year>2013</year>
+					<volume>2013</volume>
+					<issue>08</issue>
+					<fpage>049</fpage>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib11">
+				<label>[11]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Aglietta</surname>
+							<given-names>M</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Il Nuovo Cimento C</source>
+					<year>1989</year>
+					<volume>12</volume>
+					<issue>4</issue>
+					<fpage>467</fpage>
+					<lpage>477</lpage>
+					<pub-id pub-id-type="doi">10.1007/BF02525079</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib12">
+				<label>[12]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						Leonid B Bezrukov
+						<italic toggle="yes">et al</italic>
+						., I
+						<italic toggle="yes">nvestigation of depth-intensity curve of nuclear events induced by muons</italic>
+						. In International Cosmic Ray Conference, volume 3, page 1947, 1973
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib13">
+				<label>[13]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Boehm</surname>
+							<given-names>F.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Rev. D</source>
+					<year>2000</year>
+					<volume>62</volume>
+					<fpage>092005</fpage>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib14">
+				<label>[14]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Cheng</surname>
+							<given-names>Jian-Ping</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Annual Review of Nuclear and Particle Science</source>
+					<year>2017</year>
+					<volume>67</volume>
+					<fpage>231</fpage>
+					<lpage>251</lpage>
+					<pub-id pub-id-type="doi">10.1146/annurev-nucl-102115-044842</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib15">
+				<label>[15]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						Ke-Jun Kang
+						<italic toggle="yes">et al</italic>
+						.,
+						<italic toggle="yes">Status and prospects of a deep underground laboratory in China</italic>
+						. In Journal of Physics: Conference Series, volume 203, page 012028. IOP Publishing, 2010
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib16">
+				<label>[16]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Yue</surname>
+							<given-names>Qian</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Physical Review D</source>
+					<year>2014</year>
+					<volume>90</volume>
+					<issue>9</issue>
+					<fpage>091701</fpage>
+					<pub-id pub-id-type="doi">10.1103/PhysRevD.90.091701</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib17">
+				<label>[17]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Xiao</surname>
+							<given-names>Mengjiao</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Science China Physics, Mechanics &amp; Astronomy</source>
+					<year>2014</year>
+					<volume>57</volume>
+					<issue>11</issue>
+					<fpage>2024</fpage>
+					<lpage>2030</lpage>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib18">
+				<label>[18]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>F Beacom</surname>
+							<given-names>John</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Chinese physics C</source>
+					<year>2017</year>
+					<volume>41</volume>
+					<issue>2</issue>
+					<fpage>023002</fpage>
+					<pub-id pub-id-type="doi">10.1088/1674-1137/41/2/023002</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib19">
+				<label>[19]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Wan</surname>
+							<given-names>Linyan</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Rev. D</source>
+					<year>2017</year>
+					<volume>95</volume>
+					<fpage>053001</fpage>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib20">
+				<label>[20]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Wang</surname>
+							<given-names>Zhe</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Chen</surname>
+							<given-names>Shaomin</given-names>
+						</name>
+					</person-group>
+					<source>Chinese Physics C</source>
+					<year>2020</year>
+					<volume>44</volume>
+					<issue>3</issue>
+					<fpage>033001</fpage>
+					<pub-id pub-id-type="doi">10.1088/1674-1137/44/3/033001</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib21">
+				<label>[21]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Wei</surname>
+							<given-names>Hanyu</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Physics Letters B</source>
+					<year>2017</year>
+					<volume>769</volume>
+					<fpage>255</fpage>
+					<lpage>261</lpage>
+					<pub-id pub-id-type="doi">10.1016/j.physletb.2017.03.071</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib22">
+				<label>[22]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Guo</surname>
+							<given-names>Zi-yi</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Chinese Physics C</source>
+					<year>2021</year>
+					<volume>45</volume>
+					<issue>2</issue>
+					<fpage>025001</fpage>
+					<pub-id pub-id-type="doi">10.1088/1674-1137/abccae</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib23">
+				<label>[23]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Wang</surname>
+							<given-names>Zongyi</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment</source>
+					<year>2017</year>
+					<volume>855</volume>
+					<fpage>81</fpage>
+					<lpage>87</lpage>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib24">
+				<label>[24]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Li</surname>
+							<given-names>Mohan</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment</source>
+					<year>2016</year>
+					<volume>830</volume>
+					<fpage>303</fpage>
+					<lpage>308</lpage>
+					<pub-id pub-id-type="doi">10.1016/j.nima.2016.05.132</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib25">
+				<label>[25]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Guo</surname>
+							<given-names>Ziyi</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Astroparticle Physics</source>
+					<year>2019</year>
+					<volume>109</volume>
+					<fpage>33</fpage>
+					<lpage>40</lpage>
+					<pub-id pub-id-type="doi">10.1016/j.astropartphys.2019.02.001</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib26">
+				<label>[26]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						EH Bellamy
+						<italic toggle="yes">et al</italic>
+						., Absolute calibration and monitoring of a spectrometric channel using a photomultiplier. Technical report, Joint Inst. for Nuclear Research, 1993
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib27">
+				<label>[27]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Agostinelli</surname>
+							<given-names>S</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment</source>
+					<year>2003</year>
+					<volume>506</volume>
+					<fpage>250</fpage>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib28">
+				<label>[28]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Allison</surname>
+							<given-names>John</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>IEEE Transactions on nuclear science</source>
+					<year>2006</year>
+					<volume>53</volume>
+					<issue>1</issue>
+					<fpage>270</fpage>
+					<lpage>278</lpage>
+					<pub-id pub-id-type="doi">10.1109/TNS.2006.869826</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib29">
+				<label>[29]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>G Farr</surname>
+							<given-names>Tom</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Rev. geophys.</source>
+					<year>2007</year>
+					<volume>45</volume>
+					<issue>2</issue>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib30">
+				<label>[30]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Wu</surname>
+							<given-names>Yu-Cheng</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Chinese Physics C</source>
+					<year>2013</year>
+					<volume>37</volume>
+					<issue>8</issue>
+					<fpage>086001</fpage>
+					<pub-id pub-id-type="doi">10.1088/1674-1137/37/8/086001</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib31">
+				<label>[31]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						David R Lide.
+						<italic toggle="yes">CRC handbook of chemistry and physics</italic>
+						, volume 97. CRC press, 2016
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib32">
+				<label>[32]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						Thomas K Gaisser et al.
+						<italic toggle="yes">Cosmic rays and particle physics</italic>
+						. Cambridge University Press, 2016
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib33">
+				<label>[33]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Eidelman</surname>
+							<given-names>Simon</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Physics letters B</source>
+					<year>2004</year>
+					<volume>592</volume>
+					<issue>1-4</issue>
+					<fpage>1</fpage>
+					<lpage>5</lpage>
+					<pub-id pub-id-type="doi">10.1016/j.physletb.2004.06.001</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib34">
+				<label>[34]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						Mengyun Guan
+						<italic toggle="yes">et al</italic>
+						., A parametrization of the cosmic-ray muon flux at sea-level. arXiv preprint arXiv: 1509.06176, 2015
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib35">
+				<label>[35]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Wang</surname>
+							<given-names>Y-F</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Physical Review D</source>
+					<year>2001</year>
+					<volume>64</volume>
+					<issue>1</issue>
+					<fpage>013012</fpage>
+					<pub-id pub-id-type="doi">10.1103/PhysRevD.64.013012</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib36">
+				<label>[36]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						Said F Mughabghab.
+						<italic toggle="yes">Neutron Cross Sections: Neutron Resonance Parameters and Thermal Cross Sections Part B: Z= 61-100</italic>
+						, volume 1. Academic press, 2012
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib37">
+				<label>[37]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Cheng</surname>
+							<given-names>Jia-Hua</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment</source>
+					<year>2016</year>
+					<volume>827</volume>
+					<fpage>165</fpage>
+					<lpage>170</lpage>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib38">
+				<label>[38]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Kudryavtsev</surname>
+							<given-names>VA</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment</source>
+					<year>2003</year>
+					<volume>505</volume>
+					<issue>3</issue>
+					<fpage>688</fpage>
+					<lpage>698</lpage>
+					<pub-id pub-id-type="doi">10.1016/S0168-9002(03)00983-5</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib39">
+				<label>[39]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Araujo</surname>
+							<given-names>HM</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment</source>
+					<year>2005</year>
+					<volume>545</volume>
+					<issue>1-2</issue>
+					<fpage>398</fpage>
+					<lpage>411</lpage>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib40">
+				<label>[40]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Mei</surname>
+							<given-names>D-M</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Hime</surname>
+							<given-names>A</given-names>
+						</name>
+					</person-group>
+					<source>Physical Review D</source>
+					<year>2006</year>
+					<volume>73</volume>
+					<issue>5</issue>
+					<fpage>053004</fpage>
+					<pub-id pub-id-type="doi">10.1103/PhysRevD.73.053004</pub-id>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib41">
+				<label>[41]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						L. B. Bezrukov and E. V. Bugaev,
+						<italic toggle="yes">Nucleon shadowing effects in photonuclear interactions</italic>
+						. Sov. J. Nucl. Phys.(Engl. Transl.);(United States), 33(5), 1981
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib42">
+				<label>[42]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						Holger Kluck.
+						<italic toggle="yes">Review of muon-induced neutron production at underground sites</italic>
+						. In Production Yield of MuonInduced Neutrons in Lead, pages 77–150. Springer, 2015
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_8_085001_bib43">
+				<label>[43]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Alexa</surname>
+							<given-names>Calin</given-names>
+						</name>
+					</person-group>
+					<source>The European Physical Journal C-Particles and Fields</source>
+					<year>2003</year>
+					<volume>28</volume>
+					<issue>3</issue>
+					<fpage>297</fpage>
+					<lpage>304</lpage>
+				</element-citation>
+			</ref>
+		</ref-list>
+	</back>
+</article>

--- a/tests/units/iop/data/example2.xml
+++ b/tests/units/iop/data/example2.xml
@@ -1,0 +1,7111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" xml:lang="en">
+   <front>
+      <journal-meta>
+         <journal-id journal-id-type="publisher-id">cpc</journal-id>
+         <journal-title-group>
+            <journal-title xml:lang="en">Chinese Physics C</journal-title>
+         </journal-title-group>
+         <issn pub-type="ppub">1674-1137</issn>
+         <publisher>
+            <publisher-name>Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+                        </publisher-name>
+         </publisher>
+      </journal-meta>
+      <article-meta>
+         <article-id pub-id-type="publisher-id">cpc_46_10_103101</article-id>
+         <article-id pub-id-type="doi">10.1088/1674-1137/ac763c</article-id>
+         <article-id pub-id-type="manuscript">ac763c</article-id>
+         <article-categories>
+            <subj-group subj-group-type="display-article-type">
+               <subject>Paper</subject>
+            </subj-group>
+            <subj-group subj-group-type="section">
+               <subject>Particles and fields</subject>
+            </subj-group>
+         </article-categories>
+         <title-group>
+            <article-title>
+               Lepton and quark mixing patterns with generalized
+               <italic toggle="yes">CP</italic>
+               transformations
+            </article-title>
+         </title-group>
+         <contrib-group>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Ganguly</surname>
+                  <given-names>Joy</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <email>ph18resch11009@iith.ac.in</email>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Hundi</surname>
+                  <given-names>Raghavendra Srikanth</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <email>rshundi@phy.iith.ac.in</email>
+            </contrib>
+            <aff id="affiliation01">
+               <label>1</label>
+               <institution xlink:type="simple">Department of Physics, Indian Institute of Technology Hyderabad</institution>
+               , Kandi - 502 284,
+               <country>India</country>
+            </aff>
+         </contrib-group>
+         <pub-date pub-type="ppub">
+            <day>01</day>
+            <month>10</month>
+            <year>2022</year>
+         </pub-date>
+         <pub-date pub-type="open-access">
+            <day>29</day>
+            <month>7</month>
+            <year>2022</year>
+         </pub-date>
+         <volume>46</volume>
+         <issue>10</issue>
+         <elocation-id content-type="artnum">103101</elocation-id>
+         <history>
+            <date date-type="received">
+               <day>15</day>
+               <month>4</month>
+               <year>2022</year>
+            </date>
+            <date date-type="published-online">
+               <day>29</day>
+               <month>7</month>
+               <year>2022</year>
+            </date>
+            <date date-type="oa-requested">
+               <day>15</day>
+               <month>4</month>
+               <year>2022</year>
+            </date>
+         </history>
+         <permissions>
+            <copyright-statement>© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</copyright-statement>
+            <copyright-year>2022</copyright-year>
+            <license license-type="cc-by" xlink:href="http://creativecommons.org/licenses/by/3.0/" xlink:type="simple">
+               <license-p>
+                  <graphic content-type="online" orientation="portrait" position="float" xlink:href="cpc_46_10_103101_ccby.tif" xlink:type="simple" />
+                  Content from this work may be used under the terms of the
+                  <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/3.0" xlink:type="simple">Creative Commons Attribution 3.0 licence</ext-link>
+                  . Any further distribution of this work must maintain attribution to the author(s) and the title of the work, journal citation and DOI. Article funded by SCOAP
+                  <sup>3</sup>
+                  and published under licence by Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+               </license-p>
+            </license>
+         </permissions>
+         <self-uri content-type="pdf" xlink:href="cpc_46_10_103101.pdf" xlink:type="simple" />
+         <abstract>
+            <title>Abstract</title>
+            <p>
+               In this study, we modify a scenario, originally proposed by Grimus and Lavoura, in order to obtain maximal values for the atmospheric mixing angle and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M1.jpg" xlink:type="simple" />
+               </inline-formula>
+               , violating the Dirac phase of the lepton sector. To achieve this, we employ
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M2.jpg" xlink:type="simple" />
+               </inline-formula>
+               and some discrete symmetries in a type II seesaw model. To make predictions about the neutrino mass ordering and smallness of the reactor angle, we establish some conditions on the elements of the neutrino mass matrix of our model. Finally, we study the quark masses and mixing pattern within the framework of our model.
+            </p>
+         </abstract>
+         <kwd-group kwd-group-type="author">
+            <kwd>neutrino physics</kwd>
+            <kwd>nuetrino mass and mixing model</kwd>
+            <kwd>quark mass and mixing</kwd>
+            <kwd>analysis of scalar potential</kwd>
+         </kwd-group>
+         <funding-group>
+            <open-access>
+               <p content-type="scoap3">
+                  Article funded by SCOAP
+                  <sup>3</sup>
+               </p>
+            </open-access>
+         </funding-group>
+         <counts>
+            <page-count count="18" />
+         </counts>
+         <custom-meta-group>
+            <custom-meta xlink:type="simple">
+               <meta-name>arxivppt</meta-name>
+               <meta-value>2107.07275</meta-value>
+            </custom-meta>
+         </custom-meta-group>
+      </article-meta>
+   </front>
+   <body>
+      <sec id="cpc_46_10_103101_s01">
+         <label>I.</label>
+         <title>INTRODUCTION</title>
+         <p>
+            According to the global fits to neutrino oscillation data [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], it is well known that the three mixing angles in the lepton sector are close to the tribimaximal (TBM) mixing [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib2">2</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib4">4</xref>
+            ]. In the TBM pattern, the values of the three mixing angles are as follows:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{12}={1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M3.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{23}={1}/{2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M4.jpg" xlink:type="simple" />
+            </inline-formula>
+            , and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{13}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M5.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In contrast, the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M6.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating Dirac phase,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{ CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M7.jpg" xlink:type="simple" />
+            </inline-formula>
+            , in the lepton sector is yet to be measured precisely. However, from the global fits to neutrino oscillation data [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], the best fit value for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M8.jpg" xlink:type="simple" />
+            </inline-formula>
+            is around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $\pi({3}/{2}\pi)$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M9.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the case of normal (inverted) ordering of neutrino masses. The TBM value for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M10.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP}=({3}/{2})\pi $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M11.jpg" xlink:type="simple" />
+            </inline-formula>
+            are still allowed in the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M12.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges for these observables in the current neutrino oscillation data [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ]. The aforementioned values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M13.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M14.jpg" xlink:type="simple" />
+            </inline-formula>
+            are considered to be maximal. To explain these maximal values for
+            <italic toggle="yes">θ</italic>
+            <sub>23</sub>
+            and
+            <italic toggle="yes">
+               δ
+               <sub>CP</sub>
+            </italic>
+            , Harrison and Scott have proposed the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M17.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry in combination with
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${C P}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M18.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, together  called
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M19.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib5">5</xref>
+            ]. For further works regarding the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M20.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${ C P}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M21.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetries, see Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib6">6</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib12">12</xref>
+            ]. Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib6">6</xref>
+            ] is a review article.
+         </p>
+         <p>
+            In the work by Grimus and Lavoura [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], it is shown that a mass matrix for light left-handed neutrinos has the following form [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib14">14</xref>
+            ]:
+         </p>
+         <p>
+            <disp-formula>
+               <label>1</label>
+               <tex-math id="cpc_46_10_103101_E1">
+                  <?CDATA $ \begin{equation} {\cal M}_\nu=\left(\begin{array}{ccc} a & r & r^* \\ r & s & b \\ r^* & b & s^* \end{array}\right) \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E1.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            which can yield maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M22.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M23.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In the above equation,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ a,b $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M24.jpg" xlink:type="simple" />
+            </inline-formula>
+            are real and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ r,s $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M25.jpg" xlink:type="simple" />
+            </inline-formula>
+            are complex. Further, in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], a model is constructed, which is based on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M26.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry and softly broken lepton numbers, to obtain a mass matrix of the same form as in Eq. (1) for light neutrinos. In this model, three Higgs doublets are introduced and light neutrinos acquire masses via type I seesaw mechanism [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib15">15</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib16">16</xref>
+            ]. The lepton number is softly broken by the mass terms for right-handed neutrinos in this model. However, in the absence of parameter fine tuning in the model, muon and tau leptons can have masses of the same order. To explain the hierarchy in the masses for these leptons,
+            <italic toggle="yes">K</italic>
+            symmetry is introduced, under which the muon is massless [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. Realistic masses for muon and tau leptons are explained in the above mentioned scenario with the soft breaking of the
+            <italic toggle="yes">K</italic>
+            symmetry [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ]. The work done together in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ], which is based on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M27.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, consistently explains the mixing pattern in lepton sector and also the masses for charged leptons.
+         </p>
+         <p>
+            Although the work done in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ] gives a consistent picture about masses and mixing pattern in the lepton sector, it suffers from a few limitations, as explained below. It is argued in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ] that the mass matrix of Eq. (1), which is obtained from
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M28.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, cannot give predictions about neutrino mass ordering and the mixing angle
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M29.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Moreover, in the case of maximal
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M30.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the mass matrix of Eq. (1) can make no predictions regarding
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M31.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. From the current neutrino oscillation data, it is known that neutrinos can have either normal or inverted mass ordering, where
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{12}\sim{1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M32.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{13}\sim10^{-2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M33.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ]. Apart from the above mentioned limitations, in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], mixing pattern in the quark sector was not addressed. Nonetheless, the mixing pattern in the quark sector [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ] is known to be different from that of lepton sector. The interest would be to know whether the same framework could be used to understand the mixing patterns for both quark and lepton sectors.
+         </p>
+         <p>
+            As stated above, in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], a model, which is based on type I seesaw mechanism and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M34.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, is presented with the aim of obtaining the neutrino mass matrix of the same form as Eq. (1). In this work, we rather aim at investigation whether the matrix in Eq. (1) can be obtained with type II seesaw mechanism [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib19">19</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib21">21</xref>
+            ] in the framework of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M35.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry. To achieve this, we construct a model, which has three Higgs doublets and one scalar Higgs triplet. In our model, right-handed neutrinos do not exist, and hence, neutrinos acquire masses when the Higgs triplet get vacuum expectation value (VEV). The purpose of Higgs doublets is to give masses to charged leptons via Yukawa couplings. With the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M36.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry in our model, if the VEV of Higgs triplet is real, we show that mass matrix for the light neutrinos will have the form of Eq. (1). To show whether the VEV of the Higgs triplet could be real, we analyze the scalar potential of our model. We demonstrate that by using an extra discrete symmetry, the VEV of Higgs triplet can be real. In parallel to that, we also address the problem of hierarchy in the masses of muon and tau leptons. In the literature, models have been constructed in order to achieve maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M37.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M38.jpg" xlink:type="simple" />
+            </inline-formula>
+            using type II seesaw mechanism [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib22">22</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib23">23</xref>
+            ]. However, in these models, multiple Higgs triplets have been introduced in addition to the three Higgs doublets. Hence, our model  proposed here is economical compared to the aforementioned models.
+         </p>
+         <p>
+            As stated previously, the mass matrix form given in Eq. (1) can predict maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M39.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M40.jpg" xlink:type="simple" />
+            </inline-formula>
+            . However, this matrix cannot make predictions about neutrino mass ordering and the mixing angles
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{12},\theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M41.jpg" xlink:type="simple" />
+            </inline-formula>
+            . As already pointed before, we have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{13}\sim10^{-2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M42.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], which means that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M43.jpg" xlink:type="simple" />
+            </inline-formula>
+            is a small angle. In this work, we perform an analysis, based on approximation procedures [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib24">24</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib25">25</xref>
+            ], and derive some conditions on the elements of neutrino mass matrix which can make predictions about the neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M44.jpg" xlink:type="simple" />
+            </inline-formula>
+            , apart from giving maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M45.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M46.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In this analysis, we assume
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{12}\sim{1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M47.jpg" xlink:type="simple" />
+            </inline-formula>
+            . To achieve the above mentioned conditions, new mechanisms should be proposed. In this work, we have attempted to provide one mechanism to achieve one of those conditions.
+         </p>
+         <p>
+            In our model three Higgs doublets give masses to charged leptons. Thus, it is worth knowing whether these scalar doublets can also generate masses and mixing pattern for quarks. Due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M48.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry in the lepton sector, it is found that these Higgs doublets should transform non-trivially under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M49.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. As a result, we propose
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M50.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations for quarks in such a way that the corresponding Yukawa couplings are invariant under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M51.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. A large hierarchy among the masses of quarks is known. Hence, to explain the mixing pattern for quarks, their Yukawa couplings should be hierarchically suppressed [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib26">26</xref>
+            ]. To explain the realistic mixing pattern for quarks through hierarchically suppressed Yukawa couplings, we followed the work done in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ]. For more information regarding other works on quark and lepton mixings with generalized
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M52.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations, see Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib29">29</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib30">30</xref>
+            ]. Additional works addressing quark and lepton mixings with other symmetries could be found in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib31">31</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib33">33</xref>
+            ].
+         </p>
+         <p>
+            The paper is organized as follows. In the next section, we propose a model for lepton mixing, where maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M53.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M54.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be predicted if the VEV of triplet Higgs is real. In Sec. III, we analyze the scalar potential of our model and show that the VEV of triplet Higgs can be real if we introduce additional discrete symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M55.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In Sec. IV, we obtain some conditions on the elements of the neutrino mass matrix of our model, which enable predictions about the neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M56.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In Sec. VI, we investigate quark masses and mixing patterns and demonstrate that they can be explained in the framework of our model. Conclusions are presented in the last section. In the Appendix, we attempt to describe a mechanism for achieving normal order of neutrino masses.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s02">
+         <label>II.</label>
+         <title>A MODEL FOR LEPTON MIXING</title>
+         <p>
+            The model we propose for lepton mixing is similar to that in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. We propose scalar Higgs doublets
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_i=(\phi_i^+,\phi_i^0)^T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M57.jpg" xlink:type="simple" />
+            </inline-formula>
+            , where
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ i=1,2,3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M58.jpg" xlink:type="simple" />
+            </inline-formula>
+            , in order to give masses to charged leptons. We denote the lepton doublets and singlets by
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{\alpha {\rm L}}=(\nu_{\alpha {\rm L}},\alpha_{\rm L})^T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M59.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \alpha_R $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M60.jpg" xlink:type="simple" />
+            </inline-formula>
+            , where
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \alpha=e,\mu,\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M61.jpg" xlink:type="simple" />
+            </inline-formula>
+            , respectively. The
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M62.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations on the lepton fields and Higgs doublets are defined as [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>2</label>
+               <tex-math id="cpc_46_10_103101_E2">
+                  <?CDATA $ \begin{aligned}[b] & D_{\alpha {\rm L}}\to {\rm i}S_{ \alpha\beta}\gamma^0C\bar{D}_{\beta {\rm L}}^T,\quad \alpha_{\rm R}\to {\rm i}S_{ \alpha\beta}\gamma^0C\bar{\beta}_{\rm R}^T, \\ & S=\left(\begin{array}{ccc} 1 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & 1 & 0 \end{array} \right), \quad \phi_{1,2}\to\phi_{1,2}^*,\quad \phi_3\to -\phi_3^*. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E2.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <italic toggle="yes">C</italic>
+            is the charge conjugation matrix. In addition to the invariance under the above mentioned
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M63.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations, one needs to impose conservation of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M64.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M65.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetries. Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M66.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the lepton number symmetry for the individual family of leptons. Under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M67.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, only the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ e_{\rm R} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M68.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M69.jpg" xlink:type="simple" />
+            </inline-formula>
+            change sign. Considering the aforementioned charge assignments, the invariant Lagrangian for charged lepton Yukawa couplings is given by [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>3</label>
+               <tex-math id="cpc_46_10_103101_E3">
+                  <?CDATA $ \begin{equation} {\cal L}_{\rm Y} = -y_e\bar{D}_{e{\rm L}}\phi_1e_{\rm R}-\sum\limits_{j=2}^3\sum\limits_{\alpha=\mu,\tau} g_{j\alpha}\bar{D}_{\alpha {\rm L}}\phi_j\alpha_{\rm R} +{\rm h.c}.. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E3.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In order for the Lagrangian in Eq. (3) to be invariant under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M70.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, we should have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ y_e $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M71.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be real,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ g_{2\mu}=g_{2\tau}^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M72.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ g_{3\mu}=-g_{3\tau}^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M73.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Since the mass of electron should be real, we take the VEV of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M74.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be real. In contrast, the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M75.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be complex, which give masses to muon and tau leptons, whose forms are given below [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ].
+         </p>
+         <p>
+            <disp-formula>
+               <label>4</label>
+               <tex-math id="cpc_46_10_103101_E4">
+                  <?CDATA $ \begin{equation} m_\mu=|g_{2\mu}v_2+g_{3\mu}v_3|,\quad m_\tau=|g^*_{2\mu}v_2-g^*_{3\mu}v_3|. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E4.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In this work, we take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle\phi_i^0\rangle=v_i $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M76.jpg" xlink:type="simple" />
+            </inline-formula>
+            for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ i=1,2,3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M77.jpg" xlink:type="simple" />
+            </inline-formula>
+            . As an a priori assumption, the VEVs of all Higgs doublets are of the same order. Hence, from the above equations, we notice that some fine tuning is necessary in order to explain the hierarchy in the muon and tau lepton masses. To reduce this fine tuning,
+            <italic toggle="yes">K</italic>
+            symmetry is introduced, under which the non-trivial transformations of the fields are given below [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>5</label>
+               <tex-math id="cpc_46_10_103101_E5">
+                  <?CDATA $ \begin{equation} \mu_R\to -\mu_R,\quad \phi_2\leftrightarrow\phi_3. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E5.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            After imposing this
+            <italic toggle="yes">K</italic>
+            symmetry in the above model, one can see that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ g_{2\mu}=-g_{3\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M78.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Using this in Eq. (4), we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>6</label>
+               <tex-math id="cpc_46_10_103101_E6">
+                  <?CDATA $ \begin{equation} \frac{m_\mu}{m_\tau}=\left|\frac{v_2-v_3}{v_2+v_3}\right|. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E6.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Since the scalar potential of this model should also respect the
+            <italic toggle="yes">K</italic>
+            symmetry, we should get
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_2=v_3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M79.jpg" xlink:type="simple" />
+            </inline-formula>
+            , and hence,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M80.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, to explain a non-zero but small
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M81.jpg" xlink:type="simple" />
+            </inline-formula>
+            , soft breaking of
+            <italic toggle="yes">K</italic>
+            symmetry can be introduced into the scalar potential of this model [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ]. The analysis related to this is presented in the next section.
+         </p>
+         <p>To explain the masses for neutrinos in the above described framework, we introduce the following Higgs triplet into the model.</p>
+         <p>
+            <disp-formula>
+               <label>7</label>
+               <tex-math id="cpc_46_10_103101_E7">
+                  <?CDATA $ \begin{equation} \Delta=\left(\begin{array}{cc} \dfrac{\Delta^+}{\sqrt{2}} & \Delta^{++} \\ -\Delta^0 & -\dfrac{\Delta^+}{\sqrt{2}} \end{array}\right). \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E7.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Δ is singlet under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M82.jpg" xlink:type="simple" />
+            </inline-formula>
+            , but otherwise transform under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M83.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry as
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta\to\Delta^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M84.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, the Yukawa couplings for neutrinos can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <label>8</label>
+               <tex-math id="cpc_46_10_103101_E8">
+                  <?CDATA $ \begin{equation} {\cal L}_Y=\frac{1}{2}\sum\limits_{\alpha,\,\beta=e,\,\mu,\,\tau}Y^\nu_{\alpha\beta} \bar{D}^c_{\alpha {\rm L}}{\rm i}\sigma_2\Delta D_{\beta {\rm L}}+{\rm h.c}.. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E8.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{\alpha {\rm L}}^c $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M85.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the charge conjugated doublet for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{\alpha {\rm L}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M86.jpg" xlink:type="simple" />
+            </inline-formula>
+            , and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sigma_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M87.jpg" xlink:type="simple" />
+            </inline-formula>
+            is a Pauli matrix. We can notice that the terms in the above Lagrangian break the lepton number symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M88.jpg" xlink:type="simple" />
+            </inline-formula>
+            explicitly. This can be considered technically natural, since the neutrino masses become zero in this model in the limit that the symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M89.jpg" xlink:type="simple" />
+            </inline-formula>
+            is exact. Hence, to explain the smallness of neutrino masses, the symmetry of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M90.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be broken by small amounts. Therefore, here, the neutrino Yukawa couplings
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\alpha\beta} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M91.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be small. Due to the invariance under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M92.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, these Yukawa couplings should satisfy
+         </p>
+         <p>
+            <disp-formula>
+               <label>9</label>
+               <tex-math id="cpc_46_10_103101_E9">
+                  <?CDATA $ \begin{equation} SY^\nu S=(Y^\nu)^*. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E9.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            After electroweak symmetry breaking, we can have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle\Delta^0\rangle=v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M93.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, from Eq. (8), we get the mass matrix for neutrinos, which is given by
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu=Y^\nu v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M94.jpg" xlink:type="simple" />
+            </inline-formula>
+            . If
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M95.jpg" xlink:type="simple" />
+            </inline-formula>
+            is real, using Eq. (9), we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>10</label>
+               <tex-math id="cpc_46_10_103101_E10">
+                  <?CDATA $ \begin{equation} SM_\nu S=M_\nu^*. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E10.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In order to satisfy the above relation, the form for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M96.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be the same as in Eq. (1). Hence, in the above proposed model, the mixing angle
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M97.jpg" xlink:type="simple" />
+            </inline-formula>
+            and the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M98.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating phase
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M99.jpg" xlink:type="simple" />
+            </inline-formula>
+            are maximal. However, to satisfy the relation in Eq. (10),
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M100.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real. In the next section, we present an analysis of the scalar potential in our model, where we demonstrate that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M101.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be real.
+         </p>
+         <p>
+            Now, we estimate the value of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M102.jpg" xlink:type="simple" />
+            </inline-formula>
+            in our work. As stated above, the neutrino mass matrix is
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu=Y^\nu v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M103.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Since the couplings
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M104.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be small, because they break the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M105.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry by a small amount, we take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu\sim 10^{-3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M106.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, by fitting
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M107.jpg" xlink:type="simple" />
+            </inline-formula>
+            to neutrino masses, which are obtained from the neutrino oscillation data, an estimation of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M108.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be obtained. Using the neutrino oscillation data, the following mass-square differences have been found [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], where we have given the best fit values.
+         </p>
+         <p>
+            <disp-formula>
+               <label>11</label>
+               <tex-math id="cpc_46_10_103101_E11">
+                  <?CDATA $ \begin{aligned}[b] & m_s^2\equiv m_2^2-m_1^2=7.5\times10^{-5}\; {\rm eV}^2,\\ & m_a^2\equiv\left\{\begin{array}{c} m_3^2-m_1^2=2.55\times10^{-3}\; {\rm eV}^2\; \; {\rm (NO)}\\ m_1^2-m_3^2=2.45\times10^{-3}\; {\rm eV}^2\; \; {\rm (IO)} \end{array}\right.. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E11.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{1,2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M109.jpg" xlink:type="simple" />
+            </inline-formula>
+            are neutrino mass eigenvalues and NO(IO) represents normal (inverted) ordering. Using the above values, we get
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_s\sim0.0087 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M110.jpg" xlink:type="simple" />
+            </inline-formula>
+            eV and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_a\sim0.05 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M111.jpg" xlink:type="simple" />
+            </inline-formula>
+            eV, which correspond to solar and atmospheric neutrino mass scales, respectively. To fit these neutrino mass scales in our work, we can take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta\sim1-10 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M112.jpg" xlink:type="simple" />
+            </inline-formula>
+            eV.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s03">
+         <label>III.</label>
+         <title>ANALYSIS OF SCALAR POTENTIAL</title>
+         <p>
+            The scalar fields of the model proposed in the previous section are charged under the symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ C P\times Z_2\times K $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M113.jpg" xlink:type="simple" />
+            </inline-formula>
+            . The invariant scalar potential of this model can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <label>12</label>
+               <tex-math id="cpc_46_10_103101_E12">
+                  <?CDATA $ \begin{equation} V_{\rm inv}=V_D+V_T. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E12.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_D $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M114.jpg" xlink:type="simple" />
+            </inline-formula>
+            contains potential terms only for the Higgs doublets.
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M115.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the scalar potential for the triplet Higgs in our model. The form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_D $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M116.jpg" xlink:type="simple" />
+            </inline-formula>
+            is given by [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>13</label>
+               <tex-math id="cpc_46_10_103101_E13">
+                  <?CDATA $ \begin{aligned}[b] V_D= & -M_1^2\phi_1^\dagger\phi_1 -M_2^2(\phi_2^\dagger\phi_2+\phi_3^\dagger\phi_3) +\lambda_1(\phi_1^\dagger\phi_1)^2 \\ & +\lambda_2\left[(\phi_2^\dagger\phi_2)^2+(\phi_3^\dagger\phi_3)^2\right] \\ & +\lambda_3(\phi_1^\dagger\phi_1)(\phi_2^\dagger\phi_2+\phi_3^\dagger\phi_3) +\lambda_4(\phi_2^\dagger\phi_2)(\phi_3^\dagger\phi_3) \\ & +\lambda_5\left[(\phi_1^\dagger\phi_2)(\phi_2^\dagger\phi_1) +(\phi_1^\dagger\phi_3)(\phi_3^\dagger\phi_1)\right] \\ & +\lambda_6\left[(\phi_2^\dagger\phi_3)(\phi_3^\dagger\phi_2)\right] +\lambda_7\left[(\phi_2^\dagger\phi_3)^2+(\phi_3^\dagger\phi_2)^2\right] \\ & +\lambda_8\left[(\phi_1^\dagger\phi_2)^2+(\phi_1^\dagger\phi_3)^2 +(\phi_2^\dagger\phi_1)^2+(\phi_3^\dagger\phi_1)^2\right] \\ & +{\rm i}\lambda_9\left[(\phi_1^\dagger\phi_2)(\phi_1^\dagger\phi_3) -(\phi_2^\dagger\phi_1)(\phi_3^\dagger\phi_1)\right] \\ & +{\rm i}\lambda_{10}(\phi_2^\dagger\phi_3-\phi_3^\dagger\phi_2) (\phi_2^\dagger\phi_2-\phi_3^\dagger\phi_3). \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E13.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above equation, all parameters are real due to either hermiticity or
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M117.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry of the potential. To obtain
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M118.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we have followed the work in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib34">34</xref>
+            ]. The form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M119.jpg" xlink:type="simple" />
+            </inline-formula>
+            is given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>14</label>
+               <tex-math id="cpc_46_10_103101_E14">
+                  <?CDATA $ \begin{aligned}[b] V_T= & m_\Delta^2{\rm Tr}(\Delta^\dagger\Delta) +\frac{1}{2}\lambda_\Delta[{\rm Tr}(\Delta^\dagger\Delta)]^2 \\ & +\lambda_{11}\phi_1^\dagger\phi_1{\rm Tr}(\Delta^\dagger\Delta) +\lambda_{12}(\phi_2^\dagger\phi_2+\phi_3^\dagger\phi_3) {\rm Tr}(\Delta^\dagger\Delta) \\ & +\lambda_{13}{\rm Tr}(\Delta^\dagger\Delta^\dagger){\rm Tr}(\Delta\Delta) +\lambda_{14}\phi_1^\dagger\Delta^\dagger\Delta\phi_1 \\ & +\lambda_{15}(\phi_2^\dagger\Delta^\dagger\Delta\phi_2 +\phi_3^\dagger\Delta^\dagger\Delta\phi_3) \\ & +\kappa_1(\tilde{\phi}_1^T{\rm i}\sigma_2\Delta\tilde{\phi}_1+{\rm h.c}.) \\ & +\kappa_2(\tilde{\phi}_2^T{\rm i}\sigma_2\Delta\tilde{\phi}_2 +\tilde{\phi}_3^T{\rm i}\sigma_2\Delta\tilde{\phi}_3+{\rm h.c}.) \\ & +{\rm i}\kappa_3(\tilde{\phi}_2^T{\rm i}\sigma_2\Delta\tilde{\phi}_3-{\rm h.c}.) \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E14.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \tilde{\phi}_k={\rm i}\sigma_2\phi_k^*,\;k=1,2,3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M120.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Similarly, all parameters in the above equation are real, due to either hermiticity or
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M121.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry of the potential.
+         </p>
+         <p>
+            As described in the previous section, the VEV of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M122.jpg" xlink:type="simple" />
+            </inline-formula>
+            is real, whereas the VEVs for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M123.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be complex. Although all parameters in Eq. (14) are real, due to complex VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M124.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the trilinear terms containing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M125.jpg" xlink:type="simple" />
+            </inline-formula>
+            can contribute complex VEV to Δ. However, it may happen that the phases of the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M126.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be fine tuned in such a way that the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M127.jpg" xlink:type="simple" />
+            </inline-formula>
+            -terms can give a real VEV to Δ. We study these points by minimizing the scalar potential of our model. Nonetheless, we first have to estimate the order of magnitudes for the unknown parameters in Eqs. (13) and (14). From the naturalness argument, we take all dimensionless
+            <italic toggle="yes">λ</italic>
+            parameters to be
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {\cal O}(1) $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M128.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Since the VEVs of Higgs doublets should be around the electroweak scale of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_{\rm EW}= $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M129.jpg" xlink:type="simple" />
+            </inline-formula>
+            174 GeV, we take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_1^2,M_2^2\sim v_{\rm EW}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M130.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, we have to determine the order of magnitudes for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M131.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa_{1,2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M132.jpg" xlink:type="simple" />
+            </inline-formula>
+            . This is explained below. After minimizing the potential of Eq. (14) with respect to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M133.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>15</label>
+               <tex-math id="cpc_46_10_103101_E15">
+                  <?CDATA $ \begin{equation} v_\Delta\sim\frac{\kappa v_{\rm EW}^2}{m_\Delta^2+\lambda v_{\rm EW}^2}. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E15.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa\sim\kappa_{1,2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M134.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \lambda\sim\lambda_{11,12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M135.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In the above equation, we have used
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta\ll v_{\rm EW} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M136.jpg" xlink:type="simple" />
+            </inline-formula>
+            . To get a very small
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M137.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we can consider the following two cases.
+         </p>
+         <p>
+            <disp-formula>
+               <label>16</label>
+               <tex-math id="cpc_46_10_103101_E16">
+                  <?CDATA $ \begin{aligned}[b] & {\rm case\; I}:\quad m_\Delta\gg v_{\rm EW},\quad \kappa\sim m_\Delta. \\ & {\rm case\; II}:\quad m_\Delta\sim v_{\rm EW},\quad \kappa\sim v_\Delta. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E16.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In case I, the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M138.jpg" xlink:type="simple" />
+            </inline-formula>
+            is explained by considering a large value for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M139.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 10^{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M140.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV. In case II, by suppressing the
+            <italic toggle="yes">κ</italic>
+            parameters, one can understand the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M141.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In case I, the value of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M142.jpg" xlink:type="simple" />
+            </inline-formula>
+            is close to the breaking scale of supersymmetry in supergravity models [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib35">35</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib36">36</xref>
+            ]. Hence, one can motivate case I from supersymmetry. In contrast, in case II, one has to find a mechanism for the suppression of
+            <italic toggle="yes">κ</italic>
+            parameters. From the phenomenology point of view, case II can be tested in the LHC experiment, since the masses for the components of scalar triplet Higgs can be around few 100 GeV.
+         </p>
+         <p>
+            In case I, we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_D\rangle\sim\langle V_T\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M143.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Only the terms containing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M144.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <italic toggle="yes">κ</italic>
+            parameters in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_T\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M145.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be of the same order as
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_D\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M146.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Other terms in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_T\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M147.jpg" xlink:type="simple" />
+            </inline-formula>
+            give negligibly small contribution in comparison to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_D\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M148.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In contrast, in case II,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_T\rangle\ll\langle V_D\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M149.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Because of this difference in the contribution of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M150.jpg" xlink:type="simple" />
+            </inline-formula>
+            in both these cases, we minimize the scalar potential of our model separately for these two cases.
+         </p>
+         <sec id="cpc_46_10_103101_s03-01">
+            <label>A.</label>
+            <title>Case I</title>
+            <p>We parametrize the VEVs of scalar fields as follows.</p>
+            <p>
+               <disp-formula>
+                  <label>17</label>
+                  <tex-math id="cpc_46_10_103101_E17">
+                     <?CDATA $ \begin{aligned}[b] & \langle\phi_1^0\rangle=v_1,\quad \langle\phi_2^0\rangle=v_2=v\cos\sigma {\rm e}^{{\rm i}\alpha},\\ & \langle\phi_3^0\rangle=v_3=v\sin\sigma {\rm e}^{{\rm i}\beta},\quad \langle\Delta^0\rangle=v_\Delta=v^\prime {\rm e}^{{\rm i}\theta}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E17.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_1,\;v,\;v^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M151.jpg" xlink:type="simple" />
+               </inline-formula>
+               are real. We plug the above parametrizations in the scalar potential of Eq. (12). Since we want
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle\Delta^0\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M152.jpg" xlink:type="simple" />
+               </inline-formula>
+               to be real, and moreover,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M153.jpg" xlink:type="simple" />
+               </inline-formula>
+               respect
+               <italic toggle="yes">K</italic>
+               symmetry, we look for a minimum at
+            </p>
+            <p>
+               <disp-formula>
+                  <label>18</label>
+                  <tex-math id="cpc_46_10_103101_E18">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4},\quad\alpha=\beta=\omega,\quad\theta=0. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E18.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Now, we take first derivatives of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M154.jpg" xlink:type="simple" />
+               </inline-formula>
+               with respect to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta,\;\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M155.jpg" xlink:type="simple" />
+               </inline-formula>
+               at the values mentioned in Eq. (18). Thereafter, we get the following two conditions.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>19</label>
+                  <tex-math id="cpc_46_10_103101_E19">
+                     <?CDATA $ \begin{array}{*{20}{l}} & & 2\lambda_8\sin2\omega+\lambda_9\cos2\omega=0, \end{array} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E19.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>20</label>
+                  <tex-math id="cpc_46_10_103101_E20">
+                     <?CDATA $ \begin{array}{*{20}{l}} & & 2\kappa_2\sin2\omega=\kappa_3\cos2\omega. \end{array} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E20.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               By satisfying the above two conditions, Eq. (18) gives a minimum to our scalar potential. We justify that this a minimum, after computing the second derivatives of the potential. This analysis is presented shortly later. However, with the minimum of Eq. (18), we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_2=v_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M156.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Hence,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M157.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which follows from Eq. (6). To get non-zero and small
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M158.jpg" xlink:type="simple" />
+               </inline-formula>
+               , one should add
+               <italic toggle="yes">K</italic>
+               -violating terms in our model, which break the
+               <italic toggle="yes">K</italic>
+               symmetry explicitly by a small amount. Here, we can see the analogy between
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U_{L_\alpha} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M159.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <italic toggle="yes">K</italic>
+               symmetries of our model. Both of these symmetries are broken explicitly by a small amount in order to generate small masses for neutrinos and muon.
+            </p>
+            <p>
+               After including the
+               <italic toggle="yes">K</italic>
+               -violating terms, the procedure we follow for minimization of the scalar potential is similar to that in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ]. However, in this work, we write a more general form for
+               <italic toggle="yes">K</italic>
+               -violating terms as compared to that in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ]. In Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], only the soft terms, which break the
+               <italic toggle="yes">K</italic>
+               symmetry, are considered. The general form for
+               <italic toggle="yes">K</italic>
+               -violating terms in our model, which respects the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ CP\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M160.jpg" xlink:type="simple" />
+               </inline-formula>
+               , is given by
+            </p>
+            <p>
+               <disp-formula>
+                  <label>21</label>
+                  <tex-math id="cpc_46_10_103101_E21">
+                     <?CDATA $ \begin{aligned}[b]V_{\not{K}}= & {\rm i}\delta M_s^2(\phi_2^\dagger\phi_3-\phi_3^\dagger\phi_2) +\delta M_2^2\phi_2^\dagger\phi_2+\delta M_3^2\phi_3^\dagger\phi_3 \\ & +\delta\kappa_2(\tilde{\phi}_2^T{\rm i}\sigma_2\Delta\tilde{\phi}_2+{\rm h.c}.) +\delta\kappa_2^\prime(\tilde{\phi}_3^T{\rm i}\sigma_2\Delta\tilde{\phi}_3+{\rm h.c}.) \\ & +\delta\lambda_2(\phi_2^\dagger\phi_2)^2 +\delta\lambda_2^\prime(\phi_3^\dagger\phi_3)^2 +\delta\lambda_3(\phi_1^\dagger\phi_1)(\phi_2^\dagger\phi_2) \\ & +\delta\lambda_3^\prime(\phi_1^\dagger\phi_1)(\phi_3^\dagger\phi_3) \\ & +\delta\lambda_5(\phi_1^\dagger\phi_2)(\phi_2^\dagger\phi_1) +\delta\lambda_5^\prime(\phi_1^\dagger\phi_3)(\phi_3^\dagger\phi_1) \\ & +\delta\lambda_8\left[(\phi_1^\dagger\phi_2)^2+(\phi_2^\dagger\phi_1)^2\right] +\delta\lambda_8^\prime\left[(\phi_1^\dagger\phi_3)^2 +(\phi_3^\dagger\phi_1)^2\right] \\ & +{\rm i}\delta\lambda_{10}(\phi_2^\dagger\phi_2)(\phi_2^\dagger\phi_3 -\phi_3^\dagger\phi_2) \\ & +{\rm i}\delta\lambda_{10}^\prime(\phi_3^\dagger\phi_3)(\phi_2^\dagger\phi_3 -\phi_3^\dagger\phi_2) \\ & +{\rm i}\delta\lambda_s(\phi_1^\dagger\phi_1)(\phi_2^\dagger\phi_3 -\phi_3^\dagger\phi_2) \\ & +{\rm i}\delta\lambda_s^\prime\left[(\phi_1^\dagger\phi_2)(\phi_3^\dagger\phi_1) -(\phi_2^\dagger\phi_1)(\phi_1^\dagger\phi_3)\right] \\ & +\delta\lambda_{12}\phi_2^\dagger\phi_2{\rm Tr}(\Delta^\dagger\Delta) +\delta\lambda_{12}^\prime\phi_3^\dagger\phi_3{\rm Tr}(\Delta^\dagger\Delta) \\ & +\delta\lambda_{15}\phi_2^\dagger\Delta^\dagger\Delta\phi_2 +\delta\lambda_{15}^\prime\phi_3^\dagger\Delta^\dagger\Delta\phi_3 \\ & +{\rm i}\delta\lambda_t(\phi_2^\dagger\phi_3-\phi_3^\dagger\phi_2) {\rm Tr}(\Delta^\dagger\Delta) \\ & +{\rm i}\delta\lambda_t^\prime(\phi_2^\dagger\Delta^\dagger\Delta\phi_3 -\phi_3^\dagger\Delta^\dagger\Delta\phi_2). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E21.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               All parameters in the above equation are real, due to either hermiticity or
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M161.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry of the potential. Terms in the first and second lines are quadratic and trilinear, respectively. Rest of the terms in the above equation are quartic.
+            </p>
+            <p>
+               In Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], only the soft terms which are quadratic are given. Moreover, the last two terms in the first line of Eq. (21) are given in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], but by taking
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta M_2^2=-\delta M_3^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M162.jpg" xlink:type="simple" />
+               </inline-formula>
+               . We notice that if
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta M_2^2 =\delta M_3^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M163.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the sum of the corresponding terms in Eq. (21) is
+               <italic toggle="yes">K</italic>
+               -symmetric. Hence, as long as
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta M_2^2\neq\delta M_3^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M164.jpg" xlink:type="simple" />
+               </inline-formula>
+               , each of these corresponding terms in Eq. (21) is
+               <italic toggle="yes">K</italic>
+               -violating but conserving
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times Z_2$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M165.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Based on this observation, we have constructed other
+               <italic toggle="yes">K</italic>
+               -violating terms in Eq. (21). Since the terms in Eq. (21) break
+               <italic toggle="yes">K</italic>
+               symmetry by a small amount, their corresponding parameters should be small compared to the corresponding parameters of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M166.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               After including the
+               <italic toggle="yes">K</italic>
+               -violating terms, the total scalar potential of our model is
+            </p>
+            <p>
+               <disp-formula>
+                  <label>22</label>
+                  <tex-math id="cpc_46_10_103101_E22">
+                     <?CDATA $ \begin{equation} V_{\rm total}=V_{\rm inv}+V_{\not{K}}. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E22.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Previously, we minimized
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M167.jpg" xlink:type="simple" />
+               </inline-formula>
+               and argued that the minimum can be at Eq. (18). Now, due to the presence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M168.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the above minimum can be shifted by a small amount. Consequently, the minimum for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M169.jpg" xlink:type="simple" />
+               </inline-formula>
+               in terms of small deviations
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\delta_+,\delta_-,\delta_\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M170.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be written as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>23</label>
+                  <tex-math id="cpc_46_10_103101_E23">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4}-\frac{\delta_0}{2},\quad \alpha=\omega+\delta_++\frac{\delta_-}{2},\quad \beta=\omega+\delta_+-\frac{\delta_-}{2},\quad \theta=0+\delta_\theta. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E23.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Now, we express
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle V_{\rm inv}\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M171.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle V_{\not{K}}\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M172.jpg" xlink:type="simple" />
+               </inline-formula>
+               as a series summation up to second and first order, respectively, in the aforementioned small deviations. After neglecting the constant terms, we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>24</label>
+                  <tex-math id="cpc_46_10_103101_E24">
+                     <?CDATA $ \begin{equation} \langle V_{\rm total}\rangle=\frac{1}{2}\sum\limits_{a,b}{\cal F}_{ab}\delta_a\delta_b +\sum\limits_{a}f_a\delta_a. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E24.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M173.jpg" xlink:type="simple" />
+               </inline-formula>
+               is symmetric in the indices
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ a,b $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M174.jpg" xlink:type="simple" />
+               </inline-formula>
+               , corresponding to  the second derivatives of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M175.jpg" xlink:type="simple" />
+               </inline-formula>
+               calculated in Eq. (18). Non-vanishing elements of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M176.jpg" xlink:type="simple" />
+               </inline-formula>
+               are given below.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>25</label>
+                  <tex-math id="cpc_46_10_103101_E25">
+                     <?CDATA $ \begin{aligned}[b]{\cal F}_{++}= & (-8\lambda_8\cos2\omega+4\lambda_9\sin2\omega)v_1^2v^2 \\ & +(8\kappa_2\cos2\omega+4\kappa_3\sin2\omega)v^2v^\prime, \\ {\cal F}_{–}= & -2\lambda_7v^4-2\lambda_8v_1^2v^2\cos2\omega +2\kappa_2v^2v^\prime\cos2\omega, \\ {\cal F}_{00}= & -\frac{1}{2}\tilde{\lambda}v^4 +(\lambda_9v_1^2+\kappa_3v^\prime)v^2\sin2\omega, \\ {\cal F}_{\theta\theta}= & 2\kappa_1v_1^2v^\prime+2\kappa_2v^2v^\prime \cos2\omega+\kappa_3v^2v^\prime\sin2\omega, \\ {\cal F}_{0-}= & -2\lambda_8v_1^2v^2\sin2\omega+\lambda_{10}v^4 +2\kappa_2v^2v^\prime\sin2\omega, \\ {\cal F}_{+\theta}= & -2(2\kappa_2\cos2\omega+\kappa_3\sin2\omega)v^2v^\prime. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E25.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \tilde{\lambda}=-2\lambda_2+\lambda_4+\lambda_6+2\lambda_7 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M177.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The expressions for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_a $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M178.jpg" xlink:type="simple" />
+               </inline-formula>
+               are given below.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>26</label>
+                  <tex-math id="cpc_46_10_103101_E26">
+                     <?CDATA $ \begin{aligned}[b] f_0= & \frac{1}{2}(\delta M_2^2-\delta M_3^2)v^2 -(\delta\kappa_2-\delta\kappa_2^\prime)v^2v^\prime\cos2\omega \\ & +\frac{1}{2}(\delta\lambda_2-\delta\lambda_2^\prime)v^4 +\frac{1}{2}[\delta\lambda_3-\delta\lambda_3^\prime +\delta\lambda_5\\ & -\delta\lambda_5^\prime +2(\delta\lambda_8-\delta\lambda_8^\prime)\cos2\omega](v_1v)^2 \\ & +\frac{1}{2}(\delta\lambda_{12}-\delta\lambda_{12}^\prime)(vv^\prime)^2, \\f_-= & \delta M_s^2v^2+(\delta\kappa_2-\delta\kappa_2^\prime) v^2v^\prime\sin2\omega \\ & -(\delta\lambda_8-\delta\lambda_8^\prime)\sin2\omega(v_1v)^2 +\frac{1}{2}(\delta\lambda_{10}+\delta\lambda_{10}^\prime)v^4 \\ & +(\delta\lambda_s-\delta\lambda_s^\prime)(v_1v)^2 +\delta\lambda_t(vv^\prime)^2, \\ f_+= & 2(\delta\kappa_2+\delta\kappa_2^\prime)v^2v^\prime\sin2\omega -2(\delta\lambda_8+\delta\lambda_8^\prime)\sin2\omega(v_1v)^2, \\ f_\theta= & -(\delta\kappa_2+\delta\kappa_2^\prime)v^2v^\prime\sin2\omega. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E26.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Using Eq. (24), the small deviations in the minimum of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M179.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be obtained as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>27</label>
+                  <tex-math id="cpc_46_10_103101_E27">
+                     <?CDATA $ \begin{equation} \delta=-{\cal F}^{-1}f. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E27.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta=(\delta_0,\delta_-,\delta_+,\delta_\theta)^T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M180.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f=(f_0,f_-,f_+,f_\theta)^T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M181.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M182.jpg" xlink:type="simple" />
+               </inline-formula>
+               is a matrix containing the elements
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M183.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               Since some elements of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M184.jpg" xlink:type="simple" />
+               </inline-formula>
+               are zero, Eq. (27) can be decomposed into
+            </p>
+            <p>
+               <disp-formula>
+                  <label>28</label>
+                  <tex-math id="cpc_46_10_103101_E28">
+                     <?CDATA $ \begin{aligned}[b] & \left(\begin{array}{c}\delta_0 \\ \delta_-\end{array}\right) =-{\cal F}_1^{-1}\left(\begin{array}{c}f_0 \\ f_-\end{array}\right),\quad {\cal F}_1=\left(\begin{array}{cc} {\cal F}_{00} & {\cal F}_{0-} \\ {\cal F}_{0-} & {\cal F}_{–} \end{array}\right), \\ & \left(\begin{array}{c}\delta_+ \\ \delta_\theta\end{array}\right) =-{\cal F}_2^{-1}\left(\begin{array}{c}f_+ \\ f_\theta\end{array}\right),\quad {\cal F}_2=\left(\begin{array}{cc} {\cal F}_{++} & {\cal F}_{+\theta} \\ {\cal F}_{+\theta} & {\cal F}_{\theta\theta}\end{array}\right). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E28.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               We can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M185.jpg" xlink:type="simple" />
+               </inline-formula>
+               is in block diagonal form containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M186.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M187.jpg" xlink:type="simple" />
+               </inline-formula>
+               . As stated earlier, the elements of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M188.jpg" xlink:type="simple" />
+               </inline-formula>
+               correspond to second derivatives of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $V_{\rm inv}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M189.jpg" xlink:type="simple" />
+               </inline-formula>
+               calculated in Eq. (18). It follows that, if the eigenvalues of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M190.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M191.jpg" xlink:type="simple" />
+               </inline-formula>
+               are positive, then Eq. (18) gives minimum to the scalar potential in the absence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M192.jpg" xlink:type="simple" />
+               </inline-formula>
+               . One can see that the unknown
+               <italic toggle="yes">λ</italic>
+               and
+               <italic toggle="yes">κ</italic>
+               parameters of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{1,2} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M193.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be chosen in such a way that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{1,2} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M194.jpg" xlink:type="simple" />
+               </inline-formula>
+               yields positive eigenvalues. However, in the presence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M195.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the minimum of the scalar potential in our model is shifted to Eq. (23). The small deviations of Eq. (23) can be computed from Eq. (28), from which we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_-,\delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M196.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Hence,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_2\neq v_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M197.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Using the expressions for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_-,\delta_+ $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M198.jpg" xlink:type="simple" />
+               </inline-formula>
+               in Eq. (6), we can get the required hierarchy between
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M199.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\tau $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M200.jpg" xlink:type="simple" />
+               </inline-formula>
+               , provided the parameters of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M201.jpg" xlink:type="simple" />
+               </inline-formula>
+               are small. It can be noticed that the parametrizations used in Eq. (23) are similar to those in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], in whichit has been pointed out that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_+=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M202.jpg" xlink:type="simple" />
+               </inline-formula>
+               . In our work, we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M203.jpg" xlink:type="simple" />
+               </inline-formula>
+               , since
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M204.jpg" xlink:type="simple" />
+               </inline-formula>
+               . This difference is due to the fact that in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ],
+               <italic toggle="yes">K</italic>
+               -violating quartic terms are not considered.
+            </p>
+            <p>
+               We have described that using the
+               <italic toggle="yes">K</italic>
+               -violating terms of our model, we can explain the required hierarchy between muon and tau lepton masses. However, in doing so, from Eq. (28) we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_\theta\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M205.jpg" xlink:type="simple" />
+               </inline-formula>
+               , makes
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M206.jpg" xlink:type="simple" />
+               </inline-formula>
+               complex. One can fine tune the parameters in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_2,f_+, f_\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M207.jpg" xlink:type="simple" />
+               </inline-formula>
+               in such a way that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_\theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M208.jpg" xlink:type="simple" />
+               </inline-formula>
+               . In contrast, to get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_\theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M209.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we can take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{+\theta}=0=f_\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M210.jpg" xlink:type="simple" />
+               </inline-formula>
+               . After using Eq. (20),
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{+\theta}=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M211.jpg" xlink:type="simple" />
+               </inline-formula>
+               implies that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \kappa_2=\kappa_3=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M212.jpg" xlink:type="simple" />
+               </inline-formula>
+               . To make
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_\theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M213.jpg" xlink:type="simple" />
+               </inline-formula>
+               , either we can take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta\kappa_2=-\delta\kappa_2^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M214.jpg" xlink:type="simple" />
+               </inline-formula>
+               or forbid the trilinear terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M215.jpg" xlink:type="simple" />
+               </inline-formula>
+               . From the above observations,  to make
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M216.jpg" xlink:type="simple" />
+               </inline-formula>
+               real in case I, without fine tuning the parameters, the trilinear terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M217.jpg" xlink:type="simple" />
+               </inline-formula>
+               containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M218.jpg" xlink:type="simple" />
+               </inline-formula>
+               should be forbidden.
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103101_s03-02">
+            <label>B.</label>
+            <title>Case II</title>
+            <p>
+               As explained before, in this case, terms involving triplet Higgs give very small contribution in comparison to that involving only doublet Higgses. As a result, the minimization of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M219.jpg" xlink:type="simple" />
+               </inline-formula>
+               in this case proceeds in two steps. First, we minimize
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M220.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which contains only doublet Higgses and thereby determine the VEVs of these fields. Later, after using the VEVs of doublet Higgses, we minimize the potential containing the triplet Higgs field. In the first step of minimization, we can neglect
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M221.jpg" xlink:type="simple" />
+               </inline-formula>
+               in comparison to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_D $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M222.jpg" xlink:type="simple" />
+               </inline-formula>
+               and the terms in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M223.jpg" xlink:type="simple" />
+               </inline-formula>
+               containing the triplet Higgs field. In this case, we parametrize the VEVs for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{1,2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M224.jpg" xlink:type="simple" />
+               </inline-formula>
+               and Δ as given in Eq. (17). After minimizing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_D $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M225.jpg" xlink:type="simple" />
+               </inline-formula>
+               with respect to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\alpha,\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M226.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the minimum is given by Eq. (18) with the condition of Eq. (19). Since this minimum gives
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M227.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we introduce
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M228.jpg" xlink:type="simple" />
+               </inline-formula>
+               and parametrize the deviations in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\alpha,\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M229.jpg" xlink:type="simple" />
+               </inline-formula>
+               , as given by Eq. (23). Consequently, one can notice that the above mentioned deviations can be found from Eq. (27), where, in this case,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M230.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <italic toggle="yes">f</italic>
+               are 3
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \times $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M231.jpg" xlink:type="simple" />
+               </inline-formula>
+               3 and 3
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \times $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M232.jpg" xlink:type="simple" />
+               </inline-formula>
+               1 matrices, respectively. The components of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M233.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <italic toggle="yes">f</italic>
+               can be found from Eqs. (25) and (26), where the terms containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M234.jpg" xlink:type="simple" />
+               </inline-formula>
+               should be omitted, leading to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_-,\delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M235.jpg" xlink:type="simple" />
+               </inline-formula>
+               . After using this in Eq. (6), we get small and non-zero
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M236.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               Since the VEVs of doublet Higgses are determined, we now minimize
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M237.jpg" xlink:type="simple" />
+               </inline-formula>
+               and try to see if
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M238.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be real. After using Eq. (17) in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M239.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>29</label>
+                  <tex-math id="cpc_46_10_103101_E29">
+                     <?CDATA $ \begin{aligned}[b] \langle V_T\rangle= & (m_\Delta^2+\lambda_{11}v_1^2+\lambda_{12}v^2)v^{\prime^2} +\frac{1}{2}\lambda_\Delta v^{\prime^4}-2\kappa_1v_1^2v^\prime\cos\theta \\ & -2\kappa_2v^2v^\prime[\cos^2\sigma\cos(\theta-2\alpha) +\sin^2\sigma\cos(\theta-2\beta)] \\ & +\kappa_3v^2v^\prime\sin2\sigma\sin(\theta-\alpha-\beta). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E29.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since we are looking for a minimum at
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M240.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we do
+            </p>
+            <p>
+               <disp-formula>
+                  <label>30</label>
+                  <tex-math id="cpc_46_10_103101_E30">
+                     <?CDATA $ \begin{aligned}[b] \left.\frac{\partial\langle V_T\rangle}{\partial\theta}\right|_{\theta=0}= & 0 \Rightarrow -2\kappa_2[\cos^2\sigma\sin2\alpha+\sin^2\sigma\sin2\beta] \\ & +\kappa_3\sin2\sigma\cos(\alpha+\beta)=0. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E30.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               As stated earlier, we have determined
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M241.jpg" xlink:type="simple" />
+               </inline-formula>
+               up to the first order in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_-,\;\delta_+ $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M242.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Plugging the parametrizations for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M243.jpg" xlink:type="simple" />
+               </inline-formula>
+               in the above equation and expanding the terms up to the first order in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\delta_-,\delta_+ $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M244.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>31</label>
+                  <tex-math id="cpc_46_10_103101_E31">
+                     <?CDATA $ \begin{equation} 2\kappa_2\sin2\omega-\kappa_3\cos2\omega +2(2\kappa_2\cos2\omega+\kappa_3\sin2\omega)\delta_+=0. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E31.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since we have
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M245.jpg" xlink:type="simple" />
+               </inline-formula>
+               , after equating the leading and subleading terms of the above equation to zero, we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \kappa_2=\kappa_3=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M246.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Hence, in case II, one has to forbid the trilinear terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M248.jpg" xlink:type="simple" />
+               </inline-formula>
+               containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M249.jpg" xlink:type="simple" />
+               </inline-formula>
+               to make
+               <italic toggle="yes">v</italic>
+               <sub>Δ</sub>
+               real.
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103101_s03-03">
+            <label>C.</label>
+            <title>
+               Imposing an extra
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA ${\boldsymbol Z}_{\bf 3}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M250.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry
+            </title>
+            <p>
+               From the analysis of the previous two subsections, we have seen that the trilinear terms in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M251.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which contain
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M252.jpg" xlink:type="simple" />
+               </inline-formula>
+               , should be forbidden in order to make
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M253.jpg" xlink:type="simple" />
+               </inline-formula>
+               real. To achieve this, we impose the discrete symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M254.jpg" xlink:type="simple" />
+               </inline-formula>
+               in our model. Under this symmetry, the non-trivial transformations are as follows.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>32</label>
+                  <tex-math id="cpc_46_10_103101_E32">
+                     <?CDATA $ \begin{aligned}[b] & \phi_2\to\Omega\phi_2,\quad\phi_3\to\Omega\phi_3, \\ & \mu_{\rm R}\to\Omega^2\mu_{\rm R},\quad\tau_{\rm R}\to\Omega^2\tau_{\rm R}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E32.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \Omega={\rm e}^{2\pi {\rm i}/3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M255.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Under the above transformations, the Yukawa couplings for leptons are invariant, whereas the following couplings in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M256.jpg" xlink:type="simple" />
+               </inline-formula>
+               are forbidden:
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \lambda_{8,9},\;\kappa_{2,3}, \delta\kappa,\;\delta\kappa^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M257.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Now, after using the parametrizations of Eq. (17) in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M258.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>33</label>
+                  <tex-math id="cpc_46_10_103101_E33">
+                     <?CDATA $ \begin{aligned}[b] \langle V_{\rm inv}\rangle= & \frac{1}{4}[\tilde{\lambda}-4\lambda_7\sin^2\zeta]v^4 \sin^22\sigma\\ & +\frac{1}{2}\lambda_{10}v^4\sin4\sigma\sin\zeta -2\kappa_1v_1^2v^\prime\cos\theta. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E33.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \zeta=\alpha-\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M259.jpg" xlink:type="simple" />
+               </inline-formula>
+               . In the above equation, we have neglected constant terms which do not depend on
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta,\;\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M260.jpg" xlink:type="simple" />
+               </inline-formula>
+               . We can notice from the above equation that
+               <italic toggle="yes">θ</italic>
+               do not mix with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\zeta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M261.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Moreover, due to the absence of trilinear terms in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M262.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle V_{\not{K}}\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M263.jpg" xlink:type="simple" />
+               </inline-formula>
+               do not depend on
+               <italic toggle="yes">θ</italic>
+               . As a result, we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M264.jpg" xlink:type="simple" />
+               </inline-formula>
+               is a minimum to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M265.jpg" xlink:type="simple" />
+               </inline-formula>
+               if
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \kappa_1v^\prime \gt 0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M266.jpg" xlink:type="simple" />
+               </inline-formula>
+               . This statement is true for both cases I and II. Hence, after imposing the above mentioned
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M267.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M268.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be real in our model.
+            </p>
+            <p>
+               For Eq. (33), the minimum in terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\zeta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M269.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be at
+            </p>
+            <p>
+               <disp-formula>
+                  <label>34</label>
+                  <tex-math id="cpc_46_10_103101_E34">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4},\quad\zeta=0. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E34.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \zeta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M270.jpg" xlink:type="simple" />
+               </inline-formula>
+               corresponds to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M271.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we introduce
+               <italic toggle="yes">K</italic>
+               -violating terms into the model. Consequently, the above mentioned minimum can be shifted by small deviations
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_\zeta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M272.jpg" xlink:type="simple" />
+               </inline-formula>
+               as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>35</label>
+                  <tex-math id="cpc_46_10_103101_E35">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4}-\frac{\delta_0}{2},\quad\zeta=0+\delta_\zeta. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E35.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Now, after imposing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M273.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry in Eq. (21) and after following the procedure for minimizing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M274.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which is described in Sec. III.A, we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>36</label>
+                  <tex-math id="cpc_46_10_103101_E36">
+                     <?CDATA $ \begin{aligned}[b] \left(\begin{array}{c} \delta_0\\\delta_\zeta \end{array}\right) = & {\cal F}^{-1}\left(\begin{array}{c} f_0\\f_\zeta \end{array}\right),\quad {\cal F}=\left(\begin{array}{cc} -\frac{1}{2}\tilde{\lambda} & \lambda_{10}\\\lambda_{10} & -2\lambda_7 \end{array}\right)v^4, \\ f_0= & \frac{1}{2}(\delta M_2^2-\delta M_3^2)v^2 +\frac{1}{2}(\delta\lambda_2-\delta\lambda_2^\prime)v^4 \\ & +\frac{1}{2}(\delta\lambda_3 -\delta\lambda_3^\prime+\delta\lambda_5-\delta\lambda_5^\prime)(v_1v)^2 \\ & +\frac{1}{2}(\delta\lambda_{12}-\delta\lambda_{12}^\prime)(vv^\prime)^2, \\ f_\zeta= & \delta M_s^2v^2 +\frac{1}{2}(\delta\lambda_{10}+\delta\lambda_{10}^\prime)v^4 \\ & +(\delta\lambda_s-\delta\lambda_s^\prime)(v_1v)^2 +\delta_t(vv^\prime)^2. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E36.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               We can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_\zeta\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M275.jpg" xlink:type="simple" />
+               </inline-formula>
+               . After using these in the parametrizations for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M276.jpg" xlink:type="simple" />
+               </inline-formula>
+               , from Eq. (6), we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>37</label>
+                  <tex-math id="cpc_46_10_103101_E37">
+                     <?CDATA $ \begin{equation} \frac{m_\mu}{m_\tau}=\frac{1}{2}\big|\delta_0+{\rm i}\delta_\zeta\big|. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E37.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Using the above equation, the required hierarchy between muon and tau leptons can be explained if we take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_\zeta\sim0.1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M277.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               In Sec. II, we have described our model for lepton sector by introducing additional fields and symmetries. In the current section, we have introduced one more symmetry,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M278.jpg" xlink:type="simple" />
+               </inline-formula>
+               , in order to make the triplet Higgs VEV real. In
+               <xref ref-type="table" rid="cpc_46_10_103101_t1">Table 1</xref>
+               we summarize the additional fields and symmetries, which are needed for our model, in the lepton sector.
+            </p>
+            <table-wrap id="cpc_46_10_103101_t1" orientation="portrait" position="float">
+               <label>Table 1</label>
+               <caption id="cpc_46_10_103101_tc1">
+                  <p>Additional fields and symmetries, which are introduced in the lepton sector of our model. The roles of these fields and symmetries are also described here.</p>
+               </caption>
+               <table>
+                  <thead>
+                     <tr>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Additional field</th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Role</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \phi_1 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M279.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate the mass of electron</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \phi_2 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M280.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           ,
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \phi_3 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M281.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           to generate masses for
+                           <italic toggle="yes">μ</italic>
+                           and
+                           <italic toggle="yes">τ</italic>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Δ</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate masses for neutrinos</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Additional symmetry</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Role</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $CP$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M282.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           symmetry
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           to get
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $\mu-\tau$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M283.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           form for neutrino mass matrix
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $Z_2$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M284.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           forbids unwanted Yukawa couplings among
+                           <break />
+                           charged leptons
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $U(1)_{L_\alpha}$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M285.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to get diagonal masses for charged leptons</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <italic toggle="yes">K</italic>
+                           symmetry
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to reduce the fine-tuning in muon and tau masses</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $Z_3$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M286.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to make the VEV of Δ to be real</td>
+                     </tr>
+                  </tbody>
+               </table>
+            </table-wrap>
+         </sec>
+      </sec>
+      <sec id="cpc_46_10_103101_s04">
+         <label>IV.</label>
+         <title>
+            NEUTRINO MASS ORDERING AND THE SMALLNESS OF
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {\boldsymbol \theta}_{\bf 13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M287.jpg" xlink:type="simple" />
+            </inline-formula>
+         </title>
+         <p>
+            After showing that the triplet Higgs can acquire real VEV, the neutrino mass matrix of the model proposed in Sec. II satisfy Eq. (10). As a result, after diagonalizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M288.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M289.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M290.jpg" xlink:type="simple" />
+            </inline-formula>
+            would be maximal [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. However, the form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M291.jpg" xlink:type="simple" />
+            </inline-formula>
+            does not give predictions about
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{12},\theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M292.jpg" xlink:type="simple" />
+            </inline-formula>
+            or neutrino mass ordering. In this section, we carry out an analysis and provide a procedure, which can give predictions about neutrino mass ordering and the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M293.jpg" xlink:type="simple" />
+            </inline-formula>
+            in our model.
+         </p>
+         <p>
+            In the model proposed in Sec. II, the charged lepton masses are in diagonal form. Hence, the unitary matrix which diagonalizes
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M294.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <label>38</label>
+               <tex-math id="cpc_46_10_103101_E38">
+                  <?CDATA $ \begin{array}{*{20}{l}}\\ & & U=\tilde{U}U_{\rm PMNS},\quad \tilde{U}={\rm diag}(1,1,-1), \\ & & U_{\rm PMNS} = \left(\begin{array}{ccc} c_{12}c_{13} & s_{12}c_{13} & s_{13}{\rm e}^{-{\rm i}\delta_{CP}} \\ -s_{12}c_{23}-c_{12}s_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & c_{12}c_{23}-s_{12}s_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & s_{23}c_{13} \\ s_{12}s_{23}-c_{12}c_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & -c_{12}s_{23}-s_{12}c_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & c_{23}c_{13} \end{array}\right). \\ \end{array} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E38.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ c_{ij}=\cos\theta_{ij} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M295.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{ij}=\sin\theta_{ij} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M296.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M297.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the Pontecorvo-Maki-Nakagawa-Sakata (PMNS) matrix, which is parameterized in terms of the three lepton mixing angles and the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M298.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating Dirac phase, according to the convention of PDG [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ]. Diagonal elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \tilde{U} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M299.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be absorbed into the charged lepton fields. Now, the relation for diagonalizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M300.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be expressed as
+         </p>
+         <p>
+            <disp-formula>
+               <label>39</label>
+               <tex-math id="cpc_46_10_103101_E39">
+                  <?CDATA $ \begin{equation} M_\nu=U^*{\rm diag}(m_1,m_2,m_3)U^\dagger. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E39.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            While solving the above equation, we can use an approximation procedure [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib24">24</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib25">25</xref>
+            ] related to neutrino masses and mixing angle
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M301.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is explained below.
+         </p>
+         <p>
+            In the expression for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M302.jpg" xlink:type="simple" />
+            </inline-formula>
+            one can have Majorana phases, which cannot be determined from neutrino oscillation data. However, they can affect the life-time of neutrinoless double beta decay, since neutrinos in our model are Majorana particles. Nonetheless, there is no concrete evidence for this decay so far [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ], and as a result, the Majorana phases can take any value between 0 and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 2\pi $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M303.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, in our analysis, for the sake of simplicity, we have chosen these phases to be zero. In contrast, by taking some specific values for Majorana phases in the below described procedure, one can study the conditions, which can give rise for neutrino Yukawa couplings of our model. Nevertheless, we shall reserve this study for a future work.
+         </p>
+         <p>
+            In
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M304.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we put
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23}={\pi}/{4} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M305.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP}={(3\pi)}/{2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M306.jpg" xlink:type="simple" />
+            </inline-formula>
+            . From the neutrino oscillation data, we have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2\sim{1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M307.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2\sim2\cdot10^{-2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M308.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ]. Here, we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M309.jpg" xlink:type="simple" />
+            </inline-formula>
+            is negligibly small in comparison to unity, and hence
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}\sim0.15 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M310.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be treated as a small variable. In contrast,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M311.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{23}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M312.jpg" xlink:type="simple" />
+            </inline-formula>
+            are of order one. Since
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M313.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the only small variable in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M314.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we expand
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M315.jpg" xlink:type="simple" />
+            </inline-formula>
+            up to the first order in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M316.jpg" xlink:type="simple" />
+            </inline-formula>
+            . The corresponding expression is given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>40</label>
+               <tex-math id="cpc_46_10_103101_E40">
+                  <?CDATA $ \begin{aligned}[b] U_{\rm PMNS}= & U_0+\delta U, \\ U_0= & \left(\begin{array}{ccc} c_{12} & s_{12} & 0 \\ -\dfrac{s_{12}}{\sqrt{2}} & \dfrac{c_{12}}{\sqrt{2}} & \dfrac{1}{\sqrt{2}} \\ \dfrac{s_{12}}{\sqrt{2}} & -\dfrac{c_{12}}{\sqrt{2}} & \dfrac{1}{\sqrt{2}} \end{array}\right),\\\delta U= & \left(\begin{array}{ccc} 0 & 0 & 1 \\ \dfrac{c_{12}}{\sqrt{2}} & \dfrac{s_{12}}{\sqrt{2}} & 0 \\ \dfrac{c_{12}}{\sqrt{2}} & \dfrac{s_{12}}{\sqrt{2}} & 0 \end{array}\right){\rm i}s_{13}. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E40.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            From the neutrino oscillation data, two mass-squared differences for neutrinos are found, which are given in Eq. (11). From this equation we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {m_s^2}/{m_a^2}\sim s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M317.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is negligibly small compared to unity. This indicates that an approximation with respect to neutrino masses can also be applied while solving the Eq. (39). In order to fit the mass-square differences of Eq. (11), we can take the neutrino masses as follows.
+         </p>
+         <p>
+            <disp-formula>
+               <label>41</label>
+               <tex-math id="cpc_46_10_103101_E41">
+                  <?CDATA $ \begin{aligned}[b] & {\rm NO}:\quad m_1 \lesssim m_s,\quad m_2=\sqrt{m_s^2+m_1^2},\quad m_3=\sqrt{m_a^2+m_1^2}. \\ & {\rm IO}:\quad m_3 \lesssim m_s,\quad m_1=\sqrt{m_a^2+m_3^2},\quad m_2=\sqrt{m_s^2+m_1^2}. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E41.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Now we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {m_1}/{m_a} \lesssim s_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M318.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the case of NO, whereas,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {m_1}/{m_a}\sim1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M319.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the case of IO. Similar conclusions can be made about
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${m_2}/{m_a}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M320.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${m_3}/{m_a} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M321.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            Using the approximation scheme described in the previous paragraph, we can expand
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${({1}/{m_a})}M_\nu$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M322.jpg" xlink:type="simple" />
+            </inline-formula>
+            in powers of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13},\;{m_s}/{m_a} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M323.jpg" xlink:type="simple" />
+            </inline-formula>
+            . After neglecting the second and higher order corrections in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13},\;{m_s}/{m_a} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M324.jpg" xlink:type="simple" />
+            </inline-formula>
+            , for both  NO and IO cases, the elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${({1}/{m_a})}M_\nu$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M325.jpg" xlink:type="simple" />
+            </inline-formula>
+            are given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>42</label>
+               <tex-math id="cpc_46_10_103101_E42">
+                  <?CDATA $ \begin{aligned}[b] & \frac{1}{m_a}M_\nu=\frac{1}{2m_a}\left(\begin{array}{ccc} x & z & z^*\\ z & w & y\\ z^* & y & w^* \end{array}\right), \\ {\rm NO}:\;\; & x=2c_{12}^2m_1+2 s_{12}^2 m_2,\\ & z=\sqrt{2} c_{12}s_{12}(m_2-m_1)-{\rm i}\sqrt{2}m_3s_{13}, \\ & w=m_3+c_{12}^2m_2+s_{12}^2m_1,\\ & y=-m_3+c_{12}^2m_2+s_{12}^2m_1. \\ {\rm IO}:\;\; & x=2m_1,\quad z=-\sqrt{2} {\rm i} s_{13}m_1,\\ & w=m_1+m_3,\quad y=m_1-m_3. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E42.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Using the above relations, in order for the matrix
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M326.jpg" xlink:type="simple" />
+            </inline-formula>
+            to make predictions about neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M327.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the Yukawa couplings in Eq. (8) should satisfy the following conditions.
+         </p>
+         <p>
+            ● To predict NO and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M328.jpg" xlink:type="simple" />
+            </inline-formula>
+            :
+         </p>
+         <p>
+            (i)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee},Y^\nu_{e\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M329.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be suppressed by approximately 0.1 compared to that of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\mu\mu},Y^\nu_{\mu\tau} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M330.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            (ii)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\mu\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M331.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real.
+         </p>
+         <p>
+            ● To predict IO and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M332.jpg" xlink:type="simple" />
+            </inline-formula>
+            :
+         </p>
+         <p>
+            (i)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{e\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M333.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be purely imaginary and its magnitude is suppressed by approximately 0.1 compared to other elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M334.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            (ii)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\mu\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M335.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real.
+         </p>
+         <p>
+            We recall that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M336.jpg" xlink:type="simple" />
+            </inline-formula>
+            is a symmetric matrix satisfying Eq. (9). Hence, not all elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M337.jpg" xlink:type="simple" />
+            </inline-formula>
+            are independent. As a result, while describing the above conditions, we have considered
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee},Y^\nu_{e\mu},Y^\nu_{\mu\mu},Y^\nu_{\mu\tau} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M338.jpg" xlink:type="simple" />
+            </inline-formula>
+            as independent elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M339.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Another point worth mentioning here is that the aforementioned conditions are true after neglecting second and higher order corrections in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {({1}/{m_a})}M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M340.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            The condition (ii) described for the cases of NO and IO is trivially satisfied if one uses the relations in Eq. (42). The non-trivial condition to check is the condition (i) in the NO and IO cases. The suppression factor mentioned in this condition is arising due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}\sim {({m_s}/{m_a})}\sim 0.15 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M341.jpg" xlink:type="simple" />
+            </inline-formula>
+            . We have checked this suppression factor for the case of NO by computing the following ratios:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{ee}|}/{|Y^\nu_{\mu\mu}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M342.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{ee}|}/{|Y^\nu_{\mu\tau}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M343.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\mu}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M344.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\tau}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M345.jpg" xlink:type="simple" />
+            </inline-formula>
+            . While for the case of IO, the following ratios are computed in order to check condition (i):
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{ee}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M346.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\mu}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M347.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\tau}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M348.jpg" xlink:type="simple" />
+            </inline-formula>
+            . One can notice that the neutrino Yukawa couplings are proportional to the elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M349.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which are given in Eq. (42). The neutrino masses in Eq. (42) are computed using Eq. (41) and by varying
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m^2_s,\;m^2_a $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M350.jpg" xlink:type="simple" />
+            </inline-formula>
+            over their allowed
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M351.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges. The mass of the lightest neutrino is varied from 0 to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_s $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M352.jpg" xlink:type="simple" />
+            </inline-formula>
+            in  the NO and IO cases. While computing the above mentioned ratios, we have also varied
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M353.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M354.jpg" xlink:type="simple" />
+            </inline-formula>
+            over their allowed
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M355.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges. We have listed the allowed
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M356.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges for the abovementioned variables in
+            <xref ref-type="table" rid="cpc_46_10_103101_t2">Table 2</xref>
+            .
+         </p>
+         <table-wrap id="cpc_46_10_103101_t2" orientation="portrait" position="float">
+            <label>Table 2</label>
+            <caption id="cpc_46_10_103101_tc2">
+               <p>
+                  Allowed
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 3\sigma $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103101_M357.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  ranges of the neutrino oscillation observables [
+                  <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+                  ], which are used in our analysis.
+               </p>
+            </caption>
+            <table>
+               <thead>
+                  <tr>
+                     <th align="center" colspan="1" rowspan="1" valign="middle">Parameters</th>
+                     <th align="center" colspan="1" rowspan="1" valign="middle">Allowed range</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ m_s^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M358.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        (6.94
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M359.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        8.14)
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \times 10^{-5} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M360.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        eV
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ ^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M361.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ m_a^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M362.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (NO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        (2.47
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M363.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        2.63)
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \times 10^{-3} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M364.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        eV
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ ^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M365.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ m_a^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M366.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (IO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        (2.37
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M367.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        2.53)
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \times 10^{-3} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M368.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        eV
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ ^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M369.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ s_{12}^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M370.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        0.271
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M371.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        0.369
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ s_{13}^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M372.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (NO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        0.0200
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M373.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        0.02405
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ s_{13}^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M374.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (IO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        0.02018
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M375.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        0.02424
+                     </td>
+                  </tr>
+               </tbody>
+            </table>
+         </table-wrap>
+         <p>
+            As we proceeded with above analysis, we checked if the sum of the three neutrinos is less than 0.12 eV, which is a constraint obtained from the cosmological observations [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib37">37</xref>
+            ]. As already described in the previous paragraph, the suppression in the ratios of various Yukawa couplings should be around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}\sim{({m_s}/{m_a})}\sim 0.15 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M376.jpg" xlink:type="simple" />
+            </inline-formula>
+            . However, in our analysis we have found that some of these ratios can become as large as 0.5, and thus, invalidate the approximation procedure, which we are using here. Hence, in the analysis we have restricted all these ratios to be less than or of the order of 0.2. Selected plots from this analysis are presented in
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            . From this figure we can see that the mass of lightest neutrino,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{\rm lightest} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M377.jpg" xlink:type="simple" />
+            </inline-formula>
+            , is constrained due to aforementioned restriction on the ratios of Yukawa couplings. We can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{\rm lightest} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M378.jpg" xlink:type="simple" />
+            </inline-formula>
+            has a narrow allowed region in the case of NO compared to that of IO. Apart from the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{\rm lightest} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M379.jpg" xlink:type="simple" />
+            </inline-formula>
+            in
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M380.jpg" xlink:type="simple" />
+            </inline-formula>
+            is also constrained to be in the range of 0.02 to 0.023, in the case of NO. In contrast, this variable is not constrained in the case of IO. As for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M381.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we have found that it can take the full
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M382.jpg" xlink:type="simple" />
+            </inline-formula>
+            range in both the NO and IO cases of
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            . Although we have presented selected plots in
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            , we have obtained similar plots for other ratios of Yukawa couplings, which are mentioned in the previous paragraph. These plots justify the approximation procedure, which we are using here, and verify the condition (i) for the cases of NO and IO, which are mentioned below Eq. (42).
+         </p>
+         <fig id="cpc_46_10_103101_f1" orientation="portrait" position="float">
+            <label>Fig. 1</label>
+            <caption id="cpc_46_10_103101_fc1">
+               <p>
+                  (color online) Ratios of the magnitude of Yukawa couplings versus the mass of lightest neutrino. The left- and right-hand side plots are for NO and IO, respectively. In both plots, we vary the neutrino oscillation observables over their allowed
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 3\sigma $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103101_M383.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  ranges, which are given in
+                  <xref ref-type="table" rid="cpc_46_10_103101_t2">Table 2</xref>
+                  . For other details, see the text.
+               </p>
+            </caption>
+            <graphic content-type="print" id="cpc_46_10_103101_f1_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103101_f1.pdf" xlink:type="simple" />
+            <graphic content-type="online" id="cpc_46_10_103101_f1_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103101_f1.pdf" xlink:type="simple" />
+         </fig>
+         <p>
+            The conditions mentioned below Eq. (42), for both the NO and IO cases, cannot be achieved just with the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M384.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. An additional mechanism should be proposed to satisfy these conditions. In an attempt towards this, we have proposed one mechanism to achieve condition (i) for the case of NO, where the necessary suppression in the Yukawa couplings is explained through non-renormalizable terms within the framework of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M385.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. This mechanism is presented in the Appendix. In this work, we do not have a mechanism to achieve condition (i) for the case of IO and to achieve condition (ii) for both NO and IO. These problems would be investigated in future works. As already described, with the generalized
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M386.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M387.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M388.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M389.jpg" xlink:type="simple" />
+            </inline-formula>
+            will be maximal. However, in future neutrino oscillation experiments,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M390.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M391.jpg" xlink:type="simple" />
+            </inline-formula>
+            may be found to be away from their maximal values. In such a case, one needs to device a mechanism for the breaking of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M392.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry in order to explain the non-maximal values for the above mentioned observables. However, these topics are outside the scope of the present study.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s05">
+         <label>V.</label>
+         <title>QUARK MIXING</title>
+         <p>
+            In our proposed model for lepton mixing, three Higgs doublets exist. Since they can also give masses to quarks, it is interesting to check whether quark mixing can also be explained with
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M393.jpg" xlink:type="simple" />
+            </inline-formula>
+            and other symmetries of our model. As already described in Sec. I, since there is a hierarchy among quark masses, the mixing pattern for quarks can be explained if their Yukawa couplings are hierarchically suppressed. Babu and Nandi have proposed one model [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ] for explaining quark mixing through hierarchically suppressed Yukawa couplings. Later, this model has been modified in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ], where the suppression in Yukawa couplings is explained with a singlet scalar field. We follow the work of Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ] to explain quark mixing in our framework.
+         </p>
+         <sec id="cpc_46_10_103101_s05-01">
+            <label>A.</label>
+            <title>Model for quark masses and mixing</title>
+            <p>
+               We denote the three families of quark doublets, up- and down-type singlets as
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Q_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M394.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ u_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M395.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ d_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M396.jpg" xlink:type="simple" />
+               </inline-formula>
+               , respectively. We propose a scalar field
+               <italic toggle="yes">X,</italic>
+               which is singlet under standard model gauge group. We assume all the quark fields to be singlets under the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_2\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M397.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The
+               <italic toggle="yes">X</italic>
+               field is singlet under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M398.jpg" xlink:type="simple" />
+               </inline-formula>
+               but is odd under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M399.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Both the quark and
+               <italic toggle="yes">X</italic>
+               fields transform under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M400.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>43</label>
+                  <tex-math id="cpc_46_10_103101_E43">
+                     <?CDATA $ \begin{aligned}[b] & Q_{j{\rm L}}\to {\rm i}\gamma^0C\bar{Q}_{j{\rm L}}^T,\quad u_{j{\rm R}}\to {\rm i}\gamma^0C\bar{u}_{j{\rm R}}^T, \\ & d_{j{\rm R}}\to {\rm i}\gamma^0C\bar{d}_{j{\rm R}}^T, \quad X\to X^*. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E43.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>Now, with the above mentioned transformations and fields, we consider the following effective Lagrangian for quark masses.</p>
+            <p>
+               <disp-formula>
+                  <label>44</label>
+                  <tex-math id="cpc_46_10_103101_E44">
+                     <?CDATA $ \begin{aligned}[b] {\cal L}_Y= & h^u_{33}\bar{Q}_{3{\rm L}}\tilde{\phi}_1u_{3{\rm R}} +\left(\frac{X}{M}\right)^2[h^d_{33}\bar{Q}_{3{\rm L}}\phi_1 d_{3{\rm R}} \\ & +h^u_{22}\bar{Q}_{2{\rm L}}\tilde{\phi}_1u_{2{\rm R}} +h^u_{23}\bar{Q}_{2{\rm L}}\tilde{\phi}_1u_{3{\rm R}} \\ & +h^u_{32}\bar{Q}_{3{\rm L}}\tilde{\phi}_1 u_{2{\rm R}}]+\left(\frac{X}{M}\right)^4[h^d_{22}\bar{Q}_{2{\rm L}}\phi_1 d_{2{\rm R}} \\ & +h^d_{23}\bar{Q}_{2{\rm L}}\phi_1 d_{3{\rm R}}+h^d_{32}\bar{Q}_{3{\rm L}}\phi_1 d_{2{\rm R}} \\ & +h^u_{12}\bar{Q}_{1{\rm L}}\tilde{\phi}_1u_{2{\rm R}}+h^u_{21}\bar{Q}_{2{\rm L}}\tilde{\phi}_1u_{1{\rm R}}\\ & +h^u_{13}\bar{Q}_{1{\rm L}}\tilde{\phi}_1u_{3{\rm R}}+ h^u_{31}\bar{Q}_{3{\rm L}}\tilde{\phi}_1u_{1{\rm R}}] \\ & +\left(\frac{X}{M}\right)^6[h^u_{11}\bar{Q}_{1{\rm L}}\tilde{\phi}_1u_{1{\rm R}} +h^d_{11}\bar{Q}_{1{\rm L}}\phi_1 d_{1{\rm R}}\\ & +h^d_{12}\bar{Q}_{1{\rm L}}\phi_1 d_{2{\rm R}} +h^d_{13}\bar{Q}_{1{\rm L}}\phi_1 d_{3{\rm R}}] \\ & +\left(\frac{X}{M}\right)^9[h^d_{21}\bar{Q}_{2{\rm L}}\phi_1 u_{1{\rm R}}] +\left(\frac{X}{M}\right)^{10}[h^d_{31}\bar{Q}_{3{\rm L}}\phi_1 u_{1{\rm R}}]+{\rm h.c}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E44.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               The above Lagrangian is valid below a mass scale of
+               <italic toggle="yes">M</italic>
+               . The non-renormalizable terms of this Lagrangian can be motivated by the UV completion of this model, which is presented in the next subsection. According to this UV completion, we propose a flavor symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M401.jpg" xlink:type="simple" />
+               </inline-formula>
+               and heavy vector-like quark (VLQ) fields above the scale
+               <italic toggle="yes">M</italic>
+               . After integrating the heavy fields in our model, below the scale
+               <italic toggle="yes">M</italic>
+               , the non-renormalizable terms of Eq. (44) can appear. Here we can see that
+               <italic toggle="yes">M</italic>
+               represents the mass scale of heavy VLQs. Since new particles can be probed at the LHC experiment if their masses are around 1 TeV, we take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M\sim $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M402.jpg" xlink:type="simple" />
+               </inline-formula>
+               1 TeV.
+            </p>
+            <p>
+               Due to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M403.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, the Yukawa couplings
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^{u,d}_{jk} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M404.jpg" xlink:type="simple" />
+               </inline-formula>
+               should be real in Eq. (44). After
+               <italic toggle="yes">X</italic>
+               acquires VEV, for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle X\rangle \lt M $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M405.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {X}/{M} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M406.jpg" xlink:type="simple" />
+               </inline-formula>
+               gives suppression to the effective quark Yukawa couplings. Since the Yukawa couplings of Eq. (44) are real, we assume
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle X\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M407.jpg" xlink:type="simple" />
+               </inline-formula>
+               is complex, and this can be the source for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M408.jpg" xlink:type="simple" />
+               </inline-formula>
+               violation in the quark sector. In the Lagrangian of Eq. (44), only the doublet
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M409.jpg" xlink:type="simple" />
+               </inline-formula>
+               generates Yukawa couplings for quark fields. The other doublets
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M410.jpg" xlink:type="simple" />
+               </inline-formula>
+               do not generate these Yukawa couplings due to the presence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times K$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M411.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry.
+            </p>
+            <p>After electroweak symmetry breaking, using Eq. (44), the matrices for up- and down-type quarks can be written, respectively, as</p>
+            <p>
+               <disp-formula>
+                  <label>45</label>
+                  <tex-math id="cpc_46_10_103101_E45">
+                     <?CDATA $ \begin{aligned}[b] & M_u=\left(\begin{array}{ccc} h^u_{11}\epsilon^6 & h^u_{12}\epsilon^4 & h^u_{13}\epsilon^4 \\ h^u_{21}\epsilon^4 & h^u_{22}\epsilon^2 & h^u_{23}\epsilon^2 \\ h^u_{31}\epsilon^4 & h^u_{32}\epsilon^2 & h^u_{33} \end{array}\right)v_1,\\ & M_d=\left(\begin{array}{ccc} h^d_{11}\epsilon^6 & h^d_{12}\epsilon^6 & h^d_{13}\epsilon^6 \\ h^d_{21}\epsilon^9 & h^d_{22}\epsilon^4 & h^d_{23}\epsilon^4 \\ h^d_{31}\epsilon^{10} & h^d_{32}\epsilon^4 & h^d_{33}\epsilon^2 \end{array}\right)v_1. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E45.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \epsilon=\dfrac{\langle X\rangle}{M} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M412.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The form of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M_{u,d} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M413.jpg" xlink:type="simple" />
+               </inline-formula>
+               is similar to the corresponding matrices in Refs. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+               ,
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ]. However, the only difference is that the elements 21 and 31 of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M_d $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M414.jpg" xlink:type="simple" />
+               </inline-formula>
+               are generated at a higher order compared to those in Refs. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+               ,
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ]. It is argued in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ] that the above mentioned elements do not affect quark masses and mixing if they are generated at higher order. Hence, after diagonalizing the above matrices, the masses and mixing angles for quarks, up to leading order in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon| $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M415.jpg" xlink:type="simple" />
+               </inline-formula>
+               , are given by
+            </p>
+            <p>
+               <disp-formula>
+                  <label>46</label>
+                  <tex-math id="cpc_46_10_103101_E46">
+                     <?CDATA $ \begin{aligned}[b] & (m_t,m_c,m_u)\approx(|h^u_{33}|,|h^u_{22}||\epsilon|^2, |h^u_{11}-h^u_{12}h^u_{21}/h^u_{22}||\epsilon|^6)v_1, \\ & (m_b,m_s,m_d)\approx(|h^d_{33}||\epsilon|^2, |h^d_{22}||\epsilon|^4,|h^d_{11}||\epsilon|^6)v_1, \\ & |V_{us}|\approx\left|\frac{h^d_{12}}{h^d_{22}}- \frac{h^u_{12}}{h^u_{22}}\right||\epsilon|^2, \\ & |V_{cb}|\approx\left|\frac{h^d_{23}}{h^d_{33}}- \frac{h^u_{23}}{h^u_{33}}\right||\epsilon|^2, \\ & |V_{ub}|\approx\left|\frac{h^d_{13}}{h^d_{33}}- \frac{h^u_{12}h^d_{23}}{h^u_{22}h^d_{33}}- \frac{h^u_{13}}{h^u_{33}}\right||\epsilon|^4, \\ & {\rm arg}(V_{ub})\approx4{\rm arg}(\epsilon). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E46.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Due to three Higgs doublets in our model, we have
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |v_1|^2+|v_2|^2+|v_3|^2 \approx(174\; {\rm GeV})^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M416.jpg" xlink:type="simple" />
+               </inline-formula>
+               . To satisfy this, we take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_1,v\sim174/\sqrt{2} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M417.jpg" xlink:type="simple" />
+               </inline-formula>
+               GeV. With this value for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M418.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we fit the expressions of Eq. (46) to the following best fit values [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+               ].
+            </p>
+            <p>
+               <disp-formula>
+                  <tex-math id="cpc_46_10_103101_E47-1">
+                     <?CDATA $ \begin{aligned}[b] & (m_t,m_c,m_u)=(172.76,1.27,2.16\times10^{-3})\; {\rm GeV}, \\ & (m_b,m_s,m_d)=(4.18\times10^3,93,4.67)\; {\rm MeV}, \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E47-1.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>47</label>
+                  <tex-math id="cpc_46_10_103101_E47">
+                     <?CDATA $ \begin{aligned}[b] & (|V_{us}|,|V_{cb}|,|V_{ub}|)=(0.2245,0.041,0.00382), \\ & {\rm arg}(V_{ub})=-1.196 \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E47.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               After the abovementioned fitting, we give a sample set of numerical values with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/5.5 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M419.jpg" xlink:type="simple" />
+               </inline-formula>
+               as follows.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>48</label>
+                  <tex-math id="cpc_46_10_103101_E48">
+                     <?CDATA $ \begin{aligned}[b] & (|h^u_{33}|,|h^u_{22}|, |h^u_{11}-h^u_{12}h^u_{21}/h^u_{22}|) \approx(1.4,0.31,0.49), \\ & (|h^d_{33}|,|h^d_{22}|,|h^d_{11}|)\approx (1.03,0.69,1.05), \\ & (h^d_{12},h^u_{12},h^d_{23},h^u_{23}, h^d_{13},h^u_{13})\\\approx & (1.49,-1.45,0.69,-0.8,1.12,1.0), \\ & {\rm arg}(\epsilon)\approx-0.3. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E48.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               From the numerical values given above, we can see that the magnitudes of all Yukawa couplings are less than about 1.5. We have considered numerical values with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/6 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M420.jpg" xlink:type="simple" />
+               </inline-formula>
+               . However, in this case, some of the Yukawa couplings can become larger than 2.0. Hence, with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/5.5 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M421.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal O}(1) $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M422.jpg" xlink:type="simple" />
+               </inline-formula>
+               Yukawa couplings, we can explain the quark masses and mixing pattern in our model. Since we expect new physics to appear around 1 TeV, we can take the cut-off scale of Eq. (44) to be
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M\sim $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M423.jpg" xlink:type="simple" />
+               </inline-formula>
+               1 TeV. Now, for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/5.5 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M424.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\langle X\rangle|\sim $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M425.jpg" xlink:type="simple" />
+               </inline-formula>
+               181 GeV.
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103101_s05-02">
+            <label>B.</label>
+            <title>UV completion</title>
+            <p>
+               Here, we present the UV completion for our model in order to explain the origin of non-renormalizable terms of Eq. (44). To achieve this UV completion, we follow the works of Refs. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ,
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib38">38</xref>
+               ]. The idea of this UV completion is to explain non-renormalizable terms following from a theory which is renormalizable at a high scale. Hence, we assume our model is renormalizable at and above the scale
+               <italic toggle="yes">M</italic>
+               and propose a flavor symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M426.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which is exactly above
+               <italic toggle="yes">M</italic>
+               . To generate non-renormalizable terms below
+               <italic toggle="yes">M</italic>
+               , we propose additional fields like flavons and VLQs, which transform under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M427.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The standard model quarks are charged under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M428.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry. However, the Higgs doublets and
+               <italic toggle="yes">X</italic>
+               field are singlets under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M429.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M430.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry is spontaneously broken when the flavons acquire VEVs around
+               <italic toggle="yes">M</italic>
+               , which is also the mass scale of VLQs. Here, we can see that our model should respect the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times K\times Z_2\times Z_3\times U(1)_{\rm F}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M431.jpg" xlink:type="simple" />
+               </inline-formula>
+               above the scale
+               <italic toggle="yes">M</italic>
+               . However, below
+               <italic toggle="yes">M</italic>
+               , after integrating the heavy VLQs and flavon fields, our model should generate non-renormalizable terms of Eq. (44), which respect the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times K\times Z_2\times Z_3$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M432.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               Under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M433.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we denote the charges for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Q_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M434.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ u_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M435.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ d_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M436.jpg" xlink:type="simple" />
+               </inline-formula>
+               as
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ q_{jf} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M437.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ u_{jf} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M438.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ d_{jf} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M439.jpg" xlink:type="simple" />
+               </inline-formula>
+               , respectively. We propose only two flavon fields,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ F_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M440.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ F_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M441.jpg" xlink:type="simple" />
+               </inline-formula>
+               , whose charges under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M442.jpg" xlink:type="simple" />
+               </inline-formula>
+               are
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M443.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M444.jpg" xlink:type="simple" />
+               </inline-formula>
+               , respectively. Flavons are charged under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M445.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry but are otherwise singlets under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_2\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M446.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M447.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, flavons transform like the
+               <italic toggle="yes">X</italic>
+               field of our model. Now, to generate non-renormalizable terms for up-type quarks in Eq. (44), we introduce VLQs
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M448.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M449.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which are color triplets and their hypercharges are same as those of right-handed singlet up-quarks. Analogous to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M450.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M451.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we introduce
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ G_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M452.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ G_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M453.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which generate non-renormalizable terms for down-type quarks. The above VLQs are singlets under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S U(2)$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M454.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry of the standard model and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M455.jpg" xlink:type="simple" />
+               </inline-formula>
+               . These fields are charged under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M456.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry. Under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M457.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, they transform like the quark fields.
+            </p>
+            <p>
+               After describing the field content and their charge assignments in the UV completion of our model, we further explain the generation of non-renormalizable terms of Eq. (44). The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{33} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M458.jpg" xlink:type="simple" />
+               </inline-formula>
+               term in Eq. (44) is renormalizable, which can be generated in our model by taking
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ q_{3f}=u_{3f} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M459.jpg" xlink:type="simple" />
+               </inline-formula>
+               . To generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{32} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M460.jpg" xlink:type="simple" />
+               </inline-formula>
+               term in Eq. (44), we consider the below invariant terms in the UV completion.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>49</label>
+                  <tex-math id="cpc_46_10_103101_E49">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{32}= & \bar{Q}_{3{\rm L}}\tilde{\phi}_1 K_{1{\rm R}}+ F_1^*\bar{K}_{1{\rm R}}K_{1{\rm L}}+ X \bar{K}_{1{\rm L}}K_{2{\rm R}}\\ & + F_2 \bar{K}_{2{\rm R}}K_{2{\rm L}}+ X \bar{K}_{2{\rm L}}u_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E49.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since the terms in the above equation are invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M461.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, the dimensionless Yukawa couplings should be real; these are
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal O}(1) $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M462.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which we have not written explicitly here. The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M463.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm L}},K_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M464.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be fixed in terms of corresponding charges of quarks and flavons in such a way that the above equation is invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M465.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Similarly, the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M466.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for these VLQs can be assigned such that the above equation is invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M467.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F}\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M468.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for VLQs of
+               <italic toggle="yes">K</italic>
+               -type are given in Eq. (57). When the flavons acquire VEVs, the VLQs in Eq. (49) acquire masses of the order of
+               <italic toggle="yes">M</italic>
+               . After integrating these heavy VLQs, terms in Eq. (49) generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{32} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M469.jpg" xlink:type="simple" />
+               </inline-formula>
+               term of Eq. (44).
+            </p>
+            <p>
+               By introducing more VLQs of
+               <italic toggle="yes">K</italic>
+               -type, the process described in the previous paragraph can be applied to generate other non-renormalizable terms of Eq. (44). Below we show the invariant Lagrangians of the form
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal L}^u_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M470.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M471.jpg" xlink:type="simple" />
+               </inline-formula>
+               term of Eq. (44), after integrating the heavy VLQs and flavons. The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F}\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M472.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for the VLQs in these Lagrangians can be seen in Eq. (57).
+            </p>
+            <p>
+               <disp-formula>
+                  <label>50</label>
+                  <tex-math id="cpc_46_10_103101_E50">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{31}= & \bar{Q}_{3{\rm L}}\tilde{\phi}_1 K_{1{\rm R}}+ F_1^*\bar{K}_{1{\rm R}}K_{1{\rm L}}+ X \bar{K}_{1{\rm L}}K_{2{\rm R}}+ F_2 \bar{K}_{2{\rm R}}K_{2{\rm L}}+ X \bar{K}_{2{\rm L}}K_{3{\rm R}}+ F_2 \bar{K}_{3{\rm R}}K_{3{\rm L}} + X \bar{K}_{3{\rm L}}K_{4{\rm R}}+ M \bar{K}_{4{\rm R}}K_{4{\rm L}}\\ & +X\bar{K}_{4{\rm L}}u_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E50.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>51</label>
+                  <tex-math id="cpc_46_10_103101_E51">
+                     <?CDATA $ \mathcal{L}^u_{23}= \bar{Q}_{2{\rm L}}\tilde{\phi}_1K_{5{\rm R}}+M\bar{K}_{5{\rm R}}K_{5{\rm L}}+X \bar{K}_{5{\rm L}}K_{6{\rm R}}+ F_1 \bar{K}_{6{\rm R}}K_{6{\rm L}}+X \bar{K}_{6{\rm L}}u_{3{\rm R}}+{\rm h.c}. $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E51.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>52</label>
+                  <tex-math id="cpc_46_10_103101_E52">
+                     <?CDATA $ \mathcal{L}^u_{22}= \bar{Q}_{2{\rm L}}\tilde{\phi}_1K_{5{\rm R}}+M\bar{K}_{5{\rm R}}K_{5{\rm L}}+ X\bar{K}_{5{\rm L}}K_{7{\rm R}}+F_2 \bar{K}_{7{\rm R}}K_{7{\rm L}}+X\bar{K}_{7{\rm L}}u_{2{\rm R}}+{\rm h.c}. $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E52.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>53</label>
+                  <tex-math id="cpc_46_10_103101_E53">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{21}= & \bar{Q}_{2L}\tilde{\phi}_1K_{5{\rm R}}+M\bar{K}_{5{\rm R}}K_{5{\rm L}}+X\bar{K}_{5{\rm L}}K_{7{\rm R}}+F_2 \bar{K}_{7{\rm R}}K_{7{\rm L}}+X \bar{K}_{7{\rm L}}K_{8{\rm R}}+M\bar{K}_{8{\rm R}}K_{8{\rm L}}+ +X\bar{K}_{8{\rm L}}K_{9{\rm R}}+F_2\bar{K}_{9{\rm R}}K_{9{\rm L}}\\ & +X\bar{K}_{9{\rm L}}u_{1{\rm R}}+{\rm h.c}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E53.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>54</label>
+                  <tex-math id="cpc_46_10_103101_E54">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{11}= & \bar{Q}_{1{\rm L}}\tilde{\phi}_1K_{10{\rm R}}+F_2 \bar{K}_{10{\rm R}}K_{10{\rm L}}+X\bar{K}_{10{\rm L}}K_{11{\rm R}}+F_2 \bar{K}_{11{\rm R}}K_{11{\rm L}} +X\bar{K}_{11{\rm L}}K_{12{\rm R}} F_2\bar{K}_{12{\rm R}}K_{12{\rm L}}+X\bar{K}_{12{\rm L}}K_{13{\rm R}}\\ & +F_2 \bar{K}_{13{\rm R}}K_{13{\rm L}}+X\bar{K}_{13{\rm L}}K_{14{\rm R}}+F_2 \bar{K}_{14{\rm R}}K_{14{\rm L}} + X\bar{K}_{14{\rm L}}K_{15{\rm R}}+M\bar{K}_{15{\rm R}}K_{15{\rm L}}+X\bar{K}_{15{\rm L}}u_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E54.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>55</label>
+                  <tex-math id="cpc_46_10_103101_E55">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{12}= & \bar{Q}_{1{\rm L}}\tilde{\phi}_1K_{10{\rm R}}+F_2 \bar{K}_{10{\rm R}}K_{10{\rm L}}+X\bar{K}_{10{\rm L}}K_{11{\rm R}}+F_2 \bar{K}_{11{\rm R}}K_{11{\rm L}}+X\bar{K}_{11{\rm L}}K_{12{\rm R}} +F_2\bar{K}_{12{\rm R}}K_{12{\rm L}}+X\bar{K}_{12{\rm L}}K_{13{\rm R}}\\ & +F_2 \bar{K}_{13{\rm R}}K_{13{\rm L}}+X\bar{K}_{13{\rm L}}u_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E55.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>56</label>
+                  <tex-math id="cpc_46_10_103101_E56">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{13}= & \bar{Q}_{1{\rm L}}\tilde{\phi}_1K_{10{\rm R}}+F_2 \bar{K}_{10{\rm R}}K_{10{\rm L}}+X\bar{K}_{10{\rm L}}K_{11{\rm R}}+F_2 \bar{K}_{11{\rm R}}K_{11{\rm L}}+X\bar{K}_{11{\rm L}}K_{12{\rm R}} +F_2\bar{K}_{12{\rm R}}K_{12{\rm L}}\\ & +X\bar{K}_{12{\rm L}}K_{16{\rm R}}+F_1 \bar{K}_{16{\rm R}}K_{16{\rm L}}+X\bar{K}_{16{\rm L}}u_{3{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E56.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>57</label>
+                  <tex-math id="cpc_46_10_103101_E57">
+                     <?CDATA $ \begin{aligned}[b] U(1)_{\rm F}\;:\; & K_{1{\rm R}}\rightarrow q_{3f},\quad K_{1{\rm L}}, K_{2{\rm R}}\rightarrow q_{3f}+f_1,\quad K_{2{\rm L}}, K_{3{\rm R}}\rightarrow q_{3f}+f_1-f_2, \quad K_{3{\rm L}},K_{4{\rm L}}, K_{4{\rm R}}\rightarrow q_{3f}+f_1-2f_2,\\ & K_{5{\rm R}}, K_{5{\rm L}},K_{6{\rm R}},K_{7{\rm R}}\rightarrow q_{2f} \quad K_{7{\rm L}},K_{8{\rm R}},K_{8{\rm L}},K_{9{\rm R}}\rightarrow q_{2f}-f_2,\quad K_{6{\rm L}}\rightarrow q_{2f}-f_1,\quad K_{9{\rm L}}\rightarrow q_{2f}-2 f_2, \\ & K_{10{\rm R}}\rightarrow q_{1f},\quad K_{10{\rm L}},K_{11{\rm R}}\rightarrow q_{1f}-f_2,\quad K_{11{\rm L}},K_{12{\rm R}}\rightarrow q_{1f}-2 f_2, \quad K_{12{\rm L}},K_{13{\rm R}},K_{16{\rm R}}\rightarrow q_{1f}-3 f_2, \\ & K_{13{\rm L}},K_{14{\rm R}}\rightarrow q_{1f}-4 f_2, \quad K_{14{\rm L}},K_{15{\rm R}},K_{15{\rm L}}\rightarrow q_{1f}-5 f_2,\quad K_{16{\rm L}},u_{3{\rm R}}\rightarrow q_{1f}-3 f_2-f_1. \\ Z_2 \;:\; & K_{1{\rm L}}, K_{1{\rm R}}, K_{3{\rm L}}, K_{3{\rm R}},K_{5{\rm L}}, K_{5{\rm R}},K_{8{\rm L}},K_{8{\rm R}}, K_{10{\rm L}},K_{10{\rm R}},K_{12{\rm L}},K_{12{\rm R}},K_{14{\rm L}},K_{14{\rm R}}, \rightarrow \rm{even},\\ & K_{2{\rm L}}, K_{2{\rm R}}, K_{4{\rm L}}, K_{4{\rm R}},K_{6{\rm L}},K_{6{\rm R}},K_{7{\rm L}}, K_{7{\rm R}},K_{9{\rm L}},K_{9{\rm R}},K_{11{\rm L}},K_{11{\rm R}}, K_{13{\rm L}},K_{13{\rm R}},K_{15{\rm R}},K_{15{\rm L}},K_{16{\rm L}},K_{16{\rm R}}\rightarrow \rm{odd}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E57.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since the Lagragians of Eqs. (49) –(56) are invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M473.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get relations among the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M474.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges of quarks and flavons. These relations can be consistently solved. Taking
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ q_{3f} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M475.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M476.jpg" xlink:type="simple" />
+               </inline-formula>
+               , and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M477.jpg" xlink:type="simple" />
+               </inline-formula>
+               as independent variables, the above mentioned relations can be expressed as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>58</label>
+                  <tex-math id="cpc_46_10_103101_E58">
+                     <?CDATA $ \begin{aligned}[b] & q_{2f}=q_{3f}+f_1,\quad q_{1f}=q_{3f}+f_1+3f_2,\quad u_{3f}=q_{3f},\quad \\ & u_{2f}=q_{3f}+f_1-f_2,\quad u_{1f}=q_{3f}+f_1-2f_2. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E58.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               The procedure described above has been applied in order to generate non-renormalizable terms for down-type quarks of Eq. (44). In this case, we introduce VLQs
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ G_{i{\rm R}},G_{i{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M478.jpg" xlink:type="simple" />
+               </inline-formula>
+               , where
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ i=1,\cdots,30 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M479.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Below, we give invariant Lagrangians in the form of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal L}^d_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M480.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^d_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M481.jpg" xlink:type="simple" />
+               </inline-formula>
+               term in Eq. (44), after integrating the heavy VLQs and flavons. Since these Lagrangians are invariant under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F}\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M482.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the charges of VLQs under this symmetry are fixed in terms of corresponding charges of quarks and flavons. These charges are given in Eq. (68).
+            </p>
+            <p>
+               <disp-formula>
+                  <label>59</label>
+                  <tex-math id="cpc_46_10_103101_E59">
+                     <?CDATA $ \mathcal{L}^d_{33}= \bar{Q}_{3{\rm L}}\phi_1 G_{1{\rm R}}+ F_1 \bar{G}_{1{\rm R}}G_{1{\rm L}}+X \bar{G}_{1{\rm L}}G_{2{\rm R}}+ F_1 \bar{G}_{2{\rm R}}G_{2{\rm L}}+ X \bar{G}_{2{\rm L}}d_{3{\rm R}}+{\rm h.c}.. $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E59.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>60</label>
+                  <tex-math id="cpc_46_10_103101_E60">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{32}= & \bar{Q}_{3{\rm L}}\phi_1 G_{1{\rm R}}+ F_1 \bar{G}_{1{\rm R}}G_{1{\rm L}}+ X \bar{G}_{1{\rm L}}G_{2{\rm R}}+ F_1 \bar{G}_{2{\rm R}}G_{2{\rm L}}+ X \bar{G}_{2{\rm L}}G_{3{\rm R}} + M \bar{G}_{3{\rm R}}G_{3{\rm L}} + X \bar{G}_{3{\rm L}}G_{4{\rm R}}\\ & + F_2^*\bar{G}_{4{\rm R}}G_{4{\rm L}}+ X \bar{G}_{4{\rm L}}d_{2{\rm R}}+ {\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E60.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>61</label>
+                  <tex-math id="cpc_46_10_103101_E61">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{23} = & \bar{Q}_{2{\rm L}}\phi_1 G_{5{\rm R}}+ F_1 \bar{G}_{5{\rm R}}G_{5{\rm L}}+X\bar{G}_{5{\rm L}}G_{6{\rm R}}+F_1 \bar{G}_{6{\rm R}}G_{6{\rm L}}+X \bar{G}_{6{\rm L}}G_{7{\rm R}} +F_1 \bar{G}_{7{\rm R}}G_{7{\rm L}}+ X \bar{G}_{7{\rm L}}G_{8{\rm R}}\\ & +M \bar{G}_{8{\rm R}}G_{8{\rm L}}+\bar{G}_{8{\rm L}}d_{3{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E61.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>62</label>
+                  <tex-math id="cpc_46_10_103101_E62">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{22}= & \bar{Q}_{2{\rm L}}\phi_1 G_{5{\rm R}}+ F_1 \bar{G}_{5{\rm R}}G_{5{\rm L}}+X\bar{G}_{5{\rm L}}G_{6{\rm R}}+F_1 \bar{G}_{6{\rm R}}G_{6{\rm L}}+X \bar{G}_{6{\rm L}}G_{7{\rm R}} +F_1 \bar{G}_{7{\rm R}}G_{7{\rm L}}+X\bar{G}_{7{\rm L}}G_{9{\rm R}}\\ & +F_2^* \bar{G}_{9{\rm R}}G_{9{\rm L}}+X\bar{G}_{9{\rm L}}d_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E62.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>63</label>
+                  <tex-math id="cpc_46_10_103101_E63">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{13}= & \bar{Q}_{1{\rm L}}\phi_1 G_{10{\rm R}}+F_1 \bar{G}_{10{\rm R}}G_{10{\rm L}}+X\bar{G}_{10{\rm L}}G_{11{\rm R}}+ +F_1 \bar{G}_{11{\rm R}}G_{11{\rm L}}+X\bar{G}_{11{\rm L}}G_{12{\rm R}} +F_1 \bar{G}_{12{\rm R}}G_{12{\rm L}}+X \bar{G}_{12{\rm L}}G_{13{\rm R}}\\ & +F_2 \bar{G}_{13{\rm R}}G_{13{\rm L}}+X \bar{G}_{13{\rm L}}G_{14{\rm R}}+F_2 \bar{G}_{14{\rm R}}G_{14{\rm L}}+X \bar{G}_{14{\rm L}}G_{15{\rm R}}+F_2 \bar{G}_{15{\rm R}}G_{15{\rm L}}+X\bar{G}_{15{\rm L}}d_{3{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E63.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>64</label>
+                  <tex-math id="cpc_46_10_103101_E64">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{12}= & \bar{Q}_{1{\rm L}}\phi_1 G_{10{\rm R}}+F_1 \bar{G}_{10{\rm R}}G_{10{\rm L}}+X\bar{G}_{10{\rm L}}G_{11{\rm R}}+F_1 \bar{G}_{11{\rm R}}G_{11{\rm L}}+X\bar{G}_{11{\rm L}}G_{12{\rm R}} +F_1 \bar{G}_{12{\rm R}}G_{12{\rm L}}+X \bar{G}_{12{\rm L}}G_{13{\rm R}}\\ & +F_2 \bar{G}_{13{\rm R}}G_{13{\rm L}}+X \bar{G}_{13{\rm L}}G_{14{\rm R}}+F_2 \bar{G}_{14{\rm R}}G_{14{\rm L}} X \bar{G}_{14{\rm L}}G_{16{\rm R}}+M \bar{G}_{16{\rm R}}G_{16{\rm L}}+X\bar{G}_{16{\rm L}}d_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E64.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>65</label>
+                  <tex-math id="cpc_46_10_103101_E65">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{11}= & \bar{Q}_{1{\rm L}}\phi_1 G_{10{\rm R}}+F_1 \bar{G}_{10{\rm R}}G_{10{\rm L}}+X\bar{G}_{10{\rm L}}G_{11{\rm R}} +F_1 \bar{G}_{11{\rm R}}G_{11{\rm L}}+X\bar{G}_{11{\rm L}}G_{12{\rm R}} +F_1 \bar{G}_{12{\rm R}}G_{12{\rm L}}+X\bar{G}_{12{\rm L}}G_{17{\rm R}}\\ & +F_1 \bar{G}_{17{\rm R}}G_{17{\rm L}}+X\bar{G}_{17{\rm L}}G_{18{\rm R}} +F_1\bar{G}_{18{\rm R}}G_{18{\rm L}} +X\bar{G}_{18{\rm L}}G_{19{\rm R}}+F_2^* \bar{G}_{19{\rm R}}G_{19{\rm L}}+X\bar{G}_{19{\rm L}}d_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E65.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>66</label>
+                  <tex-math id="cpc_46_10_103101_E66">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{21}= & \bar{Q}_{2L}\phi_1 M_{5R}+ F_1 \bar{G}_{5R}G_{5L}+X\bar{G}_{5L}G_{6R}+F_1 \bar{G}_{6R}G_{6L}+X \bar{G}_{6L}G_{7R}+F_1 \bar{G}_{7R}G_{7L} +X\bar{G}_{7L}G_{9R}+F_2^* \bar{G}_{9R}G_{9L} \\ & + X\bar{G}_{9L}G_{20R} + F_2^*\bar{G}_{20R}G_{20L} +X\bar{G}_{20L}G_{21R}+F_2^* \bar{G}_{21R}G_{21L} + X\bar{G}_{21L}G_{22R}+ F_2^* \bar{G}_{22R}G_{22L}\\ & + X\bar{G}_{22L}G_{23R} +F_1 \bar{G}_{23R}G_{23L} + X \bar{G}_{23L}G_{24R} + F_1\bar{G}_{24R}G_{24L} + X \bar{G}_{24L}d_{1R}+h.c.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E66.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>67</label>
+                  <tex-math id="cpc_46_10_103101_E67">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{31}= & \bar{Q}_{3{\rm L}}\phi_1 G_{1{\rm R}}+ F_1 \bar{G}_{1{\rm R}}G_{1{\rm L}}+ X \bar{G}_{1{\rm L}}G_{2{\rm R}}+ F_1 \bar{G}_{2{\rm R}}G_{2{\rm L}}+ X\bar{G}_{2{\rm L}}G_{25{\rm R}} +F_1\bar{G}_{25{\rm R}}G_{25{\rm L}} + X\bar{G}_{25{\rm L}}G_{26{\rm R}} + F_1 \bar{G}_{26{\rm R}}G_{26{\rm L}} \\ & + X\bar{G}_{26{\rm L}}G_{27{\rm R}} + F_2^*\bar{G}_{27{\rm R}}G_{27{\rm L}}+X\bar{G}_{27{\rm L}}G_{28{\rm R}}+F_2^* \bar{G}_{28{\rm R}}G_{28{\rm L}} + X\bar{G}_{28{\rm L}}G_{29{\rm R}} \\ & + F_2^*\bar{G}_{29{\rm R}}G_{29{\rm L}} +X\bar{G}_{29{\rm L}}G_{30{\rm R}} +F_2^*\bar{G}_{30{\rm R}}G_{30{\rm L}} + X \bar{G}_{30L}d_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E67.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <tex-math id="cpc_46_10_103101_E68-1">
+                     <?CDATA $ \begin{aligned}[b] U(1)_F \;\;:\;\; & G_{1{\rm R}}\rightarrow q_{3f},\quad G_{1{\rm L}},G_{2{\rm R}}\rightarrow q_{3f}-f_1\quad G_{2{\rm L}},G_{3{\rm R}},G_{3{\rm L}},G_{4{\rm R}},G_{25{\rm R}}\rightarrow q_{3f}-2f_1, \\ & G_{4{\rm L}}\rightarrow q_{3f}-2f_1+f_2,\quad G_{5{\rm R}}\rightarrow q_{2f},\quad G_{5{\rm L}},G_{6{\rm R}}\rightarrow q_{2f}-f_1, \\ & G_{6{\rm L}},G_{7{\rm R}}\rightarrow q_{2f}-2f_1,\quad G_{7{\rm L}},G_{8{\rm R}},G_{8{\rm L}},G_{9{\rm R}}\rightarrow q_{2f}-3 f_1 \\ & G_{9{\rm L}},G_{20{\rm R}}\rightarrow q_{2f}-3 f_1+f_2,\quad G_{10{\rm R}}\rightarrow q_{1f},\quad G_{10{\rm L}},G_{11{\rm R}}\rightarrow q_{1f}-f_1, \\ & G_{11{\rm L}},G_{12{\rm R}}\rightarrow q_{1f}-2 f_1,\quad G_{12{\rm L}},G_{13{\rm R}},G_{17{\rm R}}\rightarrow q_{1f}-3 f_1, \\ & G_{13{\rm L}},G_{14{\rm R}}\rightarrow q_{1f}-3 f_1-f_3,\quad G_{14{\rm L}},G_{15{\rm R}},G_{16{\rm L}},G_{16{\rm R}}\rightarrow q_{1f}-3 f_1-2 f_2 \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E68-1.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>68</label>
+                  <tex-math id="cpc_46_10_103101_E68">
+                     <?CDATA $ \begin{aligned}[b] & G_{15{\rm L}}\rightarrow q_{1f}-3 f_1-3f_3,\quad G_{17{\rm L}},G_{18{\rm R}}\rightarrow q_{1f}-4 f_1,\quad G_{18{\rm L}},G_{19{\rm R}}\rightarrow q_{1f}-5 f_1, \\ & G_{19{\rm L}}\rightarrow q_{1f}-5 f_1-f_2,\quad G_{20{\rm L}},G_{21{\rm R}}\rightarrow q_{2f}-3 f_1+2 f_2, \\ & G_{21{\rm L}},G_{22{\rm R}}\rightarrow q_{2f}-3f_1+3 f_2,\quad G_{22{\rm L}},G_{23{\rm R}}\rightarrow q_{2f}-3 f_1+4 f_2, \\ & G_{23{\rm L}},G_{24{\rm R}}\rightarrow q_{2f}–4 f_1+4 f_2,\quad G_{24{\rm L}}\rightarrow q_{2f}-5 f_1+4 f_2, \\ & G_{25{\rm L}},G_{26{\rm R}}\rightarrow q_{3f}-3 f_1,\quad G_{26{\rm L}},G_{27{\rm R}{\rm R}}\rightarrow q_{3f}-4 f_1,\quad G_{27{\rm L}}, G_{28{\rm R}}\rightarrow q_{3f}-4 f_1+f_2, \\ & G_{28{\rm L}},G_{29{\rm R}}\rightarrow q_{3f}-4 f_1+2 f_2,\quad G_{29{\rm L}},G_{30{\rm R}}\rightarrow q_{3f}-4 f_1+3 f_2, \\ & g_{30{\rm L}}\rightarrow q_{3f}-4 f_1+4 f_2. \\ Z_2 \;\;:\;\; & G_{1{\rm L}},G_{1{\rm R}}, G_{3{\rm L}}, G_{3{\rm R}}, G_{5{\rm L}}, G_{5{\rm R}}, G_{7{\rm L}}, G_{7{\rm R}}, G_{10{\rm L}}, G_{10{\rm R}},G_{12{\rm L}}, G_{12{\rm R}}, G_{14{\rm L}}, G_{14{\rm R}}, G_{18{\rm L}}, \\ & G_{18{\rm R}}, G_{20{\rm L}}, G_{20{\rm R}}, G_{22{\rm L}}, G_{22{\rm R}}, G_{24{\rm L}}, G_{24{\rm R}}, G_{25{\rm L}}, G_{25{\rm R}}, G_{27{\rm L}}, G_{27{\rm R}}, G_{29{\rm L}}, G_{29{\rm R}} \rightarrow \rm{even}. \\ & G_{2{\rm L}},G_{2{\rm R}}, G_{4{\rm L}}, G_{4{\rm R}}, G_{6{\rm L}}, G_{6{\rm R}}, G_{8{\rm L}}, G_{8{\rm R}}, G_{9{\rm L}}, G_{9{\rm R}}, G_{11{\rm L}}, G_{11R}, G_{13{\rm L}}, G_{13{\rm R}},G_{15{\rm L}}, \\ & G_{15{\rm R}}, G_{16{\rm L}}, G_{16{\rm R}}, G_{17{\rm L}}, G_{17{\rm R}}, G_{19{\rm L}}, G_{19{\rm R}}, G_{21{\rm L}}, G_{21{\rm R}}, G_{23{\rm L}}, G_{23{\rm R}}, G_{26{\rm L}}, G_{26{\rm R}}, \\ & G_{28{\rm L}}, G_{28{\rm R}}, G_{30{\rm L}}, G_{30{\rm R}} \rightarrow \rm{odd}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E68.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since the Lagrangians in Eqs. (59)–(67) are invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M483.jpg" xlink:type="simple" />
+               </inline-formula>
+               , nine relations emerge among the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M484.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges of quarks and flavons. These relations can be solved consistently along with Eq. (58). After doing this, the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M485.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges of singlet down-type quarks can be expressed as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>69</label>
+                  <tex-math id="cpc_46_10_103101_E69">
+                     <?CDATA $ \begin{equation} d_{3f}=q_{3f}-2f_1,\quad d_{2f}=q_{3f}-2f_1+f_2,\quad d_{1f}=q_{3f}-4f_1+4f_2. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E69.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               In this section, we have described our model for the quark sector as well as the UV completion to it. As part of this whole construction, we introduce extra fields and symmetries into our model, which are summarized in
+               <xref ref-type="table" rid="cpc_46_10_103101_t3">Table 3</xref>
+               .
+            </p>
+            <table-wrap id="cpc_46_10_103101_t3" orientation="portrait" position="float">
+               <label>Table 3</label>
+               <caption id="cpc_46_10_103101_tc3">
+                  <p>Additional fields and symmetry, along with their roles, in the quark sector of our model.</p>
+               </caption>
+               <table>
+                  <thead>
+                     <tr>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Additional field</th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Role</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <italic toggle="yes">X</italic>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           to generate hierarchy in quark masses and also
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $C P$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M486.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           violation in quark sector
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ F_1,F_2 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M487.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate masses for VLQs in the UV completion of our model</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $K_{i{\rm L}},K_{i{\rm R}}$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M488.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           (
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ i=1,\cdots,16 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M489.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           )
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate effective Yukawa couplings for up-type quarks from UV completion our model</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $G_{i{\rm L} },G_{i{\rm R} }$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M490.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           (
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ i=1,\cdots,30 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M491.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           )
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate effective Yukawa couplings for down-type quarks from UV completion our model</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Additional symmetry</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Role</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <italic toggle="yes">U</italic>
+                           (1)
+                           <sub>
+                              <italic toggle="yes">F</italic>
+                           </sub>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate invariant terms in the UV completion of our model</td>
+                     </tr>
+                  </tbody>
+               </table>
+            </table-wrap>
+         </sec>
+      </sec>
+      <sec id="cpc_46_10_103101_s06">
+         <label>VI.</label>
+         <title>FULL SCALAR POTENTIAL</title>
+         <p>
+            In Sec. III, we have detailed the analysis of scalar potential for the model described in Sec. II. However, the model in Sec. II addresses problems related to the masses of leptons. Later, within the framework of that model, we have addressed the hierarchy in the masses of quark fields in Sec. V. Concurrently, we have introduced additional singlet scalar fields:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,\;F_1,\;F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M492.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which can give extra terms with the doublet and triplet Higgses in the scalar potential. These extra terms may change the results derived in Sec. III. For this purpose, in this section, we give the full scalar potential of our model. After minimizing the full scalar potential, we demonstrate that the above mentioned singlet scalar fields do not change the main conclusions of the analysis made in Sec. III. We recall the following main conclusions of Sec. III: (i) triplet Higgs acquire real VEV, (ii) VEVs of doublet Higgses
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M493.jpg" xlink:type="simple" />
+            </inline-formula>
+            explain the hierarchy between
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M494.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M495.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>The full scalar potential of our model is</p>
+         <p>
+            <disp-formula>
+               <label>70</label>
+               <tex-math id="cpc_46_10_103101_E70">
+                  <?CDATA $ \begin{array}{*{20}{l}} V_{{\rm full}}=V_{\rm inv}+ V_{X,F_1,F_2}+V_{\not{K}}+V^\prime_{\not{K}}. \end{array} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E70.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M496.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the invariant scalar potential of our model, arising due to the singlet fields
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,\;F_1,\;F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M497.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V^\prime_{\not{K}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M498.jpg" xlink:type="simple" />
+            </inline-formula>
+            contains potential terms due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,\;F_1,\;F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M499.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which violate
+            <italic toggle="yes">K</italic>
+            -symmetry explicitly. Recall that the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv}+V_{\not{K}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M500.jpg" xlink:type="simple" />
+            </inline-formula>
+            has been discussed in Sec. III. First we find a minimum for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv}+V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M501.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Further, we study the shift in this minimum due to the presence of
+            <italic toggle="yes">K</italic>
+            -violating terms. In this regard, the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M502.jpg" xlink:type="simple" />
+            </inline-formula>
+            , after applying the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M503.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, has been studied in Sec. III.C. Here, we verify whether this minimization can be affected by
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M504.jpg" xlink:type="simple" />
+            </inline-formula>
+            . The form for this potential is given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>71</label>
+               <tex-math id="cpc_46_10_103101_E71">
+                  <?CDATA $ \begin{aligned}[b]\\ V_{X,F_1,F_2}= & -m_X^2 (X^*X)-m_{F_1}^2(F_1^* F_1)-m_{F_2}^2(F_2^* F_2)+\lambda_X (X^*X)^2 +\lambda_{F_1}(F_1^* F_1)^2 +\lambda_{F_2}(F_2^* F_2)^2+ A(X^2+{X^*}^2)\\ & +B(X^4+{X^*}^4)+ \lambda_X^{\prime}(X^3X^{*}+{X^*}^3X) +\lambda_{F_1F_2}(F_1^* F_1)(F_2^* F_2) +\lambda_{F_1 X}(F_1^*F_1)(X^*X) +\lambda_{F_1 X}^{\prime}(F_1^*F_1)(X^2+{X^*}^2) \\ & +\lambda_{F_2 X}(F_2^*F_2)(X^*X)+\lambda_{F_2 X}^{\prime}(F_2^*F_2)(X^2+{X^*}^2) +\lambda_{\phi_1 X}(\phi_1^{\dagger}\phi_1)(X^*X) +\lambda_{\phi_1 X}^{\prime}(\phi_1^{\dagger}\phi_1)(X^2+{X^*}^2)\\ & +\lambda_{\phi_2 X}(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3)(X^*X)+\lambda_{\phi_2 X}^{\prime}(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3)(X^2+{X^*}^2)+\lambda_{\Delta X}\rm Tr(\Delta^{\dagger}\Delta)(X^*X) +\lambda_{\Delta X}^{\prime}{\rm Tr}(\Delta^{\dagger}\Delta)(X^2+{X^*}^2)\\ & +\lambda_{F_1\phi_1}(F_1^*F_1)(\phi_1^{\dagger}\phi_1)+\lambda_{F_2\phi_1}(F_2^*F_2)(\phi_1^{\dagger}\phi_1) +\lambda_{F_1\phi_2}(F_1^*F_1)(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3)+\lambda_{F_2\phi_2}(F_2^*F_2)(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3) \\ & +\lambda_{F_1\Delta}{\rm Tr}(\Delta^{\dagger}\Delta)(F_1^*F_1)+\lambda_{F_2\Delta}{\rm Tr}(\Delta^{\dagger}\Delta)(F_2^*F_2). \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E71.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above equation, all parameters are real due to hermiticity and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M505.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry.
+         </p>
+         <p>
+            In Eq. (71),
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M506.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M507.jpg" xlink:type="simple" />
+            </inline-formula>
+            appear in the form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_1^*F_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M508.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_2^*F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M509.jpg" xlink:type="simple" />
+            </inline-formula>
+            , respectively. As a result, we can consider the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M510.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M511.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be real. Hence, we can parameterize the VEVs for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M512.jpg" xlink:type="simple" />
+            </inline-formula>
+            as
+         </p>
+         <p>
+            <disp-formula>
+               <label>72</label>
+               <tex-math id="cpc_46_10_103101_E72">
+                  <?CDATA $ \begin{array}{*{20}{l}} \langle X \rangle =v_{X}{\rm e}^{{\rm i}\theta_{X}},\quad \langle F_1 \rangle =v_{f_1},\quad \langle F_2 \rangle =v_{f_2}. \end{array} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E72.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M513.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the phase in the VEV of
+            <italic toggle="yes">X</italic>
+            . After using the above VEVs and Eq. (17) in Eq. (71), we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>73</label>
+               <tex-math id="cpc_46_10_103101_E73">
+                  <?CDATA $ \begin{aligned}[b] \langle V_{X,F_1,F_2}\rangle \ni & 2 v_X^2\Big[ A +\lambda_X^{\prime} v_X^2 +\lambda_{\phi_1 X}^{\prime}v_1^2+\lambda_{\phi_2 X}^{\prime}v^2+\lambda_{\Delta X}{v^{\prime}}^2\\ & +\lambda_{F_1 X}^{\prime}v_{f_1}^2+ +\lambda_{F_2 X}^{\prime}v_{f_2}^2\Big]\cos2\theta_X +2 B v_X^4 \cos4\theta_{X}. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E73.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above equation, we have not written constant terms which do not contain phases of the VEVs of the fields. It is possible to notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M514.jpg" xlink:type="simple" />
+            </inline-formula>
+            do not mix with the phases in the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M515.jpg" xlink:type="simple" />
+            </inline-formula>
+            and Δ. Hence, the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{\rm inv}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M516.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is presented in Sec. III.C, is not affected due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{X,F_1,F_2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M517.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Consequently, Δ can acquire a real VEV, while Eq. (34) remains valid. From the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{X,F_1,F_2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M518.jpg" xlink:type="simple" />
+            </inline-formula>
+            with respect to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M519.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>74</label>
+               <tex-math id="cpc_46_10_103101_E74">
+                  <?CDATA $ \begin{aligned}[b] \cos2\theta_{X}= & -\frac{1}{4 B v_X^2}\Big[A+\lambda_X^{\prime}v_X^2+\lambda_{\phi_1 X}^{\prime}v_1^2+\lambda_{\phi_2 X}^{\prime}v^2\\ & +\lambda_{\Delta X}^{\prime}{v^{\prime}}^2+\lambda_{F_1 X}^{\prime}v_{f_1}^2+\lambda_{F_2 X}^{\prime}v_{f_2}^2\Big]. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E74.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            The above relation corresponds to the minimum for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M520.jpg" xlink:type="simple" />
+            </inline-formula>
+            , provided the below condition is satisfied.
+         </p>
+         <p>
+            <disp-formula>
+               <label>75</label>
+               <tex-math id="cpc_46_10_103101_E75">
+                  <?CDATA $ \begin{aligned}[b] 16 B^2 v_X^4 \gt & \Big[A+\lambda_X^{\prime}v_X^2+\lambda_{\phi_1 X}^{\prime}v_1^2+\lambda_{\phi_2 X}^{\prime}v^2+\lambda_{\Delta X}^{\prime}{v^{\prime}}^2\\ & +\lambda_{F_1 X}^{\prime}v_{f_1}^2+\lambda_{F_2 X}^{\prime}v_{f_2}^2\Big]^2 . \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E75.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here we have shown that
+            <italic toggle="yes">X</italic>
+            can acquire complex VEV. This must be achieved to generate the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M521.jpg" xlink:type="simple" />
+            </inline-formula>
+            violation in the quark sector, which is discussed in Sec. V.
+         </p>
+         <p>
+            After minimizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{\rm inv}\rangle+\langle V_{X,F_1,F_2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M522.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we have shown that the minimum can be given by Eqs. (34) and (74). This minimum can be shifted by small amount due to
+            <italic toggle="yes">K</italic>
+            -violating terms. Terms in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M523.jpg" xlink:type="simple" />
+            </inline-formula>
+            are presented in Sec. III. Below we give the form for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M524.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            <disp-formula>
+               <label>76</label>
+               <tex-math id="cpc_46_10_103101_E76">
+                  <?CDATA $ \begin{aligned}[b] V_{\not{K}}^{\prime}= & \delta\lambda_{\phi_2 X}(\phi_2^{\dagger}\phi_2)(X^*X)+\delta\lambda_{\phi_2 X}^{\prime}(\phi_3^{\dagger}\phi_3)(X^*X)+\delta\lambda_{\phi X}(\phi_2^{\dagger}\phi_2)(X^2+{X^*}^2) +\delta\lambda_{\phi X}^{\prime}(\phi_3^{\dagger}\phi_3)(X^2+{X^*}^2)\\ & +\delta \lambda_{\phi_2 F_1}(\phi_2^{\dagger}\phi_2)(F_1^{*}F_1)+\delta \lambda_{\phi_2 F_1}^{\prime}(\phi_3^{\dagger}\phi_3)(F_1^{*}F_1) +\delta \lambda_{\phi_2 F_2}(\phi_2^{\dagger}\phi_2)(F_2^{*}F_2)+\delta \lambda_{\phi_2 F_2}^{\prime}(\phi_3^{\dagger}\phi_3)(F_2^{*}F_2)\\ & +{\rm i}\delta\lambda_{21}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(X^*X) +{\rm i}\delta\lambda_{22}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(X^2+{X^*}^2)+{\rm i}\delta\lambda_{23}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(F_1^*F_1) +{\rm i}\delta\lambda_{24}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(F_2^*F_2). \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E76.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            All parameters in the above equation are real due to either
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M525.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry or hermiticity of the potential. These parameters should be small compared to those in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv}+V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M526.jpg" xlink:type="simple" />
+            </inline-formula>
+            , since the above potential violates
+            <italic toggle="yes">K</italic>
+            symmetry by a small amount. We can see that the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M527.jpg" xlink:type="simple" />
+            </inline-formula>
+            in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M528.jpg" xlink:type="simple" />
+            </inline-formula>
+            can give additional contribution to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M529.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_\zeta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M530.jpg" xlink:type="simple" />
+            </inline-formula>
+            in Eq. (36). Since the parameters of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M531.jpg" xlink:type="simple" />
+            </inline-formula>
+            are small, we can notice that the contribution due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M532.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be of the same order as the terms already obtained for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M533.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_\zeta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M534.jpg" xlink:type="simple" />
+            </inline-formula>
+            in Eq. (36). As a result, the hierarchy in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M535.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M536.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be explained in our framework.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s07">
+         <label>VII.</label>
+         <title>PHENOMENOLOGY OF OUR MODEL</title>
+         <p>
+            In Secs. III and VI we have analyzed the minimum of the scalar potential of our model. One needs to study whether this minimum corresponds to a global or local minimum. Following the studies made in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib39">39</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib40">40</xref>
+            ], we expect some additional conditions to be imposed on the parameters of our model in order for the minimum of the potential in this work to be global. Nonetheless, we shall work on the vacuum stability of our scalar potential in future studies.
+         </p>
+         <p>
+            The scalar fields, which are proposed in our model, are: three Higgs doublets, one Higgs triplet and three singlet scalar fields. We can choose the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{\rm F} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M537.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry of our model to be gauged. As a result, after electroweak symmetry breaking, the following fields remain in the theory: one doubly charged scalar, three singly charged scalars, seven neutral scalars, and five pseudo scalars. In case I, which is described in Sec. III, the scalar fields belonging to the triplet Higgs can have masses around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 10^{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M538.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV. Otherwise, we can choose the parameters in the scalar potential of our model in such a way that all the scalar fields can have masses less than or about 1 TeV. In the case where the masses for the scalar fields are less than 1 TeV, one can study the collider phenomenology. For this study, one needs to know the interaction of the scalar fields with the standard model particles. We can see that the scalar components of Higgs doublets and Higgs triplet have gauge interactions. For the field
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M539.jpg" xlink:type="simple" />
+            </inline-formula>
+            , it has Yukawa interactions with quark fields. Hence, the scalars belonging to doublet and triplet Higgses can be produced at the LHC experiment via gauge or strong interactions. After production, they will decay into standard model fields. In the case of singlet scalars
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M540.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the flavons have Yukawa interactions with VLQs. Moreover, these flavons interact with doublet and triplet Higgses in the scalar potential. As for the
+            <italic toggle="yes">X</italic>
+            field, it has Yukawa interactions containing a VLQ and a right-handed quark field. Moreover,
+            <italic toggle="yes">X</italic>
+            has interactions with Higgs fields in the scalar potential. Since VLQs are color triplets, they can be produced at the LHC experiment via strong interactions. From the decay of these VLQs, one can produce the abovementioned singlet scalars in the LHC experiment. Studying the collider phenomenology of this model is beyond the scope of this work.
+         </p>
+         <p>
+            In the lepton sector of our model, the Yukawa couplings for charged leptons are diagonal. Hence, these Yukawa interactions are flavor conserving. In contrast, the Yukawa couplings for neutrinos are flavor violating. As a result, the singly and doubly charged triplet Higgs fields can drive flavor violating decays of the form
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \ell\to3\ell^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M541.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \ell\to\ell^\prime\gamma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M542.jpg" xlink:type="simple" />
+            </inline-formula>
+            . However, it is stated in Sec. II that the Yukawa couplings for neutrinos are suppressed by about
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 10^{-3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M543.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, the branching ratios for the above mentioned decays are suppressed even if the components of the triplet Higgs can have masses around few hundred GeV. As a result, constraints due to non-observation of charged lepton flavor violating decays [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ] are satisfied in our model.
+         </p>
+         <p>
+            The phenomenology of our model in the quark sector is similar to that discussed in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ]. In this regard, the
+            <italic toggle="yes">X</italic>
+            field can cause flavor changing neutral currents at tree level in our model. Consequently, there can be mass splitting in the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ K^0-\bar{K}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M544.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D^0-\bar{D}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M545.jpg" xlink:type="simple" />
+            </inline-formula>
+            due to the mediation of
+            <italic toggle="yes">X</italic>
+            . We have estimated the above mentioned mass splittings, using the procedures described in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ]. For this purpose, we define
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \beta={v_1}/{M} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M546.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In our calculations, we have taken
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \epsilon\sim\beta={1}/{5.5} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M547.jpg" xlink:type="simple" />
+            </inline-formula>
+            and the mass of
+            <italic toggle="yes">X</italic>
+            as 1 TeV. The Yukawa couplings for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ h^{d,u}_{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M548.jpg" xlink:type="simple" />
+            </inline-formula>
+            are given in Eq. (48). We have chosen
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ h_{21}^d\sim1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M549.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ h_{21}^u=-0.7 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M550.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Using the above set of parameters, we have found
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_{K}\approx 10^{-16} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M551.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_D\approx 10^{-15} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M552.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV. These numerical values are smaller than the corresponding current experimental values, which are as follows:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_{K}=3.5 \times 10^{-15} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M553.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_D=2.35 \times 10^{-14} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M554.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ]. Hence, our model satisfies the constraints due to the mass splitting in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ K^0-\bar{K}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M555.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D^0-\bar{D}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M556.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            By choosing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{\rm F} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M557.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be gauged, the gauge boson corresponding to this symmetry,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M558.jpg" xlink:type="simple" />
+            </inline-formula>
+            , can be massive. The mixing between
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z-Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M559.jpg" xlink:type="simple" />
+            </inline-formula>
+            is constrained to be very small. In this regard, phenomenology due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M560.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be studied in our model. For more details about the phenomenology on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M561.jpg" xlink:type="simple" />
+            </inline-formula>
+            , see Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib41">41</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib42">42</xref>
+            ].
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s08">
+         <label>VIII.</label>
+         <title>CONCLUSIONS</title>
+         <p>
+            In this work, we have proposed a model, which explains the maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M562.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M563.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the lepton sector. To achieve this purpose, we have introduced three Higgs doublets and one Higgs triplet. This model is based on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M564.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry and type II seesaw mechanism. To explain the above observables, the VEV of triplet Higgs should be real. Moreover, due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M565.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, the masses for muon and tau can be of the same order. After introducing the
+            <italic toggle="yes">K</italic>
+            symmetry and explicit violation of it by a small amount, we have studied the minimization of the scalar potential of our model. Thereafter, we have shown that the VEV of triplet Higgs can be real, apart from explaining the hierarchy in the muon and tau masses. In addition to predicting the above observables, the mass matrix for neutrinos in our model can make predictions about the neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M566.jpg" xlink:type="simple" />
+            </inline-formula>
+            , if the elements of this matrix satisfy certain conditions, which are given in Sec. IV. To explain these conditions, one has to propose a new mechanism in addition to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M567.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. Although we do not have a mechanism to explain all the conditions given in Sec. IV, we have attempted to give one mechanism to explain condition (i) for the case of NO. This mechanism is presented in the Appendix.
+         </p>
+         <p>
+            Since in our model three Higgs doublets exist, we have studied the Yukawa couplings between quarks and these doublets by proposing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M568.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations for quark fields. After employing a certain texture for these Yukawa couplings, we have consistently explained the quark masses and mixing pattern. To employ this texture in the quark sector of our model, we have introduced additional fields like VLQs and singlet scalars. One of these singlet scalars should acquire a complex VEV in order to generate the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M569.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating phase in quark sector. Finally, we have analyzed the scalar potential containing the singlet scalars and the above mentioned Higgs fields. After this analysis, we have demonstrated that the masses and mixing pattern in lepton and quark sectors can be consistently explained.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s08_1">
+         <title>ACKNOWLEDGEMENT</title>
+         <p>
+            <italic toggle="yes">JG acknowledges Dr. Anirban Karan for some useful discussion.</italic>
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s09">
+         <title>APPENDIX: A MODEL FOR ACHIEVING CONDITION (I) IN THE CASE OF NO</title>
+         <p>
+            In Sec. IV, we have described some conditions on the elements of the neutrino mass matrix, which can make predictions regarding the case of NO or IO and about the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M570.jpg" xlink:type="simple" />
+            </inline-formula>
+            . These conditions are purely phenomenological and cannot be achieved with just the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M571.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. An additional mechanism should be proposed in order to satisfy these conditions. For the case of NO, condition (i) can be achieved if we propose an extra
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M572.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry and the singlet scalar fields
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1,S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M573.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M574.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, we consider the following charge assignments, where
+            <italic toggle="yes">l</italic>
+            is some non-zero rational number:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{e{\rm L}}\to l $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M575.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1\to-2l $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M576.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_2\to-l $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M577.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M578.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ e_{\rm R} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M579.jpg" xlink:type="simple" />
+            </inline-formula>
+            should transform like
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{e{\rm L}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M580.jpg" xlink:type="simple" />
+            </inline-formula>
+            , whereas the rest of the fields in our model are singlets.
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1,S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M581.jpg" xlink:type="simple" />
+            </inline-formula>
+            transform under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M582.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry as
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2}\to S_{1,2}^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M583.jpg" xlink:type="simple" />
+            </inline-formula>
+            . With the above charge assignments, the Yukawa terms for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{e{\rm L}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M584.jpg" xlink:type="simple" />
+            </inline-formula>
+            in Eq. (8) are forbidden. Now, these terms can be effectively generated by the following invariant terms.
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E77">
+                  <?CDATA $ \begin{aligned}[b] & Y_e\frac{S_1}{M}\bar{D}^c_{e{\rm L}}{\rm i}\sigma_2\Delta D_{e{\rm L}} +Y_\mu\frac{S_2}{M}\bar{D}^c_{e{\rm L}}{\rm i}\sigma_2\Delta D_{\mu {\rm L}} \\ & +Y_\tau\frac{S_2}{M}\bar{D}^c_{e{\rm L}}{\rm i}\sigma_2\Delta D_{\tau L}+{\rm h.c}.. \end{aligned}\tag{A1} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E77.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <italic toggle="yes">M</italic>
+            is a mass scale that is analogous to that in the quark sector Lagrangian of Eq. (44). The above non-renormalizable terms can be generated by studying the UV completion for these terms, where one can propose heavy vector-like leptons whose masses are around
+            <italic toggle="yes">M</italic>
+            . The process of this UV completion is analogous to the description in Sec. V.B. In order for Eq. (77) to be invariant under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M585.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y_e $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M586.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y_\mu=Y_\tau^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M587.jpg" xlink:type="simple" />
+            </inline-formula>
+            . After
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M588.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry is spontaneously broken, terms in Eq. (77) effectively generate the Yukawa couplings
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee}, Y^\nu_{e\mu},Y^\nu_{e\tau} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M589.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Moreover, by taking
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {\langle S_{1,2}\rangle}/{M}\sim0.1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M590.jpg" xlink:type="simple" />
+            </inline-formula>
+            , condition (i) for the case of NO is satisfied. Since
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M591.jpg" xlink:type="simple" />
+            </inline-formula>
+            is real and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{e\mu}=(Y^\nu_{e\tau})^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M592.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_{1}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M593.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_{2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M594.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real. We justify this statement by studying the scalar potential for these fields.
+         </p>
+         <p>
+            The scalar potential, which is invariant under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P\times Z_2\times Z_3\times K \times U(1)_{\rm F}\times U(1)_S$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M595.jpg" xlink:type="simple" />
+            </inline-formula>
+            and contains
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $S_{ 1,2}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M596.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E78">
+                  <?CDATA $ \begin{aligned}[b] V_{S_1,S_2}= & -m_{S_1}^2 (S_1^* S_1)- m_{S_2}^2 (S_2^* S_2)+\lambda_{S_1} (S_1^* S_1)^2\\ & +\lambda_{S_2} (S_2^* S_2)^2 + \lambda_{S_1 S_2} (S_1^* S_1)(S_2^* S_2) \\ & +\lambda_{\phi_1 S_1}(\phi_1^* \phi_1)(S_1^*S_1) + \lambda_{\phi_2 S_1}(\phi_2^* \phi_2\\ & +\phi_3^* \phi_3)(S_1^*S_1)+\lambda_{\phi_1 S_2}(\phi_1^* \phi_1)(S_2^*S_2) \\ & +\lambda_{\phi_2 S_2}(\phi_2^* \phi_2+\phi_3^* \phi_3)(S_2^*S_2)+\lambda_{\Delta S_1}{\rm Tr}(\Delta^{\dagger}\Delta)(S_1^* S_1)\\ & +\lambda_{\Delta S_2}{\rm Tr}(\Delta^{\dagger}\Delta)(S_2^* S_2) +\lambda_{S_1 X}(S_1^*S_1)(X^*X)\\ & + \lambda_{S_2 X}(S_2^*S_2)(X^*X)+\lambda_{S_1 X}^{\prime}(S_1^*S_1)(X^2+{X^*}^2) \\ & +\lambda_{S_2 X}^{\prime}(S_2^*S_2)(X^2+{X^*}^2)+\lambda_{F_1S_1}(F_1^*F_1)(S_1^*S_1)\\ & +\lambda_{F_1S_2}(F_1^*F_1)(S_2^*S_2) +\lambda_{F_2S_1}(F_2^*F_2)(S_1^*S_1)\\ & +\lambda_{F_2S_2}(F_2^*F_2)(S_2^*S_2) + a (S_1^*S_2^2+S_1 {S_2^*}^2). \end{aligned}\tag{A2} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E78.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Now, the
+            <italic toggle="yes">K</italic>
+            -violating terms containing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $S_{ 1,2}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M597.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E79">
+                  <?CDATA $ \begin{aligned}[b] V_{\not{K}}^{\prime\prime}= & \delta \lambda_{\phi_2 S_1}(\phi_2^{\dagger}\phi_2)(S_1^{*}S_1)+\delta\lambda_{\phi_2 S_1}^{\prime}(\phi_3^{\dagger}\phi_3)(S_1^{*}S_1)\\ & +\delta\lambda_{\phi_2 S_2}(\phi_2^{\dagger}\phi_2)(S_2^*S_2) +\lambda_{\phi_2 S_2}^{\prime}(\phi_3^{\dagger}\phi_3)(S_2^*S_2)\\ & +{\rm i}\delta\lambda_{25}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(S_1^*S_1)+{\rm i}\delta\lambda_{26}(\phi_2^{\dagger}\phi_3 \\ & -\phi_3^{\dagger}\phi_2)(S_2^*S_2). \end{aligned}\tag{A3} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E79.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above two potentials, all parameters are real due to hermiticity or
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M598.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. Similar to the desciption in Sec. VI, we can see that the potential terms in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{S_1,S_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M599.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^{\prime\prime} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M600.jpg" xlink:type="simple" />
+            </inline-formula>
+            do not alter the main conclusions of Sec. III.C. This means, even with the fields
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M601.jpg" xlink:type="simple" />
+            </inline-formula>
+            , Δ acquires real VEV, whereas the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M602.jpg" xlink:type="simple" />
+            </inline-formula>
+            explain the hierarchy in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M603.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M604.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            Here, we demonstrate that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M605.jpg" xlink:type="simple" />
+            </inline-formula>
+            can acquire real VEVs. In this regard, we can see that the last term of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{S_1,S_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M606.jpg" xlink:type="simple" />
+            </inline-formula>
+            can only contain the phases in the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M607.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, after parameterizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_1\rangle =v_{s_1}{\rm e}^{\theta_{s_1}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M608.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_1\rangle=v_{s_2}{\rm e}^{\theta_{s_2}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M609.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we get
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E80">
+                  <?CDATA $ \langle V_{S_1,S_2}\rangle \ni + 2 a v_{s_1}v_{s_2}^2\cos(2\theta_{s_2}-\theta_{s_1}). \tag{A4} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E80.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            The above term has a minimum at
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 2\theta_{s_2}-\theta_{s_1}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M610.jpg" xlink:type="simple" />
+            </inline-formula>
+            when
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ av_{s_1} \lt 0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M611.jpg" xlink:type="simple" />
+            </inline-formula>
+            . To satisfy this minimum, we can choose
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{s_1}=\theta_{s_2}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M612.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, the minimum at
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{s_1}=\theta_{s_2}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M613.jpg" xlink:type="simple" />
+            </inline-formula>
+            cannot be shifted by the terms of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^{\prime\prime} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M614.jpg" xlink:type="simple" />
+            </inline-formula>
+            , since
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M615.jpg" xlink:type="simple" />
+            </inline-formula>
+            appear in the form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1^*S_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M616.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_2^*S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M617.jpg" xlink:type="simple" />
+            </inline-formula>
+            in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^{\prime\prime} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M618.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, there exist a parameter region where the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M619.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M620.jpg" xlink:type="simple" />
+            </inline-formula>
+            are real in this model.
+         </p>
+      </sec>
+   </body>
+   <back>
+      <ref-list>
+         <title>References</title>
+         <ref id="cpc_46_10_103101_bib1">
+            <label>[1]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. de Salas</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>V. Forero</surname>
+                     <given-names>D.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Gariazzo</surname>
+                     <given-names>S.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>JHEP</source>
+               <year>2021</year>
+               <volume>02</volume>
+               <fpage>071</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP02(2021)071</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2006.11237" xlink:type="simple">2006.11237</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib2">
+            <label>[2]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. Harrison</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>H. Perkins</surname>
+                     <given-names>D.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>G. Scott</surname>
+                     <given-names>W.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>530</volume>
+               <fpage>167</fpage>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0202074 " xlink:type="simple">hep-ph/0202074 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib3">
+            <label>[3]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. Harrison</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>G. Scott</surname>
+                     <given-names>W.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>535</volume>
+               <fpage>163</fpage>
+               <lpage>169</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)01753-7</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0203209 " xlink:type="simple">hep-ph/0203209 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib4">
+            <label>[4]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>z. Xing</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>533</volume>
+               <fpage>85</fpage>
+               <lpage>93</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)01649-0</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0204049 " xlink:type="simple">hep-ph/0204049 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib5">
+            <label>[5]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. Harrison</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>G. Scott</surname>
+                     <given-names>W.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>547</volume>
+               <fpage>219</fpage>
+               <lpage>228</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)02772-7</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0210197" xlink:type="simple">hep-ph/0210197</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib6">
+            <label>[6]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>z. Xing</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>h. Zhao</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+               </person-group>
+               <source>Rept. Prog. Phys.</source>
+               <year>2016</year>
+               <volume>79</volume>
+               <issue>7</issue>
+               <fpage>076201</fpage>
+               <pub-id pub-id-type="doi">10.1088/0034-4885/79/7/076201</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1512.04207" xlink:type="simple">1512.04207</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib7">
+            <label>[7]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Holthausen</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lindner</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>A. Schmidt</surname>
+                     <given-names>M.</given-names>
+                  </name>
+               </person-group>
+               <source>JHEP</source>
+               <year>2013</year>
+               <volume>04</volume>
+               <fpage>122</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP04(2013)122</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1211.6953 " xlink:type="simple">1211.6953 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib8">
+            <label>[8]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Feruglio</surname>
+                     <given-names>F.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Hagedorn</surname>
+                     <given-names>C.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Ziegler</surname>
+                     <given-names>R.</given-names>
+                  </name>
+               </person-group>
+               <source>Eur. Phys. J. C</source>
+               <year>2014</year>
+               <volume>74</volume>
+               <fpage>2753</fpage>
+               <pub-id pub-id-type="doi">10.1140/epjc/s10052-014-2753-2</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1303.7178 " xlink:type="simple">1303.7178 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib9">
+            <label>[9]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>J. He</surname>
+                     <given-names>H.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Rodejohann</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>J. Xu</surname>
+                     <given-names>X.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2015</year>
+               <volume>751</volume>
+               <fpage>586</fpage>
+               <lpage>594</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2015.10.066</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1507.03541 " xlink:type="simple">1507.03541 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib10">
+            <label>[10]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Joshipura</surname>
+                     <given-names>A.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>M. Patel</surname>
+                     <given-names>K.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2015</year>
+               <volume>749</volume>
+               <fpage>159</fpage>
+               <lpage>166</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2015.07.062</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1507.01235 " xlink:type="simple">1507.01235 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib11">
+            <label>[11]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>C. Nishi</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>JHEP</source>
+               <year>2015</year>
+               <volume>08</volume>
+               <fpage>092</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP08(2015)092</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1506.06788 " xlink:type="simple">1506.06788 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib12">
+            <label>[12]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. King</surname>
+                     <given-names>S.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>C. Nishi</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2018</year>
+               <volume>785</volume>
+               <fpage>391</fpage>
+               <lpage>398</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2018.08.056</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1807.00023 " xlink:type="simple">1807.00023 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib13">
+            <label>[13]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Grimus</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lavoura</surname>
+                     <given-names>L.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2004</year>
+               <volume>579</volume>
+               <fpage>113</fpage>
+               <lpage>122</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2003.10.075</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0305309" xlink:type="simple">hep-ph/0305309</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib14">
+            <label>[14]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Babu</surname>
+                     <given-names>K.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Ma</surname>
+                     <given-names>E.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>W. F. Valle</surname>
+                     <given-names>J.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2003</year>
+               <volume>552</volume>
+               <fpage>207</fpage>
+               <lpage>213</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)03153-2</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0206292" xlink:type="simple">hep-ph/0206292</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib15">
+            <label>[15]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Senjanovic</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. Lett.</source>
+               <year>1980</year>
+               <volume>44</volume>
+               <fpage>912</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevLett.44.912</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib16">
+            <label>[16]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Schechter</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>W. F. Valle</surname>
+                     <given-names>J.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>1980</year>
+               <volume>22</volume>
+               <fpage>2227</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.22.2227</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib17">
+            <label>[17]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Grimus</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lavoura</surname>
+                     <given-names>L.</given-names>
+                  </name>
+               </person-group>
+               <source>J. Phys. G</source>
+               <year>2004</year>
+               <volume>30</volume>
+               <fpage>73</fpage>
+               <lpage>82</lpage>
+               <pub-id pub-id-type="doi">10.1088/0954-3899/30/2/007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0309050" xlink:type="simple">hep-ph/0309050</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib18">
+            <label>[18]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>
+                  P. A. Zyla
+                  <italic toggle="yes">et al.</italic>
+                  (Particle Data Group), PTEP
+                  <bold>2020</bold>
+                  (8), 083C01 (2020) doi:
+                  <ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1093/ptep/ptaa104" xlink:type="simple">10.1093/ptep/ptaa104</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib19">
+            <label>[19]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Magg</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Wetterich</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>1980</year>
+               <volume>94</volume>
+               <fpage>61</fpage>
+               <lpage>64</lpage>
+               <pub-id pub-id-type="doi">10.1016/0370-2693(80)90825-4</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib20">
+            <label>[20]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Senjanovic</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>1981</year>
+               <volume>23</volume>
+               <fpage>165</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.23.165</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib21">
+            <label>[21]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Lazarides</surname>
+                     <given-names>G.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Shafi</surname>
+                     <given-names>Q.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Wetterich</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Nucl. Phys. B</source>
+               <year>1981</year>
+               <volume>181</volume>
+               <fpage>287</fpage>
+               <lpage>300</lpage>
+               <pub-id pub-id-type="doi">10.1016/0550-3213(81)90354-0</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib22">
+            <label>[22]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>M. Ferreira</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Grimus</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lavoura</surname>
+                     <given-names>L.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>JHEP</source>
+               <year>2012</year>
+               <volume>09</volume>
+               <fpage>128</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP09(2012)128</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1206.7072" xlink:type="simple">1206.7072</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib23">
+            <label>[23]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>C. Nishi</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2012</year>
+               <volume>86</volume>
+               <fpage>073007</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.86.073007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1208.2875" xlink:type="simple">1208.2875</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib24">
+            <label>[24]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Hundi</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Sethi</surname>
+                     <given-names>I.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2020</year>
+               <volume>102</volume>
+               <fpage>055007</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.102.055007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2003.09809 " xlink:type="simple">2003.09809 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib25">
+            <label>[25]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Ganguly</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>S. Hundi</surname>
+                     <given-names>R.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2021</year>
+               <volume>103</volume>
+               <issue>3</issue>
+               <fpage>035007</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.103.035007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:2005.04023 " xlink:type="simple">arXiv:2005.04023 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib26">
+            <label>[26]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Rasin</surname>
+                     <given-names>A.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys.Rev.  D</source>
+               <year>1998</year>
+               <volume>58</volume>
+               <fpage>096012</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.58.096012</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:hep-ph/9802356" xlink:type="simple">arXiv:hep-ph/9802356</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib27">
+            <label>[27]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Babu</surname>
+                     <given-names>K.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Nandi</surname>
+                     <given-names>S.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2000</year>
+               <volume>62</volume>
+               <fpage>033002</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.62.033002</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/9907213" xlink:type="simple">hep-ph/9907213</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib28">
+            <label>[28]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>D. Lykken</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Murdock</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Nandi</surname>
+                     <given-names>S.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2009</year>
+               <volume>79</volume>
+               <fpage>075014</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.79.075014</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/0812.1826" xlink:type="simple">0812.1826</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib29">
+            <label>[29]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>C. Li</surname>
+                     <given-names>C.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>N. Lu</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>J. Ding</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>JHEP</source>
+               <year>2018</year>
+               <volume>02</volume>
+               <fpage>038</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP02(2018)038</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1706.04576 " xlink:type="simple">1706.04576 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib30">
+            <label>[30]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Lu</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>J. Ding</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2018</year>
+               <volume>98</volume>
+               <fpage>055011</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.98.055011</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1806.02301 " xlink:type="simple">1806.02301 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib31">
+            <label>[31]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>H. Rahat</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Ramond</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Xu</surname>
+                     <given-names>B.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2018</year>
+               <volume>98</volume>
+               <issue>5</issue>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.98.055030</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:1805.10684 " xlink:type="simple">arXiv:1805.10684 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib32">
+            <label>[32]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <etal>et al</etal>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2019</year>
+               <volume>100</volume>
+               <issue>7</issue>
+               <fpage>075008</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.100.075008</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:1907.10698 " xlink:type="simple">arXiv:1907.10698 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib33">
+            <label>[33]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <etal>et al</etal>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2020</year>
+               <volume>101</volume>
+               <issue>7</issue>
+               <fpage>075018</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.101.075018</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:2001.04019 " xlink:type="simple">arXiv:2001.04019 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib34">
+            <label>[34]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Ma</surname>
+                     <given-names>E.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Raidal</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Sarkar</surname>
+                     <given-names>U.</given-names>
+                  </name>
+               </person-group>
+               <source>Nucl. Phys. B</source>
+               <year>2001</year>
+               <volume>615</volume>
+               <fpage>313</fpage>
+               <lpage>330</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0550-3213(01)00416-3</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0012101" xlink:type="simple">hep-ph/0012101</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib35">
+            <label>[35]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>
+                  M. Drees, R. Godbole, and P. Roy,
+                  <italic toggle="yes">Theory and Phenomenology of Sparticles</italic>
+                  (World Scientific, Singapore, 2004); P. Bińetruy,
+                  <italic toggle="yes">Supersymmetry</italic>
+                  (Oxford University Press, Oxford, England, 2006)
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib36">
+            <label>[36]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>P. Martin</surname>
+                     <given-names>S.</given-names>
+                  </name>
+               </person-group>
+               <source>Adv. Ser. Direct. High Energy Phys.</source>
+               <year>2010</year>
+               <volume>21</volume>
+               <fpage>1</fpage>
+               <lpage>53</lpage>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:hep-ph/9709356 " xlink:type="simple">arXiv:hep-ph/9709356 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib37">
+            <label>[37]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>
+                  N. Aghanim
+                  <italic toggle="yes">et al.</italic>
+                  (Planck Collaboration), arXiv:1807.06209 [astro-ph.CO]
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib38">
+            <label>[38]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>K. Ghosh</surname>
+                     <given-names>D.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>S. Hundi</surname>
+                     <given-names>R.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2012</year>
+               <volume>85</volume>
+               <fpage>013005</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.85.013005</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1108.3428" xlink:type="simple">1108.3428</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib39">
+            <label>[39]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>J. Xu</surname>
+                     <given-names>X.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2016</year>
+               <volume>94</volume>
+               <issue>11</issue>
+               <fpage>115025</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.94.115025</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:1612.04950 " xlink:type="simple">arXiv:1612.04950 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib40">
+            <label>[40]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>J. Xu</surname>
+                     <given-names>X.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys.  Rev.  D</source>
+               <year>2017</year>
+               <volume>95</volume>
+               <issue>11</issue>
+               <fpage>115019</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.95.115019</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/ arXiv:1705.08965 " xlink:type="simple"> arXiv:1705.08965 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib41">
+            <label>[41]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>B. N. Grossmann, Z. Murdock, and S. Nandi, arXiv:1011.5256 [hep-ph]</comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib42">
+            <label>[42]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Erler</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Langacker</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Munir</surname>
+                     <given-names>S.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>JHEP</source>
+               <year>2011</year>
+               <volume>11</volume>
+               <fpage>076</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP11(2011)076</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1103.2659 " xlink:type="simple">1103.2659 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+      </ref-list>
+   </back>
+</article>

--- a/tests/units/iop/data/without_abstract.xml
+++ b/tests/units/iop/data/without_abstract.xml
@@ -1,0 +1,4079 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" xml:lang="en">
+   <front>
+      <journal-meta>
+         <journal-id journal-id-type="publisher-id">cpc</journal-id>
+         <journal-title-group>
+            <journal-title xml:lang="en">Chinese Physics C</journal-title>
+         </journal-title-group>
+         <issn pub-type="ppub">1674-1137</issn>
+         <publisher>
+            <publisher-name>Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+                        </publisher-name>
+         </publisher>
+      </journal-meta>
+      <article-meta>
+         <article-id pub-id-type="publisher-id">cpc_46_10_103001</article-id>
+         <article-id pub-id-type="doi">10.1088/1674-1137/ac7cd8</article-id>
+         <article-id pub-id-type="manuscript">ac7cd8</article-id>
+         <article-categories>
+            <subj-group subj-group-type="display-article-type">
+               <subject>Paper</subject>
+            </subj-group>
+            <subj-group subj-group-type="section">
+               <subject>Particles and fields</subject>
+            </subj-group>
+         </article-categories>
+         <title-group>
+            <article-title>
+               Study of background from accidental coincidence signalsin the PandaX-II experiment
+               <xref ref-type="fn" rid="cpc_46_10_103001_fn1">*</xref>
+               <fn id="cpc_46_10_103001_fn1">
+                  <label>*</label>
+                  <p>Supported in part by a grant from the Ministry of Science and Technology of China (2016YFA0400301),  National Science Foundation of China (12090060, 12005131, 11905128, 11925502, 11775141), and Office of Science and Technology, Shanghai Municipal Government (18JC1410200)</p>
+               </fn>
+            </article-title>
+         </title-group>
+         <contrib-group>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Abdukerim</surname>
+                  <given-names>Abdusalam</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>阿布都沙拉木&amp;middot;</surname>
+                  <given-names>阿布都克力木</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Chen</surname>
+                  <given-names>Wei</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>陈</surname>
+                  <given-names>葳</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Chen</surname>
+                  <given-names>Xun</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>谌</surname>
+                  <given-names>勋</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <xref ref-type="aff" rid="affiliation02">2</xref>
+               <email>chenxun@sjtu.edu.cn</email>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Chen</surname>
+                  <given-names>Yunhua</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>陈</surname>
+                  <given-names>云华</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation03">3</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Cheng</surname>
+                  <given-names>Chen</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>程</surname>
+                  <given-names>晨</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation04">4</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Cui</surname>
+                  <given-names>Xiangyi</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>崔</surname>
+                  <given-names>祥仪</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation05">5</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Fan</surname>
+                  <given-names>Yingjie</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>樊</surname>
+                  <given-names>英杰</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation06">6</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Fang</surname>
+                  <given-names>Deqing</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>方</surname>
+                  <given-names>德清</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation07">7</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Fu</surname>
+                  <given-names>Changbo</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>符</surname>
+                  <given-names>长波</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation07">7</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Fu</surname>
+                  <given-names>Mengting</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>付</surname>
+                  <given-names>孟婷</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation08">8</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Geng</surname>
+                  <given-names>Lisheng</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>耿</surname>
+                  <given-names>立升</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation09">9</xref>
+               <xref ref-type="aff" rid="affiliation10">10</xref>
+               <xref ref-type="aff" rid="affiliation11">11</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Giboni</surname>
+                  <given-names>Karl</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Gu</surname>
+                  <given-names>Linhui</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>顾</surname>
+                  <given-names>琳慧</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Guo</surname>
+                  <given-names>Xuyuan</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>郭</surname>
+                  <given-names>绪元</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation03">3</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Han</surname>
+                  <given-names>Ke</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>韩</surname>
+                  <given-names>柯</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>He</surname>
+                  <given-names>Changda</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>何</surname>
+                  <given-names>昶达</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Huang</surname>
+                  <given-names>Di</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>黄</surname>
+                  <given-names>迪</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Huang</surname>
+                  <given-names>Yan</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>黄</surname>
+                  <given-names>焱</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation03">3</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Huang</surname>
+                  <given-names>Yanlin</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>黄</surname>
+                  <given-names>彦霖</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation12">12</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Huang</surname>
+                  <given-names>Zhou</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>黄</surname>
+                  <given-names>周</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Ji</surname>
+                  <given-names>Xiangdong</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>季</surname>
+                  <given-names>向东</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation13">13</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Ju</surname>
+                  <given-names>Yonglin</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>巨</surname>
+                  <given-names>永林</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation14">14</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Li</surname>
+                  <given-names>Shuaijie</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>李</surname>
+                  <given-names>帅杰</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation05">5</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Liu</surname>
+                  <given-names>Huaxuan</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>刘</surname>
+                  <given-names>华萱</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation15">15</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Liu</surname>
+                  <given-names>Jianglai</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>刘</surname>
+                  <given-names>江来</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <xref ref-type="aff" rid="affiliation05">5</xref>
+               <xref ref-type="aff" rid="affiliation02">2</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Ma</surname>
+                  <given-names>Wenbo</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>马</surname>
+                  <given-names>文博</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Ma</surname>
+                  <given-names>Yugang</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>马</surname>
+                  <given-names>余刚</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation07">7</xref>
+               <xref ref-type="aff" rid="affiliation16">16</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Mao</surname>
+                  <given-names>Yajun</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>冒</surname>
+                  <given-names>亚军</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation08">8</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Meng</surname>
+                  <given-names>Yue</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>孟</surname>
+                  <given-names>月</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <xref ref-type="aff" rid="affiliation02">2</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Ni</surname>
+                  <given-names>Kaixiang</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>倪</surname>
+                  <given-names>恺翔</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Ning</surname>
+                  <given-names>Jinhua</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>宁</surname>
+                  <given-names>金华</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation03">3</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Ning</surname>
+                  <given-names>Xuyang</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>宁</surname>
+                  <given-names>旭阳</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Ren</surname>
+                  <given-names>Xiangxiang</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>任</surname>
+                  <given-names>祥祥</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation15">15</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Shang</surname>
+                  <given-names>Changsong</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>商</surname>
+                  <given-names>长松</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation06">6</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Si</surname>
+                  <given-names>Lin</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>司</surname>
+                  <given-names>琳</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Shen</surname>
+                  <given-names>Guofang</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>申</surname>
+                  <given-names>国防</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation09">9</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Tan</surname>
+                  <given-names>Andi</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>谈</surname>
+                  <given-names>安迪</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation15">15</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Wang</surname>
+                  <given-names>Anqing</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>王</surname>
+                  <given-names>安庆</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation14">14</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Wang</surname>
+                  <given-names>Hongwei</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>王</surname>
+                  <given-names>宏伟</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation16">16</xref>
+               <xref ref-type="aff" rid="affiliation17">17</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Wang</surname>
+                  <given-names>Meng</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>王</surname>
+                  <given-names>萌</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation15">15</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Wang</surname>
+                  <given-names>Qiuhong</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>王</surname>
+                  <given-names>秋红</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation07">7</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Wang</surname>
+                  <given-names>Siguang</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>王</surname>
+                  <given-names>思广</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation08">8</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Wang</surname>
+                  <given-names>Wei</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>王</surname>
+                  <given-names>为</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation04">4</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Wang</surname>
+                  <given-names>Xiuli</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>王</surname>
+                  <given-names>秀丽</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation14">14</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Wang</surname>
+                  <given-names>Zhou</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>王</surname>
+                  <given-names>舟</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <xref ref-type="aff" rid="affiliation02">2</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Wu</surname>
+                  <given-names>Mengmeng</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>武</surname>
+                  <given-names>蒙蒙</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation04">4</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Wu</surname>
+                  <given-names>Shiyong</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>吴</surname>
+                  <given-names>世勇</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation03">3</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Wu</surname>
+                  <given-names>Weihao</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>邬</surname>
+                  <given-names>维浩</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Xia</surname>
+                  <given-names>Jingkai</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>夏</surname>
+                  <given-names>经铠</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Xiao</surname>
+                  <given-names>Mengjiao</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>肖</surname>
+                  <given-names>梦姣</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation13">13</xref>
+               <xref ref-type="aff" rid="affiliation18">18</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Xie</surname>
+                  <given-names>Pengwei</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>谢</surname>
+                  <given-names>鹏伟</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation05">5</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Yan</surname>
+                  <given-names>Binbin</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>燕</surname>
+                  <given-names>斌斌</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Yang</surname>
+                  <given-names>Jijun</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>杨</surname>
+                  <given-names>继军</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Yang</surname>
+                  <given-names>Yong</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>杨</surname>
+                  <given-names>勇</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Yu</surname>
+                  <given-names>Chunxu</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>喻</surname>
+                  <given-names>纯旭</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation06">6</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Yuan</surname>
+                  <given-names>Jumin</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>袁</surname>
+                  <given-names>鞠敏</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation15">15</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Yuan</surname>
+                  <given-names>Ying</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>袁</surname>
+                  <given-names>影</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Zeng</surname>
+                  <given-names>Xinning</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>曾</surname>
+                  <given-names>鑫宁</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Zhang</surname>
+                  <given-names>Dan</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>张</surname>
+                  <given-names>丹</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation13">13</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Zhang</surname>
+                  <given-names>Tao</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>张</surname>
+                  <given-names>涛</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <xref ref-type="aff" rid="affiliation02">2</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Zhao</surname>
+                  <given-names>Li</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>赵</surname>
+                  <given-names>力</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <xref ref-type="aff" rid="affiliation02">2</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Zheng</surname>
+                  <given-names>Qibin</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>郑</surname>
+                  <given-names>其斌</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation12">12</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Zhou</surname>
+                  <given-names>Jifang</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>周</surname>
+                  <given-names>济芳</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation03">3</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Zhou</surname>
+                  <given-names>Ning</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>周</surname>
+                  <given-names>宁</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Zhou</surname>
+                  <given-names>Xiaopeng</given-names>
+               </name>
+               <name content-type="non-latin-no-space" name-style="eastern">
+                  <surname>周</surname>
+                  <given-names>小朋</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation09">9</xref>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname />
+                  <given-names>(PandaX-II Collaboration)</given-names>
+               </name>
+            </contrib>
+            <aff id="affiliation01">
+               <label>1</label>
+               <institution xlink:type="simple">School of Physics and Astronomy, Shanghai Jiao Tong University, MOE Key Laboratory for Particle Astrophysics and Cosmology, Shanghai Key Laboratory for Particle Physics and Cosmology</institution>
+               , Shanghai 200240,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation02">
+               <label>2</label>
+               <institution xlink:type="simple">Shanghai Jiao Tong University Sichuan Research Institute</institution>
+               , Chengdu 610213,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation03">
+               <label>3</label>
+               <institution xlink:type="simple">Yalong River Hydropower Development Company, Ltd., 288 Shuanglin Road</institution>
+               , Chengdu 610051,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation04">
+               <label>4</label>
+               <institution xlink:type="simple">School of Physics, Sun Yat-Sen University</institution>
+               , Guangzhou 510275,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation05">
+               <label>5</label>
+               <institution xlink:type="simple">Tsung-Dao Lee Institute</institution>
+               , Shanghai 200240,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation06">
+               <label>6</label>
+               <institution xlink:type="simple">School of Physics, Nankai University</institution>
+               , Tianjin 300071,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation07">
+               <label>7</label>
+               <institution xlink:type="simple">Key Laboratory of Nuclear Physics and Ion-beam Application (MOE), Institute of Modern Physics, Fudan University</institution>
+               , Shanghai 200433,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation08">
+               <label>8</label>
+               <institution xlink:type="simple">School of Physics, Peking University</institution>
+               , Beijing 100871,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation09">
+               <label>9</label>
+               <institution xlink:type="simple">School of Physics, Beihang University</institution>
+               , Beijing 102206,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation10">
+               <label>10</label>
+               <institution xlink:type="simple">Beijing Key Laboratory of Advanced Nuclear Materials and Physics, Beihang University, Beijing</institution>
+               , 102206,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation11">
+               <label>11</label>
+               <institution xlink:type="simple">School of Physics and Microelectronics, Zhengzhou University, Zhengzhou</institution>
+               , Henan 450001,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation12">
+               <label>12</label>
+               <institution xlink:type="simple">School of Medical Instrument and Food Engineering, University of Shanghai for Science and Technology</institution>
+               , Shanghai 200093,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation13">
+               <label>13</label>
+               <institution xlink:type="simple">Department of Physics, University of Maryland, College Park</institution>
+               , Maryland 20742,
+               <country>USA</country>
+            </aff>
+            <aff id="affiliation14">
+               <label>14</label>
+               <institution xlink:type="simple">School of Mechanical Engineering, Shanghai Jiao Tong University</institution>
+               , Shanghai 200240,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation15">
+               <label>15</label>
+               <institution xlink:type="simple">School of Physics and Key Laboratory of Particle Physics and Particle Irradiation (MOE), Shandong University</institution>
+               , Jinan 250100,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation16">
+               <label>16</label>
+               <institution xlink:type="simple">Shanghai Institute of Applied Physics, Chinese Academy of Sciences</institution>
+               , Shanghai 201800,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation17">
+               <label>17</label>
+               <institution xlink:type="simple">Shanghai Advanced Research Institute, Chinese Academy of Sciences</institution>
+               , Shanghai 201210,
+               <country>China</country>
+            </aff>
+            <aff id="affiliation18">
+               <label>18</label>
+               <institution xlink:type="simple">Center for High Energy Physics, Peking University</institution>
+               , Beijing 100871,
+               <country>China</country>
+            </aff>
+         </contrib-group>
+         <pub-date pub-type="ppub">
+            <day>01</day>
+            <month>10</month>
+            <year>2022</year>
+         </pub-date>
+         <pub-date pub-type="open-access">
+            <day>18</day>
+            <month>8</month>
+            <year>2022</year>
+         </pub-date>
+         <volume>46</volume>
+         <issue>10</issue>
+         <elocation-id content-type="artnum">103001</elocation-id>
+         <history>
+            <date date-type="received">
+               <day>22</day>
+               <month>6</month>
+               <year>2022</year>
+            </date>
+            <date date-type="published-online">
+               <day>18</day>
+               <month>8</month>
+               <year>2022</year>
+            </date>
+            <date date-type="oa-requested">
+               <day>22</day>
+               <month>6</month>
+               <year>2022</year>
+            </date>
+         </history>
+         <permissions>
+            <copyright-statement>© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</copyright-statement>
+            <copyright-year>2022</copyright-year>
+            <license license-type="cc-by" xlink:href="http://creativecommons.org/licenses/by/3.0/" xlink:type="simple">
+               <license-p>
+                  <graphic content-type="online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_ccby.tif" xlink:type="simple" />
+                  Content from this work may be used under the terms of the
+                  <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/3.0" xlink:type="simple">Creative Commons Attribution 3.0 licence</ext-link>
+                  . Any further distribution of this work must maintain attribution to the author(s) and the title of the work, journal citation and DOI. Article funded by SCOAP
+                  <sup>3</sup>
+                  and published under licence by Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+               </license-p>
+            </license>
+         </permissions>
+         <self-uri content-type="pdf" xlink:href="cpc_46_10_103001.pdf" xlink:type="simple" />
+         <kwd-group kwd-group-type="author">
+            <kwd>dark matter</kwd>
+            <kwd>xenon detector</kwd>
+            <kwd>background</kwd>
+            <kwd>accidental coincidence</kwd>
+            <kwd>machine learning</kwd>
+         </kwd-group>
+         <funding-group>
+            <open-access>
+               <p content-type="scoap3">
+                  Article funded by SCOAP
+                  <sup>3</sup>
+               </p>
+            </open-access>
+         </funding-group>
+         <counts>
+            <page-count count="14" />
+         </counts>
+         <custom-meta-group>
+            <custom-meta xlink:type="simple">
+               <meta-name>arxivppt</meta-name>
+               <meta-value>2204.11175</meta-value>
+            </custom-meta>
+         </custom-meta-group>
+      </article-meta>
+   </front>
+   <body>
+      <sec id="cpc_46_10_103001_s01">
+         <label>I.</label>
+         <title>INTRODUCTION</title>
+         <p>
+            The direct detection of dark matter particles, especially the weakly interacting massive particles (WIMPs), is being actively carried out by a couple of experiments worldwide [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib1">1</xref>
+            ]. In recent years, the PandaX-II experiment located in the China Jinping Underground Laboratory (CJPL) [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib1">1</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib3">3</xref>
+            ], which uses the technology of dual phase liquid xenon time projection chambers (TPCs), has pushed the limits of the cross section between WIMPs and nucleons to a new level for most of the possible WIMP masses; other experiments of the same type are also being performed [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib4">4</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib10">10</xref>
+            ]. The scattering of incident particles with xenon atoms in the TPC may produce a prompt scintillation
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M1.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which results from the de-excitation of xenon atoms and the recombination process of some ionized electrons. Some electrons escaping from the recombination may drift along the electric field inside the TPC and be extracted into the gaseous region, producing the proportional electroluminescent scintillation
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M2.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib11">11</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib12">12</xref>
+            ]. The detected
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M3.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M4.jpg" xlink:type="simple" />
+            </inline-formula>
+            signals are used to reconstruct the scattering event in the data analysis. Due to the low probability of scattering events between WIMPs and ordinary matter, a good physical event requires only one pair of physically correlated
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M5.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M6.jpg" xlink:type="simple" />
+            </inline-formula>
+            within the maximum electron drift time window inside the TPC. In the last results of the PandaX-I experiment [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib13">13</xref>
+            ], it was realized that the accidental coincidence of isolated
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M7.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M8.jpg" xlink:type="simple" />
+            </inline-formula>
+            within the window comprises a new type of background, which promotes a number of events in the signal parameter space to search for WIMPs. Understanding this type of background and the development of methods to suppress it become important for the improvement of dark matter detection sensitivity. In the data analysis of PandaX-II with full exposure, we conducted a thorough study of the accidental background and presented an accurate estimation of its level for all three data taking runs (9, 10, and 11) [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib4">4</xref>
+            ].
+         </p>
+         <p>In this article, we present a detailed introduction on the study of accidental background in PandaX-II in Sec. I. In Sec. II, we provide a brief introduction to the PandaX-II TPC, signals, and backgrounds. Then, we discuss the possible origin of the accidental background in Sec. III, with the estimation of its level presented in Sec. IV. The application of the boost-decision-tree (BDT) method to suppress the background is given in Sec. V, with the performance presented. Finally, we give a brief summary and outlook in Sec. VI.</p>
+      </sec>
+      <sec id="cpc_46_10_103001_s02">
+         <label>II.</label>
+         <title>TPC, SIGNALS, AND BACKGROUNDS OF PandaX-II</title>
+         <p>
+            A detailed description of the PandaX-II TPC is presented in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib7">7</xref>
+            ]. A more detailed schematic view of the TPC is presented in
+            <xref ref-type="fig" rid="cpc_46_10_103001_f1">Fig. 1</xref>
+            . The near-cylindrical shaped TPC confined by polytetrafluoroethylene (PTFE) walls, contains both gaseous xenon (top) and liquid xenon (bottom) in its volume. Scintillation light generated inside the TPC is detected by the two arrays of photo-multiplier tubes (PMTs) located on the top and bottom region, respectively. The cathode in the bottom part of the TPC and the gate electrode right below the liquid surface provide the drift electric field for ionized electrons and define the sensitive region of the detector (region 1 in
+            <xref ref-type="fig" rid="cpc_46_10_103001_f1">Fig. 1</xref>
+            ).
+         </p>
+         <fig id="cpc_46_10_103001_f1" orientation="portrait" position="float">
+            <label>Fig. 1</label>
+            <caption id="cpc_46_10_103001_fc1">
+               <p>
+                  (color online) Schematic view of the TPC of PandaX-II, with six regions labeled with numbers: 1. the liquid part below the gate and above the cathode; 2. the liquid part below the cathode; 3. the liquid part above the gate; 4. the gas part below the anode; 5. the gas part above the anode; 6. the parts outside the inner PTFE walls. A recoil event in region 1 may produce
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M9.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  and
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 2 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M10.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  signals at different regions in the detector with a time delay.
+               </p>
+            </caption>
+            <graphic content-type="print" id="cpc_46_10_103001_f1_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f1.eps" xlink:type="simple" />
+            <graphic content-type="online" id="cpc_46_10_103001_f1_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f1.jpg" xlink:type="simple" />
+         </fig>
+         <p>
+            Deposited energies by scattering events inside the sensitive region result in a
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M11.jpg" xlink:type="simple" />
+            </inline-formula>
+            signal, typically with a time spreading
+            <sup>
+               <xref ref-type="fn" rid="cpc_46_10_103001_pn1">①</xref>
+            </sup>
+            smaller than 150 ns, which is a very short time, while the possible
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M12.jpg" xlink:type="simple" />
+            </inline-formula>
+            signal will be produced after a time delay, due to the limited drift velocity of ionized electrons inside liquid xenon. The drift velocity of the electrons depends only on the electric field strength; thus, the time difference between the physically correlated
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M13.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M14.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be used to calculate the vertical position of a scattering event. The maximum drift time for electrons in the sensitive region is
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 350\pm8 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M15.jpg" xlink:type="simple" />
+            </inline-formula>
+            μs in Run 9 and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 360\pm8 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M16.jpg" xlink:type="simple" />
+            </inline-formula>
+            μs in Runs 10 and 11, due to the different drift fields [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib4">4</xref>
+            ]. When a "trigger" signal, observed during the ordinary recording of data, exceeds the pre-defined threshold, the digitized waveform of all the PMTs within a window of 500 μs before and after the trigger time is recorded as an event. The data processing steps calculate the baseline of each recorded waveform, search for a "hit" exceeding a given threshold of 0.25 photoelectrons (PE), and cluster the overlapped hits into signals. Events of single scattering (with only one
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M17.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M18.jpg" xlink:type="simple" />
+            </inline-formula>
+            reconstructed) are selected, and then filtered by the quality cuts to search for the possible rare scattering from WIMPs.
+         </p>
+         <p>
+            Recognition, understanding, and suppression of the different types of backgrounds are critical in the data analysis of WIMP searching experiments because the desired signal rate is very low. In the PandaX-II experiment, the backgrounds can be categorized into four types. The electron recoil (ER) background, mainly from the radioactive isotopes in the detector material or in the xenon target, has been studied and understood with the ER calibration data and Geant4-based Monte Carlo (MC) simulations [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib14">14</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib15">15</xref>
+            ]. The nuclear recoil (NR) background, mainly from neutrons produced by the (
+            <italic toggle="yes">α</italic>
+            ,
+            <italic toggle="yes">n</italic>
+            ) process or spontaneous fission of isotopes in detectors, has been estimated by the correlated high energy gamma events with the help of simulation [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib16">16</xref>
+            ]. The surface background is created by daughters of
+            <sup>222</sup>
+            Rn attached on the inner surface of the TPC and has a suppressed
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M19.jpg" xlink:type="simple" />
+            </inline-formula>
+            due to the charge loss on the PTFE wall. The level of surface background is estimated with a data driven method [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib4">4</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib17">17</xref>
+            ]. Finally, the nonphysical accidental background results from the false pairing of unrelated
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M20.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M21.jpg" xlink:type="simple" />
+            </inline-formula>
+            signals. A large proportion of the accidental background events have relatively small
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M22.jpg" xlink:type="simple" />
+            </inline-formula>
+            signals and thus are not easily distinguished from the physical NR events (neutron or WIMPs) by investigating the ratio of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2/S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M23.jpg" xlink:type="simple" />
+            </inline-formula>
+            only. Effective suppression of the accidental background will improve the discovery sensitivity of WIMPs greatly.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103001_s03">
+         <label>III.</label>
+         <title>ORIGINS OF THE ACCIDENTAL BACKGROUND</title>
+         <p>
+            In the TPC, some
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M24.jpg" xlink:type="simple" />
+            </inline-formula>
+            or
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M25.jpg" xlink:type="simple" />
+            </inline-formula>
+            -like signals may be produced without any other signals from the same source observed by detector. We call these signals "isolated." Since the events with a pair of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M26.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M27.jpg" xlink:type="simple" />
+            </inline-formula>
+            are used to search for dark matter, the isolated signals appearing in the same drift window may be paired, resulting in the accidental background.
+         </p>
+         <sec id="cpc_46_10_103001_s03-01">
+            <label>A.</label>
+            <title>
+               The isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\boldsymbol S}{\bf 1} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M28.jpg" xlink:type="simple" />
+               </inline-formula>
+            </title>
+            <p>
+               The origins of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M29.jpg" xlink:type="simple" />
+               </inline-formula>
+               s may be physical or non-physical. The physical origins might be in the following:
+            </p>
+            <p>● tiny sparks on the TPC electrode; thus, no electrons are produced;</p>
+            <p>
+               ● scattering events in the region between the cathode and the screening electrode of the bottom array (region 2 in
+               <xref ref-type="fig" rid="cpc_46_10_103001_f1">Fig. 1</xref>
+               ), which prevent electrons from drifting into the gas xenon; thus, no
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M30.jpg" xlink:type="simple" />
+               </inline-formula>
+               could be produced;
+            </p>
+            <p>
+               ● physical events occur near the bottom wall of the detector, resulting in a loss of all electrons owing to an imperfect drift field; thus, no
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M31.jpg" xlink:type="simple" />
+               </inline-formula>
+               is produced;
+            </p>
+            <p>
+               ● scattering events above the anode in the gaseous region (region 5 in
+               <xref ref-type="fig" rid="cpc_46_10_103001_f1">Fig. 1</xref>
+               ), which prevent electrons from entering the region below the anode; thus, no
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M32.jpg" xlink:type="simple" />
+               </inline-formula>
+               is produced;
+            </p>
+            <p>
+               ● signals produced by single electron extract into the gas region, which are mis-identified as
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M33.jpg" xlink:type="simple" />
+               </inline-formula>
+               s;
+            </p>
+            <p>
+               ● possible light leakage from scattering events outside the TPC (region 6 in
+               <xref ref-type="fig" rid="cpc_46_10_103001_f1">Fig. 1</xref>
+               ).
+            </p>
+            <p>
+               The dominant non-physical origin of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M34.jpg" xlink:type="simple" />
+               </inline-formula>
+               is from the dark noise of the PMT, which produce small hits in the readout waveform of each PMT. During the event reconstruction, a valid signal should contain overlapped hits from at least three PMTs. The relatively high rate of dark noise (average rates are 1.9, 0.17, and 0.23 kHz per PMT for Runs 9, 10, and 11, respectively) makes the formation of small
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M35.jpg" xlink:type="simple" />
+               </inline-formula>
+               -like signals via the random coincidence of the dark noises possible. Since these signals have a contribution from the top PMTs, their top-bottom asymmetry (discussed in Sec. V.A) should not be
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ -1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M36.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103001_s03-02">
+            <label>B.</label>
+            <title>
+               The isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\boldsymbol S}{\bf 2} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M37.jpg" xlink:type="simple" />
+               </inline-formula>
+            </title>
+            <p>
+               The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M38.jpg" xlink:type="simple" />
+               </inline-formula>
+               signals are from the electroluminescent of electrons in the gas region. The isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M39.jpg" xlink:type="simple" />
+               </inline-formula>
+               signals, without exception, resulted from the same process. The origin of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M40.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be categorized into four types:
+            </p>
+            <p>
+               ● real scattering event in the sensitive region with small energy deposition; the weak
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M41.jpg" xlink:type="simple" />
+               </inline-formula>
+               is not recognized due to the detection efficiency;
+            </p>
+            <p>
+               ● real scattering event in the sensitive region that it is too close to the liquid surface, resulting in overlapped
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M42.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M43.jpg" xlink:type="simple" />
+               </inline-formula>
+               signals, which are recognized as one
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M44.jpg" xlink:type="simple" />
+               </inline-formula>
+               ;
+            </p>
+            <p>
+               ● real scattering event in the region above the gate but below the anode (region 3 and 4 in
+               <xref ref-type="fig" rid="cpc_46_10_103001_f1">Fig. 1</xref>
+               ), resulting in overlapped
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M45.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M46.jpg" xlink:type="simple" />
+               </inline-formula>
+               signals recognized as one
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M47.jpg" xlink:type="simple" />
+               </inline-formula>
+               ; the signal may have a smaller width and asymmetrical shape;
+            </p>
+            <p>● the electrons generated with large energy deposition may not be extracted into the gas region completely. The rest of the electrons gather on the liquid surface and are released into the gas randomly, producing electroluminescent directly.</p>
+         </sec>
+      </sec>
+      <sec id="cpc_46_10_103001_s04">
+         <label>IV.</label>
+         <title>ESTIMATION OF ACCIDENTALBACKGROUND</title>
+         <p>
+            Since the isolated signals are independent from each other, the level of accidental background can be calculated by the rates of isolated
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M48.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M49.jpg" xlink:type="simple" />
+            </inline-formula>
+            signals, assuming they follow a uniform distribution over time in a selected period with same run conditions. Estimation of the rates of these signals becomes important in this study.
+         </p>
+         <p>
+            For each of the data taking runs, the average rates
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \bar{r}_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M50.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \bar{r}_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M52.jpg" xlink:type="simple" />
+            </inline-formula>
+            for isolated
+            <italic toggle="yes">S1</italic>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M53.jpg" xlink:type="simple" />
+            </inline-formula>
+            , respectively, are computed by the time weighted average of the corresponding rates:
+         </p>
+         <p>
+            <disp-formula>
+               <label>1</label>
+               <tex-math id="cpc_46_10_103001_E1">
+                  <?CDATA $ \bar{r}_1 = \frac{1}{\displaystyle\sum_i T_i}\sum_i r_{1i}\cdot T_i, $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103001_E1.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            <disp-formula>
+               <label>2</label>
+               <tex-math id="cpc_46_10_103001_E2">
+                  <?CDATA $ \bar{r}_2 = \frac{1}{\displaystyle\sum_i T_i}\sum_i r_{2i}\cdot T_i, $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103001_E2.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            where
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ T_i $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M54.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ r_{1i} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M55.jpg" xlink:type="simple" />
+            </inline-formula>
+            , and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ r_{2i} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M56.jpg" xlink:type="simple" />
+            </inline-formula>
+            are the duration, and rates of isolated
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M57.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M58.jpg" xlink:type="simple" />
+            </inline-formula>
+            for each selected period
+            <italic toggle="yes">i</italic>
+            , respectively. The uncertainties of the rates are calculated as the unbiased standard errors of the mean value.
+         </p>
+         <sec id="cpc_46_10_103001_s04-01">
+            <label>A.</label>
+            <title>
+               Tagging of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA ${\boldsymbol S}{\bf 1}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M59.jpg" xlink:type="simple" />
+               </inline-formula>
+            </title>
+            <p>
+               To calculate the rate of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M60.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we need to recognize this type of signal correctly in the data. Three methods have been developed to search for the isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M61.jpg" xlink:type="simple" />
+               </inline-formula>
+               within the range of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ (3,100) $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M62.jpg" xlink:type="simple" />
+               </inline-formula>
+               PE, which covers the energy region of searching for dark matter. One is based on a special type of "random trigger" data set, with the event triggered by hardware randomly. The other two methods are based on the dark matter search data. We describe these three methods here.
+            </p>
+            <sec id="cpc_46_10_103001_s04-01-01">
+               <label>1.</label>
+               <title>Method 1</title>
+               <p>
+                  This method is used to search isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M63.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  events in the random trigger data. The events should satisfy all the required data quality cuts mentioned in Ref. [
+                  <xref ref-type="bibr" rid="cpc_46_10_103001_bib4">4</xref>
+                  ]. The rate
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ r_1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M64.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  in one run can be calculated easily by
+                  <sup>
+                     <xref ref-type="fn" rid="cpc_46_10_103001_pn2">②</xref>
+                  </sup>
+               </p>
+               <p>
+                  <disp-formula>
+                     <label>3</label>
+                     <tex-math id="cpc_46_10_103001_E3">
+                        <?CDATA $ r_1 = \frac{n_{iS 1}}{T}, $?>
+                     </tex-math>
+                     <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103001_E3.jpg" xlink:type="simple" />
+                  </disp-formula>
+               </p>
+               <p>
+                  where
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ n_{iS 1} $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M65.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  is the number of qualified isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M66.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  , and
+                  <italic toggle="yes">T</italic>
+                  is the live time of the random trigger events. This method is unbiased, and is used to estimate the accidental background level in Run 10 [
+                  <xref ref-type="bibr" rid="cpc_46_10_103001_bib5">5</xref>
+                  ]. Due to the short time of data taking with random trigger, the long term evolution of the rate can not be extracted. No random trigger data taking was performed in Run 9, so this method can only work in Runs 10 and 11.
+               </p>
+            </sec>
+            <sec id="cpc_46_10_103001_s04-01-02">
+               <label>2.</label>
+               <title>Method 2</title>
+               <p>
+                  In this method, the isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M67.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  is defined as small
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M68.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  signals before the triggered
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M69.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  , which has no paired
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 2 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M70.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  within the window of maximum drift time (see
+                  <xref ref-type="fig" rid="cpc_46_10_103001_f2">Fig. 2</xref>
+                  ). The triggered
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M71.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  should be larger than 100 PE. The time difference
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ \Delta t $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M72.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  (see
+                  <xref ref-type="fig" rid="cpc_46_10_103001_f3">Fig. 3</xref>
+                  ) between the isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M73.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  and the triggered
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M74.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  is used directly in the simulation of accidental background by pairing the selected isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M75.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  and
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 2 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M76.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  signals (see following section). Therefore, we require that
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ \Delta t $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M77.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  be within the window of
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ (10,\;350) $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M78.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  μs for Run 9 or
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ (10,\;360) $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M79.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  μs for Runs 10 and 11 before the triggered
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M80.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  by considering the cut on the drifting time.
+               </p>
+               <fig id="cpc_46_10_103001_f2" orientation="portrait" position="float">
+                  <label>Fig. 2</label>
+                  <caption id="cpc_46_10_103001_fc2">
+                     <p>
+                        (color online) Schematic view on the search of isolated
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M81.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        in events triggered by unpaired
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M82.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1_{\rm max} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M83.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        ) in Runs 10 and 11. The event has a fixed time window of 1 ms, and the trigger window is within
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ (490,510) $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M84.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        μs. The symbols "
+                        <italic toggle="yes">A</italic>
+                        " and "
+                        <italic toggle="yes">B</italic>
+                        " indicate the searching window for isolated
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M85.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        .
+                     </p>
+                  </caption>
+                  <graphic content-type="print" id="cpc_46_10_103001_f2_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f2.eps" xlink:type="simple" />
+                  <graphic content-type="online" id="cpc_46_10_103001_f2_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f2.jpg" xlink:type="simple" />
+               </fig>
+               <fig id="cpc_46_10_103001_f3" orientation="portrait" position="float">
+                  <label>Fig. 3</label>
+                  <caption id="cpc_46_10_103001_fc3">
+                     <p>
+                        (color online) Distribution of the time difference
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \Delta t $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M86.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        between the isolated
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M87.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        and the triggered
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M88.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        in method 2.
+                     </p>
+                  </caption>
+                  <graphic content-type="print" id="cpc_46_10_103001_f3_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f3.eps" xlink:type="simple" />
+                  <graphic content-type="online" id="cpc_46_10_103001_f3_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f3.jpg" xlink:type="simple" />
+               </fig>
+               <p>
+                  The rate
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ r_1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M89.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  of isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M90.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  in one data taking period, each consisting of several adjacent runs with nearly identical running conditions, can be estimated by
+               </p>
+               <p>
+                  <disp-formula>
+                     <label>4</label>
+                     <tex-math id="cpc_46_10_103001_E4">
+                        <?CDATA $ r_{1} = \frac{n_{iS 1}}{n_{tS 1}}\cdot \frac{1}{\Delta t_{AB}}, $?>
+                     </tex-math>
+                     <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103001_E4.jpg" xlink:type="simple" />
+                  </disp-formula>
+               </p>
+               <p>
+                  where
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ n_{iS 1} $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M91.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  is the number of isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M92.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  ,
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ n_{tS 1} $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M93.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  is the number of events triggered by unpaired
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M94.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  , and
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ \Delta t_{AB} $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M95.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  is size of the time window, which equals to
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 340 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M96.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  μs for Run 9, and
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 350 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M97.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  μs for Runs 10 and 11. The data taking periods have similar duration.
+               </p>
+               <p>
+                  This method was used in the first analysis of PandaX-II [
+                  <xref ref-type="bibr" rid="cpc_46_10_103001_bib6">6</xref>
+                  ]. By studying the distribution of
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ \Delta t $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M98.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  in
+                  <xref ref-type="fig" rid="cpc_46_10_103001_f3">Fig. 3</xref>
+                  , we found that the number of events decreased with increasing
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ \Delta t $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M99.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  , indicating the possible physical correlation between some selected
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M100.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  s. This phenomenon becomes obvious in Run 11 due to the long data taking time. The correlation may come from the
+                  <sup>214</sup>
+                  Bi-
+                  <sup>214</sup>
+                  Po cascade decay in the region below the cathode (region 2 in
+                  <xref ref-type="fig" rid="cpc_46_10_103001_f1">Fig. 1</xref>
+                  ). A half-life of
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 173.59\pm12.53 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M101.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  μs is obtained by fitting the decay component of the time distribution, and the value is consistent with the half-life of
+                  <sup>214</sup>
+                  Po (164 μs). Thus, the hypothesis is supported, and method 2 results in an over-estimated rate of isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M102.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  . The average rate could be corrected by subtracting the contribution from the
+                  <sup>214</sup>
+                  Bi-
+                  <sup>214</sup>
+                  Po events, with additional uncertainty introduced by the correction.
+               </p>
+            </sec>
+            <sec id="cpc_46_10_103001_s04-01-03">
+               <label>3.</label>
+               <title>Method 3</title>
+               <p>
+                  This method searches for isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M103.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  before a good event, which is triggered by an
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M104.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  signal larger than 100 PE and paired with an
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 2 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M105.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  signal larger than
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 10,000 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M106.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  PE (see
+                  <xref ref-type="fig" rid="cpc_46_10_103001_f4">Fig. 4</xref>
+                  for details). The isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M107.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  is required to be before the maximum drift time of the
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 2 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M108.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  signal, i.e., 350 μs for Run 9 and 360 μs for Runs 10 and 11, to ensure no correlation between the isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M109.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  and the
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 2 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M110.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  in the good event. The cascaded decays of
+                  <sup>214</sup>
+                  Bi-
+                  <sup>214</sup>
+                  Po could not enter into the data selection because two large
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 2 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M111.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  signals are expected if they occur in the sensitive region.
+               </p>
+               <fig id="cpc_46_10_103001_f4" orientation="portrait" position="float">
+                  <label>Fig. 4</label>
+                  <caption id="cpc_46_10_103001_fc4">
+                     <p>
+                        (color online) Schematic view on the search of isolated
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M112.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        in events triggered by
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M113.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S1_{\rm max} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M114.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        ) in Runs 10 and 11.
+                     </p>
+                  </caption>
+                  <graphic content-type="print" id="cpc_46_10_103001_f4_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f4.eps" xlink:type="simple" />
+                  <graphic content-type="online" id="cpc_46_10_103001_f4_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f4.jpg" xlink:type="simple" />
+               </fig>
+               <p>
+                  In this method, the rate
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ r_1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M115.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  in a data taking period can be estimated as
+               </p>
+               <p>
+                  <disp-formula>
+                     <label>5</label>
+                     <tex-math id="cpc_46_10_103001_E5">
+                        <?CDATA $ \begin{equation} r_1 = \frac{n_{iS 1}}{ \sum{(t_{S 2} - \Delta t_{A2}})}, \end{equation} $?>
+                     </tex-math>
+                     <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103001_E5.jpg" xlink:type="simple" />
+                  </disp-formula>
+               </p>
+               <p>
+                  where
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ n_{iS 1} $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M116.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  is the total number of isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M117.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  . The variables of time are defined in each of the good events, with
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ t_{S 2} $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M118.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  as the start time of the
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 2 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M119.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  signal relative to the start of the event, and
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ \Delta t_{A2} $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M120.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  as the size of the exclusion window, which takes the same value as the maximum drift time.
+               </p>
+               <p>
+                  We studied the distribution of time difference
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ \Delta t $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M121.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  between the isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M122.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  and the good
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M123.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  , as shown in
+                  <xref ref-type="fig" rid="cpc_46_10_103001_f5">Fig. 5</xref>
+                  . Considering the uniformity separation of the physical
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M124.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  and
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 2 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M125.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  signals, the requirement of the isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M126.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  outside the maximum drift window reduces the probability of isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M127.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  s with a small
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ \Delta t $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M128.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  being selected. Because the selection window is reduced in the same time, the rate calculation is not affected. This behavior is reproduced with a simple toy MC simulation by randomly sampling
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 2 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M129.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  after the triggered
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M130.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  in the drift window and randomly sampling isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M131.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  in the whole event window, especially for Run 9. The same MC simulation can also be used to verify the rate calculation. Assuming the rate of isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M132.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  is 500 Hz, the rate calculated with method 3 is
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 498.9 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M133.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  Hz, showing a good accuracy. For Run 10, this behavior is not visible owing to the relative low statistics of the isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M134.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  . For Run 11, excess isolated
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ S 1 $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M135.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  s (
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 11.6\% $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M136.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  ) are observed for
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $\Delta t \lt 120$?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103001_M137.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  μs, which are found in the events accumulated in the cathode region, as illustrated in
+                  <xref ref-type="fig" rid="cpc_46_10_103001_fA1">Fig. A1</xref>
+                  in Appendix A. The origin of these signals is still unknown.
+               </p>
+               <fig id="cpc_46_10_103001_f5" orientation="portrait" position="float">
+                  <label>Fig. 5</label>
+                  <caption id="cpc_46_10_103001_fc5">
+                     <p>
+                        (color online) Distribution of the time difference
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \Delta t $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M169.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        between the isolated
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M170.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        and triggered
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M171.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        in method 3. (a) Raw distribution. (b) The integration of the distribution is normalized to 1.
+                     </p>
+                  </caption>
+                  <graphic content-type="print" id="cpc_46_10_103001_f5_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f5.eps" xlink:type="simple" />
+                  <graphic content-type="online" id="cpc_46_10_103001_f5_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f5.jpg" xlink:type="simple" />
+               </fig>
+               <fig id="cpc_46_10_103001_fA1" orientation="portrait" position="float">
+                  <label>Fig. A1</label>
+                  <caption id="cpc_46_10_103001_fcA1">
+                     <p>
+                        (color online) Distribution of the time difference between
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1_{\rm max} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M255.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        and
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 2_{\rm max} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M256.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        at the condition where time difference between the isolated
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M257.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        and
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ S 1_{\rm max} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M258.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        is smaller than 120 μs (
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \Delta t \lt 120 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103001_M259.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        μs) in method 3. The pink dashed line represents the maximum drift time.
+                     </p>
+                  </caption>
+                  <graphic content-type="print" id="cpc_46_10_103001_fA1_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_fA1.eps" xlink:type="simple" />
+                  <graphic content-type="online" id="cpc_46_10_103001_fA1_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_fA1.jpg" xlink:type="simple" />
+               </fig>
+            </sec>
+         </sec>
+         <sec id="cpc_46_10_103001_s04-02">
+            <label>B.</label>
+            <title>
+               Tagging of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\boldsymbol S}{\bf 2} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M138.jpg" xlink:type="simple" />
+               </inline-formula>
+            </title>
+            <p>
+               The estimation of the rate
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ r_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M139.jpg" xlink:type="simple" />
+               </inline-formula>
+               for isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M140.jpg" xlink:type="simple" />
+               </inline-formula>
+               is more straightforward in comparison with isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M141.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The events triggered by unpaired
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M142.jpg" xlink:type="simple" />
+               </inline-formula>
+               , with all the related quality cuts applied, are selected to calculate the rate. The rate is defined as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>6</label>
+                  <tex-math id="cpc_46_10_103001_E6">
+                     <?CDATA $ r_{2} = \frac{n_{iS 2}}{T}, $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103001_E6.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               where
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $n_{iS 2}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M143.jpg" xlink:type="simple" />
+               </inline-formula>
+               is the number of events that satisfy the selection criteria, and
+               <italic toggle="yes">T</italic>
+               is the duration of the run.
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103001_s04-03">
+            <label>C.</label>
+            <title>Properties of isolated signals</title>
+            <p>
+               The estimated average rates of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M144.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M145.jpg" xlink:type="simple" />
+               </inline-formula>
+               in each run are presented in
+               <xref ref-type="table" rid="cpc_46_10_103001_t1">Table 1</xref>
+               . Run 9 has the highest rate of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M146.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which is very likely to be attributed to the higher dark rate of PMTs operating with a higher gain [
+               <xref ref-type="bibr" rid="cpc_46_10_103001_bib5">5</xref>
+               ]. For Runs 10 and 11, the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \bar{r}_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M147.jpg" xlink:type="simple" />
+               </inline-formula>
+               values calculated with methods 1 and 3 are consistent with each other within uncertainty. The results of method 3 are used in the final analysis of PandaX-II [
+               <xref ref-type="bibr" rid="cpc_46_10_103001_bib4">4</xref>
+               ] and in the rest of this study to estimate the rate of accidental background. The variance of the average rates of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M148.jpg" xlink:type="simple" />
+               </inline-formula>
+               is small.
+            </p>
+            <table-wrap id="cpc_46_10_103001_t1" orientation="portrait" position="float">
+               <label>Table 1</label>
+               <caption id="cpc_46_10_103001_tc1">
+                  <p>
+                     Average rates of isolated
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $ S 1 $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M149.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     and
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $ S 2 $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M150.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     extracted from PandaX-II data. The results from method 2 have been corrected by subtracting the contamination from the possible
+                     <sup>214</sup>
+                     Bi-
+                     <sup>214</sup>
+                     Po cascade decay signals.
+                  </p>
+               </caption>
+               <table>
+                  <thead>
+                     <tr>
+                        <th align="center" colspan="1" rowspan="2" valign="middle">Run</th>
+                        <th align="center" colspan="1" rowspan="2" valign="middle">Duration/d</th>
+                        <th align="center" colspan="3" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \bar{r}_1 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M151.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           /Hz
+                        </th>
+                        <th align="center" colspan="1" rowspan="2" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \bar{r}_2 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M152.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           /Hz
+                        </th>
+                     </tr>
+                     <tr>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Method 1</th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Method 2</th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Method 3</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">9</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">79.6</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">−</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 1.40\pm0.25 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M153.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 1.53\pm0.16 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M154.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 0.0121\pm0.0002 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M155.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">10</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">77.1</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 0.46\pm0.05 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M156.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 0.27\pm0.20 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M157.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 0.47\pm0.02 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M158.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 0.0130\pm0.0007 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M159.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">11</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">244.2</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 0.77\pm0.06 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M160.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 0.37\pm0.16 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M161.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 0.69\pm0.06 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M162.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 0.0121\pm0.0001 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M163.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </table-wrap>
+            <p>
+               A more detailed evolution of the rates of the isolated signals during the whole PandaX-II data taking period, with those of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M164.jpg" xlink:type="simple" />
+               </inline-formula>
+               calculated by method 3, is presented in
+               <xref ref-type="fig" rid="cpc_46_10_103001_f6">Fig. 6</xref>
+               . The rate of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M165.jpg" xlink:type="simple" />
+               </inline-formula>
+               remains stable, while that of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M166.jpg" xlink:type="simple" />
+               </inline-formula>
+               varies greatly. The large variance of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ r_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M167.jpg" xlink:type="simple" />
+               </inline-formula>
+               in Run 9 might come from the occasional sparking of electrodes or PMTs. A peak rate of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M168.jpg" xlink:type="simple" />
+               </inline-formula>
+               is observed in Run 11, which can be explained by the fact that some PMTs were unstable during the corresponding period, as shown in
+               <xref ref-type="fig" rid="cpc_46_10_103001_fA2">Fig. A2</xref>
+               in Appendix A. The ordinary data quality cut cannot remove related events efficiently.
+            </p>
+            <fig id="cpc_46_10_103001_f6" orientation="portrait" position="float">
+               <label>Fig. 6</label>
+               <caption id="cpc_46_10_103001_fc6">
+                  <p>(color online) Evolution of rates of the isolated signals during the whole PandaX-II data taking period, selected by method 3.</p>
+               </caption>
+               <graphic content-type="print" id="cpc_46_10_103001_f6_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f6.eps" xlink:type="simple" />
+               <graphic content-type="online" id="cpc_46_10_103001_f6_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f6.jpg" xlink:type="simple" />
+            </fig>
+            <fig id="cpc_46_10_103001_fA2" orientation="portrait" position="float">
+               <label>Fig. A2</label>
+               <caption id="cpc_46_10_103001_fcA2">
+                  <p>(color online) Accumulated charge pattern in the top PMT array of all isolated S1s from Mar. 11, 2018 to Apr. 6, 2018. Three PMTs are observed to have the largest contribution to these signals.</p>
+               </caption>
+               <graphic content-type="print" id="cpc_46_10_103001_fA2_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_fA2.eps" xlink:type="simple" />
+               <graphic content-type="online" id="cpc_46_10_103001_fA2_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_fA2.jpg" xlink:type="simple" />
+            </fig>
+            <p>
+               The charge spectra of the isolated signals selected by method 3 are shown in
+               <xref ref-type="fig" rid="cpc_46_10_103001_f7">Fig. 7</xref>
+               . Most of the isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M172.jpg" xlink:type="simple" />
+               </inline-formula>
+               are found to be smaller than 10 PE. All of the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M173.jpg" xlink:type="simple" />
+               </inline-formula>
+               spectra have a similar shape when the charge is larger than 6 PE, but a higher peak is observed below 6 PE for Run 9. This may be explained by the higher chance of accidental coincidence of hits from dark current in this run due to the higher operation voltage of the PMTs. A small peak in Run 11 around 10 PE results from the unstable PMTs mentioned before (see
+               <xref ref-type="fig" rid="cpc_46_10_103001_fA3">Fig. A3</xref>
+               in Appendix A). The spectra of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M174.jpg" xlink:type="simple" />
+               </inline-formula>
+               are consistent with each other.
+            </p>
+            <fig id="cpc_46_10_103001_f7" orientation="portrait" position="float">
+               <label>Fig. 7</label>
+               <caption id="cpc_46_10_103001_fc7">
+                  <p>(color online) Charge spectra of isolated signals selected by method 3.</p>
+               </caption>
+               <graphic content-type="print" id="cpc_46_10_103001_f7_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f7.eps" xlink:type="simple" />
+               <graphic content-type="online" id="cpc_46_10_103001_f7_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f7.jpg" xlink:type="simple" />
+            </fig>
+            <fig id="cpc_46_10_103001_fA3" orientation="portrait" position="float">
+               <label>Fig. A3</label>
+               <caption id="cpc_46_10_103001_fcA3">
+                  <p>
+                     (color online) Accumulated charge pattern in the top PMT array of isolated S1s in the window of
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $ (10, 12) $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M260.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     PE in Run 11. Three PMTs are observed to have the largest contribution to these signals.
+                  </p>
+               </caption>
+               <graphic content-type="print" id="cpc_46_10_103001_fA3_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_fA3.eps" xlink:type="simple" />
+               <graphic content-type="online" id="cpc_46_10_103001_fA3_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_fA3.jpg" xlink:type="simple" />
+            </fig>
+         </sec>
+         <sec id="cpc_46_10_103001_s04-04">
+            <label>D.</label>
+            <title>Study of the accidental background with simulation</title>
+            <p>
+               A data-driven MC simulation with the selected isolated signals is used to study the accidental background events. For each run, the isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M175.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M176.jpg" xlink:type="simple" />
+               </inline-formula>
+               are paired randomly, with the time separation between them sampled uniformly in the time window
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \Delta t_w $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M177.jpg" xlink:type="simple" />
+               </inline-formula>
+               defined by the fiducial volume cut. The horizontal position of the event is determined by the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M178.jpg" xlink:type="simple" />
+               </inline-formula>
+               signal. The paired mock event is treated as an event with raw signals. The same position-dependent charge corrections and quality cuts for dark matter search data are applied to these events, resulting in a cut efficiency
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \epsilon $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M179.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               Then, the total number of accidental background events
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ n_{\rm{acc}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M180.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be calculated by
+            </p>
+            <p>
+               <disp-formula>
+                  <label>7</label>
+                  <tex-math id="cpc_46_10_103001_E7">
+                     <?CDATA $ \begin{equation} n_{\rm{acc}} = \bar{r}_1\cdot \bar{r}_2 \cdot \Delta t_{w} \cdot T \cdot \epsilon. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103001_E7.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               The efficiency
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \epsilon $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M181.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the total number of accidental events, and the number of events below the median line of the NR band from calibration data [
+               <xref ref-type="bibr" rid="cpc_46_10_103001_bib4">4</xref>
+               ] results, are presented in
+               <xref ref-type="table" rid="cpc_46_10_103001_t2">Table 2</xref>
+               . Run 11 has the largest number of accidental background events because it has the largest duration
+               <italic toggle="yes">T</italic>
+               .
+            </p>
+            <table-wrap id="cpc_46_10_103001_t2" orientation="portrait" position="float">
+               <label>Table 2</label>
+               <caption id="cpc_46_10_103001_tc2">
+                  <p>Number of accidental events estimated with the selected isolated signals using method 3.</p>
+               </caption>
+               <table>
+                  <thead>
+                     <tr>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Run</th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Type</th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \epsilon $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M182.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ n_{\rm{acc}} $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M183.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="2" valign="middle">9</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">total</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">21.9%</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 8.15\pm0.94 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M184.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">below NR median</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">3.5%</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 1.31\pm0.15 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M185.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="2" valign="middle">10</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">total</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">25.6%</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 3.16\pm0.15 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M186.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">below NR median</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">8.5%</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 1.06\pm0.05 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M187.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="2" valign="middle">11</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">total</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">18.2%</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 9.87\pm0.89 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M188.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">below NR median</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">5.6%</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 2.93\pm0.27 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M189.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </table-wrap>
+            <p>
+               The distributions of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \log_{10}(S 2/S 1) $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M190.jpg" xlink:type="simple" />
+               </inline-formula>
+               vs.
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M191.jpg" xlink:type="simple" />
+               </inline-formula>
+               for the simulated accidental background events after all the quality cuts within the dark matter search window [
+               <xref ref-type="bibr" rid="cpc_46_10_103001_bib4">4</xref>
+               ] are given in
+               <xref ref-type="fig" rid="cpc_46_10_103001_f8">Fig. 8</xref>
+               , together with those of the NR calibration data. Most of the accidental events have a relatively small
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M192.jpg" xlink:type="simple" />
+               </inline-formula>
+               charge and are above the NR median. Considering the low statistics of the most critical ER backgrounds below the NR median, the non-negligible accidental background in this region will reduce the discovery power for WIMPs. Suppressing these background events could improve the sensitivity of the detector for WIMP search.
+            </p>
+            <fig id="cpc_46_10_103001_f8" orientation="portrait" position="float">
+               <label>Fig. 8</label>
+               <caption id="cpc_46_10_103001_fc8">
+                  <p>
+                     (color online) Distribution of
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $ \log_{10}(S 2/S 1) $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M193.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     vs.
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $ S 1 $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M194.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     for the simulated accidental background and NR calibration data. The red curves are the corresponding NR median for each run.
+                  </p>
+               </caption>
+               <graphic content-type="print" id="cpc_46_10_103001_f8_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f8.eps" xlink:type="simple" />
+               <graphic content-type="online" id="cpc_46_10_103001_f8_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f8.jpg" xlink:type="simple" />
+            </fig>
+         </sec>
+      </sec>
+      <sec id="cpc_46_10_103001_s05">
+         <label>V.</label>
+         <title>SUPPRESSION OF ACCIDENTAL BACKGROUND WITH BDT</title>
+         <p>
+            The accidental events are composed of isolated
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M195.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M196.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Since there is no physical correlation between the two signals, we would expect there to be a method that is able to distinguish them from the physical events by considering the joint distributions of the properties of these signals. However, because all of the selected accidental events have passed the quality cuts, it is difficult to differentiate between any single property of the signals from accidental and physical events. A multi-variant analysis can be a possible solution. The BDT algorithm, one of the most successful multi-variant analysis methods used in particle physics [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib18">18</xref>
+            ], was first used to suppress the accidental background in the first analysis results of PandaX-II [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib6">6</xref>
+            ]. The real signal of the WIMP-nucleon scattering is NR, thus the single scattering events from NR calibration runs (AmBe) should be used as input signals in  machine learning, with randomly paired events as backgrounds. Given the fact that the ER events dominate the region above the NR median in the dark matter search data and the relatively low estimated number of accidental events in the region, we only distinguish the accidental background from the physical NR events below the NR median.
+         </p>
+         <sec id="cpc_46_10_103001_s05-01">
+            <label>A.</label>
+            <title>Variables</title>
+            <p>
+               The TMVA (Toolkit for Multivariate Data Analysis) package in ROOT is used to perform the BDT machine learning [
+               <xref ref-type="bibr" rid="cpc_46_10_103001_bib19">19</xref>
+               ]. A set of signal properties are exploited to search for the difference between the accidental events and the physical NR events, including：
+            </p>
+            <p>
+               ● corrected charge of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M197.jpg" xlink:type="simple" />
+               </inline-formula>
+               (qS1);
+            </p>
+            <p>
+               ● corrected charge of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S 2$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M198.jpg" xlink:type="simple" />
+               </inline-formula>
+               (qS2);
+            </p>
+            <p>
+               ● raw charge of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S 1$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M199.jpg" xlink:type="simple" />
+               </inline-formula>
+               (qS1R);
+            </p>
+            <p>
+               ● raw charge of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S 2$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M200.jpg" xlink:type="simple" />
+               </inline-formula>
+               (qS2R);
+            </p>
+            <p>
+               ● width of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S 2$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M201.jpg" xlink:type="simple" />
+               </inline-formula>
+               (wS2);
+            </p>
+            <p>
+               ● full width at tenth maximum of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S 2$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M202.jpg" xlink:type="simple" />
+               </inline-formula>
+               (wTenS2);
+            </p>
+            <p>
+               ● asymmetry between the top and bottom charges for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S 1$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M203.jpg" xlink:type="simple" />
+               </inline-formula>
+               (S1TBA);
+            </p>
+            <p>
+               ● ratio of the top charge to the bottom charge for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S 2$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M204.jpg" xlink:type="simple" />
+               </inline-formula>
+               (S2TBR);
+            </p>
+            <p>
+               ● the ratio of the pre-max-height charge to the total charge of an
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S 2$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M205.jpg" xlink:type="simple" />
+               </inline-formula>
+               signal (S2SY1 in the directly summed over waveform, S2SY2 in the smoothed waveform);
+            </p>
+            <p>
+               ● number of local maximums (peaks) of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S 1$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M206.jpg" xlink:type="simple" />
+               </inline-formula>
+               (S1NPeaks);
+            </p>
+            <p>
+               ● ratio of the largest charge collected by the bottom PMT of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S 1$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M207.jpg" xlink:type="simple" />
+               </inline-formula>
+               to total charge of
+               <italic toggle="yes">S</italic>
+               1 (S1LargestBCQ).
+            </p>
+            <p>
+               The distributions of the these variables for the events below the NR median can be found in
+               <xref ref-type="fig" rid="cpc_46_10_103001_f9">Fig. 9</xref>
+               , and their correlations are presented in
+               <xref ref-type="fig" rid="cpc_46_10_103001_fA5">Fig. A5</xref>
+               .
+            </p>
+            <fig id="cpc_46_10_103001_f9" orientation="portrait" position="float">
+               <label>Fig. 9</label>
+               <caption id="cpc_46_10_103001_fc9">
+                  <p>(color online) Distribution of the selected variables from the NR calibration data (signal) and the simulated accidental events (background) in Run 11. Only the events below the NR median were selected.</p>
+               </caption>
+               <graphic content-type="print" id="cpc_46_10_103001_f9_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f9.eps" xlink:type="simple" />
+               <graphic content-type="online" id="cpc_46_10_103001_f9_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f9.jpg" xlink:type="simple" />
+            </fig>
+            <fig id="cpc_46_10_103001_fA5" orientation="portrait" position="float">
+               <label>Fig. A5</label>
+               <caption id="cpc_46_10_103001_fcA5">
+                  <p>(color online) Correlations between the variables used for BDT training, from the events below the NR median.</p>
+               </caption>
+               <graphic content-type="print" id="cpc_46_10_103001_fA5_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_fA5.eps" xlink:type="simple" />
+               <graphic content-type="online" id="cpc_46_10_103001_fA5_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_fA5.jpg" xlink:type="simple" />
+            </fig>
+         </sec>
+         <sec id="cpc_46_10_103001_s05-02">
+            <label>B.</label>
+            <title>BDT results</title>
+            <p>
+               We constructed the adaptive BDT using the default parameters provided by the official ROOT TMVA classification example, except the parameter of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $\texttt{NTrees}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M208.jpg" xlink:type="simple" />
+               </inline-formula>
+               (number of trees). We trained the data for the three runs independently, each with a predefined set of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $\texttt{NTrees}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M209.jpg" xlink:type="simple" />
+               </inline-formula>
+               . After the training, the resulted BDT response distributions of the training and test data samples were superimposed, and the Kolmogorov-Smirnov (K-S) test was performed to check for overtraining (see
+               <xref ref-type="fig" rid="cpc_46_10_103001_fA4">Fig. A4</xref>
+               for details). We chose
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $\texttt{NTrees} =90 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M210.jpg" xlink:type="simple" />
+               </inline-formula>
+               for further study. With the trained BDT, the "likelihood" estimators can be calculated for an input event to be classified. The best cut criterion for the estimator was obtained with the test data set by maximizing the significance
+               <italic toggle="yes">S</italic>
+               ,
+            </p>
+            <fig id="cpc_46_10_103001_fA4" orientation="portrait" position="float">
+               <label>Fig. A4</label>
+               <caption id="cpc_46_10_103001_fcA4">
+                  <p>(color online) The distributions of BDT response of the train and test data samples. The K-S test probabilities are used to indicate the overtraining.</p>
+               </caption>
+               <graphic content-type="print" id="cpc_46_10_103001_fA4_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_fA4.eps" xlink:type="simple" />
+               <graphic content-type="online" id="cpc_46_10_103001_fA4_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_fA4.jpg" xlink:type="simple" />
+            </fig>
+            <p>
+               <disp-formula>
+                  <label>8</label>
+                  <tex-math id="cpc_46_10_103001_E8">
+                     <?CDATA $ S = \frac{\epsilon_s n_s}{\sqrt{\epsilon_s n_s + \epsilon_b n_b}}, $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103001_E8.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               where
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ n_s $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M211.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ n_b $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M212.jpg" xlink:type="simple" />
+               </inline-formula>
+               are the number of signal and background events, respectively, and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \epsilon_s $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M213.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \epsilon_b $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M214.jpg" xlink:type="simple" />
+               </inline-formula>
+               are the efficiencies for signal and background events at a given estimator value, respectively. In this study, the expected signal events below the NR median are likely to be the neutron background or the WIMP events, and they are estimated at the same level as the accidental background [
+               <xref ref-type="bibr" rid="cpc_46_10_103001_bib4">4</xref>
+               ]. Therefore, the identical numbers
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ n_s $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M215.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ n_b $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M216.jpg" xlink:type="simple" />
+               </inline-formula>
+               are used to calculate the significance. The evolution of the background rejection efficiency with the signal efficiency at different BDT cut values is shown in
+               <xref ref-type="fig" rid="cpc_46_10_103001_f10">Fig. 10</xref>
+               . The results at the maximum significance
+               <italic toggle="yes">S</italic>
+               are presented in
+               <xref ref-type="table" rid="cpc_46_10_103001_t3">Table 3</xref>
+               . The BDT algorithm is able to remove
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ 70\% $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M217.jpg" xlink:type="simple" />
+               </inline-formula>
+               of the accidental background events, while keeping about
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ 90\% $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M218.jpg" xlink:type="simple" />
+               </inline-formula>
+               of the single scattering NR events below the NR median curve in all of the three runs. The distributions of the BDT cut efficiency on the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \log_{10}(S 2/S 1) $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M219.jpg" xlink:type="simple" />
+               </inline-formula>
+               vs.
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M220.jpg" xlink:type="simple" />
+               </inline-formula>
+               plane for the simulated accidental background are shown in
+               <xref ref-type="fig" rid="cpc_46_10_103001_f11">Fig. 11</xref>
+               .
+            </p>
+            <fig id="cpc_46_10_103001_f10" orientation="portrait" position="float">
+               <label>Fig. 10</label>
+               <caption id="cpc_46_10_103001_fc10">
+                  <p>(color online) The evolution of the background rejection efficiency with the signal efficiency at different BDT cuts for different runs. The initial numbers of background and signal events are assumed to be identical.</p>
+               </caption>
+               <graphic content-type="print" id="cpc_46_10_103001_f10_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f10.eps" xlink:type="simple" />
+               <graphic content-type="online" id="cpc_46_10_103001_f10_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f10.jpg" xlink:type="simple" />
+            </fig>
+            <table-wrap id="cpc_46_10_103001_t3" orientation="portrait" position="float">
+               <label>Table 3</label>
+               <caption id="cpc_46_10_103001_tc3">
+                  <p>
+                     The significance
+                     <italic toggle="yes">S</italic>
+                     , signal efficiencies
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $ \epsilon_s $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M221.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     , and background rejection efficiencies
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $ 1-\epsilon_b $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M222.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     at the best cut value of the estimator for events below the NR median lines, assuming
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $ n_s=n_b $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M223.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     .
+                  </p>
+               </caption>
+               <table>
+                  <thead>
+                     <tr>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Run</th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">
+                           <italic toggle="yes">S</italic>
+                        </th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \epsilon_s $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M224.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ 1-\epsilon_b $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103001_M225.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">9</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">25.9</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">90.4%</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">70.2%</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">10</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">26.5</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">91.1%</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">74.6%</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">11</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">26.2</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">90.7%</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">73.7%</td>
+                     </tr>
+                  </tbody>
+               </table>
+            </table-wrap>
+            <fig id="cpc_46_10_103001_f11" orientation="portrait" position="float">
+               <label>Fig. 11</label>
+               <caption id="cpc_46_10_103001_fc11">
+                  <p>
+                     (color online) BDT cut efficiency map on the
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $\log_{10}(S 2/S 1)$?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M250.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     vs.
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $S 1$?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M251.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     distribution for the simulated accidental background.
+                  </p>
+               </caption>
+               <graphic content-type="print" id="cpc_46_10_103001_f11_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f11.eps" xlink:type="simple" />
+               <graphic content-type="online" id="cpc_46_10_103001_f11_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f11.jpg" xlink:type="simple" />
+            </fig>
+            <p>
+               The contribution of each input variable to the discrimination power is extracted by the BDT training. The variables wS2, S2SY2, and S1TBA are found to be the most critical to the recognition of accidental backgrounds. By checking the distributions of these variables, isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M226.jpg" xlink:type="simple" />
+               </inline-formula>
+               signals are found to have a smaller width (wS2) and more asymmetrical shape (S2SY2) in comparison with those in normal events, indicating that most of these signals are generated near the grid wires [
+               <xref ref-type="bibr" rid="cpc_46_10_103001_bib20">20</xref>
+               ]. The peak in the S1TBA distribution of physical events at the value of -1 suggests a large fraction of the physical
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M227.jpg" xlink:type="simple" />
+               </inline-formula>
+               signals have no hits on the top PMT array. Given the fact that physical
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M228.jpg" xlink:type="simple" />
+               </inline-formula>
+               s are produced inside the liquid xenon, small signals have a smaller chance of being detected by the top PMTs due to the total reflection on the surface between the liquid and gas xenon. However, some of the non-physical
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M229.jpg" xlink:type="simple" />
+               </inline-formula>
+               s are from the coincidence of dark noises on top PMTs, resulting in a S1TBA larger than -1. The distribution of S1TBA could be used to estimate the fraction of isolated
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M230.jpg" xlink:type="simple" />
+               </inline-formula>
+               s from the coincidence of dark noise on top PMTs. This phenomenon helps to distinguish the non-physical small
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M231.jpg" xlink:type="simple" />
+               </inline-formula>
+               signals from the real ones.
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103001_s05-03">
+            <label>C.</label>
+            <title>Overall results</title>
+            <p>
+               In the analysis, the BDT cut is applied to not only the events below the NR median but to all events in the search window. The efficiencies of BDT for different types of events are extracted by using the calibration data sets, shown in
+               <xref ref-type="fig" rid="cpc_46_10_103001_f12">Fig. 12</xref>
+               . The BDT cut efficiencies for the ER and NR calibration data, expressed as functions of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M232.jpg" xlink:type="simple" />
+               </inline-formula>
+               , are used to build the final signal model [
+               <xref ref-type="bibr" rid="cpc_46_10_103001_bib21">21</xref>
+               ]. The efficiencies for ER events are lower than those of NR events when
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 \lt 8 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M233.jpg" xlink:type="simple" />
+               </inline-formula>
+               PE, in all of the data set. From the 2D efficiency maps, it is observed that in the region of low
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M234.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the ER events with a higher ratio of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2/S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M235.jpg" xlink:type="simple" />
+               </inline-formula>
+               are suppressed heavily in Runs 10 and 11. On the contrary, more ER events with smaller
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2/S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M236.jpg" xlink:type="simple" />
+               </inline-formula>
+               in the same region are suppressed in Run 9. The different distributions of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M237.jpg" xlink:type="simple" />
+               </inline-formula>
+               related variables of the different ER calibration data may result in the different efficiencies. The distributions of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \log_{10}(S 2/S 1) $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M238.jpg" xlink:type="simple" />
+               </inline-formula>
+               vs.
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ S 1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M239.jpg" xlink:type="simple" />
+               </inline-formula>
+               of accidental background after the BDT cut are used directly in the model.
+            </p>
+            <fig id="cpc_46_10_103001_f12" orientation="portrait" position="float">
+               <label>Fig. 12</label>
+               <caption id="cpc_46_10_103001_fc12">
+                  <p>
+                     (color online) The BDT cut efficiency curves as a function of
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $ S 1 $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M252.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     and efficiency maps on the
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $ \log_{10}(S 2/S 1) $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M253.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     versus
+                     <inline-formula>
+                        <tex-math>
+                           <?CDATA $ S 1 $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_10_103001_M254.jpg" xlink:type="simple" />
+                     </inline-formula>
+                     for different calibration data in the dark matter search window for different runs.
+                  </p>
+               </caption>
+               <graphic content-type="print" id="cpc_46_10_103001_f12_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f12.eps" xlink:type="simple" />
+               <graphic content-type="online" id="cpc_46_10_103001_f12_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103001_f12.jpg" xlink:type="simple" />
+            </fig>
+            <p>
+               The expected numbers of accidental background (below NR median) in the PandaX-II full exposure data set after the BDT cuts are
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ 2.09\pm0.25 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M240.jpg" xlink:type="simple" />
+               </inline-formula>
+               (
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ 0.39\pm0.05 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M241.jpg" xlink:type="simple" />
+               </inline-formula>
+               ),
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ 1.03\pm0.05 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M242.jpg" xlink:type="simple" />
+               </inline-formula>
+               (
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ 0.27\pm0.01 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M243.jpg" xlink:type="simple" />
+               </inline-formula>
+               ), and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ 2.53\pm0.24 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M244.jpg" xlink:type="simple" />
+               </inline-formula>
+               (
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ 0.77\pm0.07 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103001_M245.jpg" xlink:type="simple" />
+               </inline-formula>
+               ) for Runs 9, 10, and 11, respectively. The total number of expected accidental background events below the NR median is smaller than 1.5. Considering that the total data taking period of PandaX-II is 244.2 days, we have successfully suppressed the accidental background to a trivial level and improved the final sensitivity for dark matter search [
+               <xref ref-type="bibr" rid="cpc_46_10_103001_bib4">4</xref>
+               ].
+            </p>
+         </sec>
+      </sec>
+      <sec id="cpc_46_10_103001_s06">
+         <label>VI.</label>
+         <title>SUMMARY AND OUTLOOK</title>
+         <p>
+            The accidental background is an important composition of the backgrounds in the dark matter search experiments with a dual phase xenon detector. In this study, we discussed the possible origins of the two components, isolated
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M246.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M247.jpg" xlink:type="simple" />
+            </inline-formula>
+            , and developed methods to estimate the level of accidental background in the PandaX-II experiment. The BDT algorithm is used to distinguish this non-physical background from real NR signals below the NR median lines, so that the level of this background is suppressed greatly.
+         </p>
+         <p>
+            We found that the rate of isolated
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M248.jpg" xlink:type="simple" />
+            </inline-formula>
+            is much higher in Run 9, during which the PMTs run with higher gains than in other runs. This suggests the coincident combination of hits created by dark noise contributes to a large amount of the isolated
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S 1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103001_M249.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Thus, reducing the dark noise of PMTs is critical for next generation of experiments [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib22">22</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib24">24</xref>
+            ].
+         </p>
+         <p>
+            The BDT method works well in the suppression of the accidental background in our study. The analysis framework and suppression method can be used in the data analysis of the subsequent PandaX-4T experiment [
+            <xref ref-type="bibr" rid="cpc_46_10_103001_bib25">25</xref>
+            ]. Because the number of accidental events is nearly proportional to the operation time, only a few of them have been produced in the commissioning run, and have been suppressed to a very low level with the quality cuts. Therefore, this method is not used in the first PandaX-4T WIMP search. However, PandaX-4T and other similar experiments will be running much longer than PandaX-II, and our study provides a valuable reference for them. With the rapid development of machine learning methods in recent years, we may expect neural networks or other machine learning algorithms to achieve equivalent success in this topic.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103001_s08">
+         <title>ACKNOWLEDGMENT</title>
+         <p>
+            <italic toggle="yes">We are grateful for the support from the Double First Class Plan of the Shanghai Jiao Tong University. We are also thankful for the sponsorship from the Chinese Academy of Sciences Center for Excellence in Particle Physics (CCEPP), Hongwen Foundation in Hong Kong, and Tencent Foundation in China. Finally, we thank the CJPL administration and the Yalong River Hydropower Development Company Ltd. for indispensable logistical support and other assistance.</italic>
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103001_s09">
+         <label>APPENDIX A:.</label>
+         <title>Complementary plots</title>
+      </sec>
+   </body>
+   <back>
+      <fn-group>
+         <fn id="cpc_46_10_103001_pn1">
+            <p>We use the term of "width" in following text to represent this concept.</p>
+         </fn>
+         <fn id="cpc_46_10_103001_pn2">
+            <p>
+               The subscript "
+               <italic toggle="yes">i</italic>
+               " is omitted in following formulas.
+            </p>
+         </fn>
+      </fn-group>
+      <ref-list>
+         <title>References</title>
+         <ref id="cpc_46_10_103001_bib1">
+            <label>[1]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Liu</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Chen</surname>
+                     <given-names>X.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Ji</surname>
+                     <given-names>X.</given-names>
+                  </name>
+               </person-group>
+               <source>Nature Phys.</source>
+               <year>2017</year>
+               <volume>13</volume>
+               <fpage>212</fpage>
+               <pub-id pub-id-type="doi">10.1038/nphys4039</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib2">
+            <label>[2]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>J. Kang</surname>
+                     <given-names>K.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>J. Phys. Conf. Ser.</source>
+               <year>2010</year>
+               <volume>203</volume>
+               <fpage>012028</fpage>
+               <pub-id pub-id-type="doi">10.1088/1742-6596/203/1/012028</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib3">
+            <label>[3]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Zhao</surname>
+                     <given-names>L.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Liu</surname>
+                     <given-names>J.</given-names>
+                  </name>
+               </person-group>
+               <source>Front. Phys. (Beijing)</source>
+               <year>2020</year>
+               <volume>15</volume>
+               <fpage>44301</fpage>
+               <pub-id pub-id-type="doi">10.1007/s11467-020-0960-x</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2004.04547" xlink:type="simple">2004.04547</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib4">
+            <label>[4]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Wang (PandaX-Ⅱ collaboration)</surname>
+                     <given-names>Qiuhong</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>Chin. Phys. C</source>
+               <year>2020</year>
+               <volume>44</volume>
+               <fpage>125001</fpage>
+               <pub-id pub-id-type="doi">10.1088/1674-1137/abb658</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2007.15469" xlink:type="simple">2007.15469</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib5">
+            <label>[5]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>PandaX-Ⅱ</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. Lett.</source>
+               <year>2017</year>
+               <volume>119</volume>
+               <fpage>181302</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevLett.119.181302</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1708.06917" xlink:type="simple">1708.06917</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib6">
+            <label>[6]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>PandaX-Ⅱ</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. Lett.</source>
+               <year>2016</year>
+               <volume>117</volume>
+               <fpage>121303</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevLett.117.121303</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1607.07400" xlink:type="simple">1607.07400</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib7">
+            <label>[7]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>PandaX</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev.D</source>
+               <year>2016</year>
+               <volume>93</volume>
+               <fpage>122009</fpage>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1602.06563" xlink:type="simple">1602.06563</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib8">
+            <label>[8]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>LUX</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. Lett.</source>
+               <year>2017</year>
+               <volume>118</volume>
+               <fpage>021303</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevLett.118.021303</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib9">
+            <label>[9]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>XENON</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. Lett.</source>
+               <year>2018</year>
+               <volume>121</volume>
+               <fpage>111302</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevLett.121.111302</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib10">
+            <label>[10]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>XENON</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. Lett.</source>
+               <year>2017</year>
+               <volume>119</volume>
+               <fpage>181301</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevLett.119.181301</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1705.06655" xlink:type="simple">1705.06655</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib11">
+            <label>[11]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Aprile</surname>
+                     <given-names>E.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Doke</surname>
+                     <given-names>T.</given-names>
+                  </name>
+               </person-group>
+               <source>Rev. Mod. Phys.</source>
+               <year>2010</year>
+               <volume>82</volume>
+               <fpage>2053</fpage>
+               <pub-id pub-id-type="doi">10.1103/RevModPhys.82.2053</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/0910.4956" xlink:type="simple">0910.4956</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib12">
+            <label>[12]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Aprile</surname>
+                     <given-names>E.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>E. Dahl</surname>
+                     <given-names>C.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>DeViveiros</surname>
+                     <given-names>L.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>Phys. Rev. Lett.</source>
+               <year>2006</year>
+               <volume>97</volume>
+               <fpage>081302</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevLett.97.081302</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/astro-ph/0601552" xlink:type="simple">astro-ph/0601552</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib13">
+            <label>[13]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>PandaX</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2015</year>
+               <volume>92</volume>
+               <fpage>052004</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.92.052004</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1505.00771" xlink:type="simple">1505.00771</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib14">
+            <label>[14]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>GEANT4</given-names>
+                  </name>
+               </person-group>
+               <source>Nucl. Instrum. Meth. A</source>
+               <year>2003</year>
+               <volume>506</volume>
+               <fpage>250</fpage>
+               <pub-id pub-id-type="doi">10.1016/S0168-9002(03)01368-8</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib15">
+            <label>[15]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Allison</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>IEEE Trans. Nucl. Sci.</source>
+               <year>2006</year>
+               <volume>53</volume>
+               <fpage>270</fpage>
+               <pub-id pub-id-type="doi">10.1109/TNS.2006.869826</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib16">
+            <label>[16]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>PandaX-Ⅱ</given-names>
+                  </name>
+               </person-group>
+               <source>Sci. China Phys. Mech. Astron.</source>
+               <year>2020</year>
+               <volume>63</volume>
+               <fpage>231011</fpage>
+               <pub-id pub-id-type="doi">10.1007/s11433-019-9603-9</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1907.00545" xlink:type="simple">1907.00545</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib17">
+            <label>[17]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Zhang</surname>
+                     <given-names>D.</given-names>
+                  </name>
+               </person-group>
+               <source>JINST</source>
+               <year>2019</year>
+               <volume>14</volume>
+               <fpage>C10039</fpage>
+               <pub-id pub-id-type="doi">10.1088/1748-0221/14/10/C10039</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib18">
+            <label>[18]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>P. Roe</surname>
+                     <given-names>B.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Yang</surname>
+                     <given-names>H.-J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Zhu</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>Nucl. Instrum. Meth. A</source>
+               <year>2005</year>
+               <volume>543</volume>
+               <fpage>577</fpage>
+               <pub-id pub-id-type="doi">10.1016/j.nima.2004.12.018</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/physics/0408124" xlink:type="simple">physics/0408124</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib19">
+            <label>[19]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>
+                  A. Hocker
+                  <italic toggle="yes">et al</italic>
+                  .,
+                  <italic toggle="yes">TMVA - Toolkit for Multivariate Data Analysis</italic>
+                  , physics/0703039
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib20">
+            <label>[20]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>LUX</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2021</year>
+               <volume>104</volume>
+               <fpage>012011</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.104.012011</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2011.09602" xlink:type="simple">2011.09602</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib21">
+            <label>[21]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>PandaX-Ⅱ</given-names>
+                  </name>
+               </person-group>
+               <source>Chin. Phys. C</source>
+               <year>2021</year>
+               <volume>45</volume>
+               <fpage>075001</fpage>
+               <pub-id pub-id-type="doi">10.1088/1674-1137/abf6c2</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2102.09158" xlink:type="simple">2102.09158</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib22">
+            <label>[22]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>PandaX</given-names>
+                  </name>
+               </person-group>
+               <source>Sci. China Phys. Mech. Astron.</source>
+               <year>2019</year>
+               <volume>62</volume>
+               <fpage>31011</fpage>
+               <pub-id pub-id-type="doi">10.1007/s11433-018-9259-0</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib23">
+            <label>[23]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>
+                  B. J. Mount
+                  <italic toggle="yes">et al</italic>
+                  .,
+                  <italic toggle="yes">LUX-ZEPLIN (LZ) Technical Design Report</italic>
+                  , arXiv: 1703.09144
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib24">
+            <label>[24]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>XENON</given-names>
+                  </name>
+               </person-group>
+               <source>JCAP</source>
+               <year>2020</year>
+               <volume>11</volume>
+               <fpage>031</fpage>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103001_bib25">
+            <label>[25]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>collaboration</surname>
+                     <given-names>PandaX-4T</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. Lett.</source>
+               <year>2021</year>
+               <volume>127</volume>
+               <fpage>261802</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevLett.127.261802</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2107.13438" xlink:type="simple">2107.13438</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+      </ref-list>
+   </back>
+</article>

--- a/tests/units/iop/data/without_arxiv.xml
+++ b/tests/units/iop/data/without_arxiv.xml
@@ -1,0 +1,3752 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" xml:lang="en">
+	<front>
+		<journal-meta>
+			<journal-id journal-id-type="publisher-id">cpc</journal-id>
+			<journal-title-group>
+				<journal-title xml:lang="en">Chinese Physics C</journal-title>
+			</journal-title-group>
+			<issn pub-type="ppub">1674-1137</issn>
+			<publisher>
+				<publisher-name>Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</publisher-name>
+			</publisher>
+		</journal-meta>
+		<article-meta>
+			<article-id pub-id-type="publisher-id">cpc_46_9_093112</article-id>
+			<article-id pub-id-type="doi">10.1088/1674-1137/ac7547</article-id>
+			<article-id pub-id-type="manuscript">ac7547</article-id>
+			<article-categories>
+				<subj-group subj-group-type="display-article-type">
+					<subject>Paper</subject>
+				</subj-group>
+				<subj-group subj-group-type="section">
+					<subject>Particles and fields</subject>
+				</subj-group>
+			</article-categories>
+			<title-group>
+				<article-title>
+					Exploring fermionic multiplet dark matter through precision measurements at the CEPC
+					<xref ref-type="fn" rid="cpc_46_9_093112_fn1">*</xref>
+					<fn id="cpc_46_9_093112_fn1">
+						<label>*</label>
+						<p>The work of LQG and XJB is Supported by the National Natural Science Foundation of China (12175248); The work of JWW is Supported by the research grant "the Dark Universe: A Synergic Multi-messenger Approach" number (2017X7X85K) under the program PRIN 2017 funded by the Ministero dell'Istruzione, Universitàe della Ricerca (MIUR)</p>
+					</fn>
+				</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Gao</surname>
+						<given-names>Lin-Qing</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>高</surname>
+						<given-names>林青</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+					<email>gaolq@ihep.ac.cn</email>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Bi</surname>
+						<given-names>Xiao-Jun</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>毕</surname>
+						<given-names>效军</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<xref ref-type="aff" rid="affiliation02">2</xref>
+					<email>bixj@ihep.ac.cn</email>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Wang</surname>
+						<given-names>Jin-Wei</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>王</surname>
+						<given-names>金伟</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation03">3</xref>
+					<xref ref-type="aff" rid="affiliation04">4</xref>
+					<xref ref-type="aff" rid="affiliation05">5</xref>
+					<email>jinwei.wang@sissa.it</email>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Xiang</surname>
+						<given-names>Qian-Fei</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>向</surname>
+						<given-names>仟飞</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation06">6</xref>
+					<email>xiangqf@pku.edu.cn</email>
+				</contrib>
+				<contrib contrib-type="author" xlink:type="simple">
+					<name name-style="western">
+						<surname>Yin</surname>
+						<given-names>Peng-Fei</given-names>
+					</name>
+					<name content-type="non-latin-no-space" name-style="eastern">
+						<surname>殷</surname>
+						<given-names>鹏飞</given-names>
+					</name>
+					<xref ref-type="aff" rid="affiliation01">1</xref>
+					<email>yinpf@ihep.ac.cn</email>
+				</contrib>
+				<aff id="affiliation01">
+					<label>1</label>
+
+					<institution xlink:type="simple">Key Laboratory of Particle Astrophysics, Institute of High Energy Physics, Chinese Academy of Sciences</institution>
+					, Beijing 100049,
+					<country>China</country>
+				</aff>
+				<aff id="affiliation02">
+					<label>2</label>
+
+					<institution xlink:type="simple">School of Physical Sciences, University of Chinese Academy of Sciences</institution>
+					, Beijing 100049,
+					<country>China</country>
+				</aff>
+				<aff id="affiliation03">
+					<label>3</label>
+
+					<institution xlink:type="simple">Scuola Internazionale Superiore di Studi Avanzati (SISSA), via Bonomea 265</institution>
+					, 34136 Trieste,
+					<country>Italy</country>
+				</aff>
+				<aff id="affiliation04">
+					<label>4</label>
+
+					<institution xlink:type="simple">INFN, Sezione di Trieste, via Valerio 2</institution>
+					, 34127 Trieste,
+					<country>Italy</country>
+				</aff>
+				<aff id="affiliation05">
+					<label>5</label>
+
+					<institution xlink:type="simple">Institute for Fundamental Physics of the Universe (IFPU), via Beirut 2</institution>
+					, 34151 Trieste,
+					<country>Italy</country>
+				</aff>
+				<aff id="affiliation06">
+					<label>6</label>
+
+					<institution xlink:type="simple">Center for High Energy Physics, Peking University</institution>
+					, Beijing 100871,
+					<country>China</country>
+				</aff>
+			</contrib-group>
+			<pub-date pub-type="ppub">
+				<day>01</day>
+				<month>9</month>
+				<year>2022</year>
+			</pub-date>
+			<pub-date pub-type="open-access">
+				<day>19</day>
+				<month>7</month>
+				<year>2022</year>
+			</pub-date>
+			<volume>46</volume>
+			<issue>9</issue>
+			<elocation-id content-type="artnum">093112</elocation-id>
+			<history>
+				<date date-type="received">
+					<day>17</day>
+					<month>2</month>
+					<year>2022</year>
+				</date>
+				<date date-type="published-online">
+					<day>19</day>
+					<month>7</month>
+					<year>2022</year>
+				</date>
+				<date date-type="oa-requested">
+					<day>17</day>
+					<month>2</month>
+					<year>2022</year>
+				</date>
+			</history>
+			<permissions>
+				<copyright-statement>© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</copyright-statement>
+				<copyright-year>2022</copyright-year>
+				<license license-type="cc-by" xlink:href="http://creativecommons.org/licenses/by/3.0/" xlink:type="simple">
+					<license-p>
+						<graphic content-type="online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_ccby.tif" xlink:type="simple" />
+						Content from this work may be used under the terms of the
+						<ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/3.0" xlink:type="simple">Creative Commons Attribution 3.0 licence</ext-link>
+						. Any further distribution of this work must maintain attribution to the author(s) and the title of the work, journal citation and DOI. Article funded by SCOAP
+						<sup>3</sup>
+						and published under licence by Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+					</license-p>
+				</license>
+			</permissions>
+			<self-uri content-type="pdf" xlink:href="cpc_46_9_093112.pdf" xlink:type="simple" />
+			<abstract>
+				<title>Abstract</title>
+				<p>
+					New physics could be explored through loop effects using the precision measurements at the Circular Electron Positron Collider (CEPC) owing to its clean collision environment and high luminosity. In this paper, we focus on two dark matter models that involve additional electroweak fermionic multiplets. We calculate their one-loop corrections in five processes, i.e.,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+e^- \to \mu^+\mu^-, \; Zh, \; W^+W^-, \; ZZ $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M1.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Z\gamma $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M2.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and investigate the corresponding signatures at the CEPC with the projected sensitivity. We observe that the detectable parameter regions of these processes are complementary. The combined analysis shows that the mass of dark matter
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_{\chi^0_1} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M3.jpg" xlink:type="simple" />
+					</inline-formula>
+					in these two models can be probed up to
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sim 150\; {\rm{GeV}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M4.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sim 450 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M5.jpg" xlink:type="simple" />
+					</inline-formula>
+					GeV, respectively, at a 95% confidence level.
+				</p>
+			</abstract>
+			<kwd-group kwd-group-type="author">
+				<kwd>CEPC</kwd>
+				<kwd>dark matter</kwd>
+				<kwd>loop correction</kwd>
+			</kwd-group>
+			<funding-group>
+				<open-access>
+					<p content-type="scoap3">
+						Article funded by SCOAP
+						<sup>3</sup>
+					</p>
+				</open-access>
+			</funding-group>
+			<counts>
+				<page-count count="14" />
+			</counts>
+		</article-meta>
+	</front>
+	<body>
+		<sec id="cpc_46_9_093112_s01">
+			<label>I.</label>
+			<title>INTRODUCTION</title>
+			<p>
+				The discovery of the Higgs boson at the Large Hadron Collider (LHC) marked a significant success for the standard model (SM) of particle physics [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib1">1</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib2">2</xref>
+				]. However, the existence of dark matter (DM), which has been revealed by many astrophysical and cosmological observations, clearly shows that the SM is not a complete theory and the new physics (NP) beyond the SM must exist [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib3">3</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib4">4</xref>
+				]. Under the assumption that DM is an unknown particle, its properties would be effectively detected at colliders, particularly when its mass is smaller than the center of mass energy of the collider. If this is not the case, the properties of DM might also be investigated through the loop effects at the proposed electron-positron colliders owing to their high precision, such as the Circular Electron Positron Collider (CEPC) [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib5">5</xref>
+				], Future Circular Collider [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib6">6</xref>
+				], and International Linear Collider [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib7">7</xref>
+				].
+			</p>
+			<p>
+				Among various DM candidates proposed in the literature, weakly interacting massive particles (WIMPs) are very compelling because they can naturally explain the DM relic density (dubbed WIMP miracle). It is natural to construct a WIMP model by introducing a dark sector containing electroweak (EW)
+				<inline-formula>
+					<tex-math>
+						<?CDATA ${S U}(2)_L$?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M6.jpg" xlink:type="simple" />
+				</inline-formula>
+				multiplets, such as the minimal DM model [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib8">8</xref>
+				], which involves one nontrivial
+				<inline-formula>
+					<tex-math>
+						<?CDATA ${S U}(2)_L$?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M7.jpg" xlink:type="simple" />
+				</inline-formula>
+				multiplet and is considered the minimal extension. In this paper, we focus on a type of DM model that contains more than one EW multiplet:
+			</p>
+			<p>
+				● Singlet-doublet fermionic dark matter (SDFDM) model: the dark sector involves one singlet Weyl spinor and two doublet Weyl spinors [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib9">9</xref>
+				–
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib13">13</xref>
+				];
+			</p>
+			<p>
+				● Doublet-triplet fermionic dark matter (DTFDM) model: the dark sector involves two doublet Weyl spinors and one triplet Weyl spinor [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib11">11</xref>
+				–
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib14">14</xref>
+				].
+			</p>
+			<p>
+				Because the even dimensional representation of the
+				<inline-formula>
+					<tex-math>
+						<?CDATA $S U(2)$?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M8.jpg" xlink:type="simple" />
+				</inline-formula>
+				group is pseudoreal, two doublet Weyl spinors are introduced to generate the corresponding mass terms. After EW symmetry breaking (EWSB), the Yukawa terms result in mixing between these multiplets. Specifically, the SDFDM (DTFDM) model contains three neutral Majorana fermions and one (two) charged fermions. With a discrete
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Z_2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M9.jpg" xlink:type="simple" />
+				</inline-formula>
+				symmetry, the lightest Majorana fermion is stable and can be the DM candidate. Considering the possible couplings between dark sector particles and the gauge bosons (e.g.,
+				<italic toggle="yes">W</italic>
+				,
+				<italic toggle="yes">Z</italic>
+				, and
+				<italic toggle="yes">γ</italic>
+				) or Higgs boson, the CEPC is an ideal tool to explore these models because of its accurate measurement and large luminosity.
+			</p>
+			<p>
+				According to it operation plan [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib5">5</xref>
+				], the CEPC will operate in three possible modes: the Higgs factory,
+				<italic toggle="yes">Z</italic>
+				factory, and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ WW $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M10.jpg" xlink:type="simple" />
+				</inline-formula>
+				threshold scan. For the Higgs factory period, the CEPC will run at
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sqrt{s}=240 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M11.jpg" xlink:type="simple" />
+				</inline-formula>
+				GeV for
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ e^+ e^- \to Z h $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M12.jpg" xlink:type="simple" />
+				</inline-formula>
+				production, and the total integrated luminosity can reach
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sim 5.6\; {{\rm{ab}}}^{-1} $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M13.jpg" xlink:type="simple" />
+				</inline-formula>
+				[
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib5">5</xref>
+				]. As a result, the CEPC can collect
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sim 10^6 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M14.jpg" xlink:type="simple" />
+				</inline-formula>
+				Higgs bosons,
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sim 10^7 \mu^+\mu^- $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M15.jpg" xlink:type="simple" />
+				</inline-formula>
+				events,
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sim 3 \times 10^6 ZZ $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M16.jpg" xlink:type="simple" />
+				</inline-formula>
+				events,
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sim 5 \times 10^7 W^+ W^- $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M17.jpg" xlink:type="simple" />
+				</inline-formula>
+				events, and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sim5\times 10^7 Z\gamma $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M18.jpg" xlink:type="simple" />
+				</inline-formula>
+				events. With such many events, the sensitivities of these channels at the CEPC could reach a sub-percentage level. Therefore, the hint of NP could be detected through the loop order processes [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib12">12</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib15">15</xref>
+				–
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib21">21</xref>
+				]. Some recent studies have investigated such effects in the Higgs decay [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib22">22</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib23">23</xref>
+				], EW oblique parameters [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib11">11</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib24">24</xref>
+				],
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ e^+ e^- \to W^+ W^- $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M19.jpg" xlink:type="simple" />
+				</inline-formula>
+				[
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib25">25</xref>
+				,
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib26">26</xref>
+				],
+				<inline-formula>
+					<tex-math>
+						<?CDATA $e^+ e^- \to \mu^+ \mu^-$?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M20.jpg" xlink:type="simple" />
+				</inline-formula>
+				[
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib27">27</xref>
+				–
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib29">29</xref>
+				], etc.
+			</p>
+			<p>
+				In our paper, we investigate the loop effects of the SDFDM and DTFDM models at the CEPC with
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sqrt{s}= 240 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M21.jpg" xlink:type="simple" />
+				</inline-formula>
+				GeV through five processes:
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ e^+e^- \to \mu^+ \mu^-, \; Zh, \; W^+W^-, \; ZZ $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M22.jpg" xlink:type="simple" />
+				</inline-formula>
+				, and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Z \gamma $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M23.jpg" xlink:type="simple" />
+				</inline-formula>
+				. We calculate the deviations of the cross sections of these processes that are induced by the NP sector at one-loop level and provide the combined CEPC constraints at the 95% confidence level. The results show that the constraints of these five processes can be complementary to each other in some parameter regions. Note that the process of
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ e^+e^- \to Zh $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M24-5.jpg" xlink:type="simple" />
+				</inline-formula>
+				has been studied in Ref. [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib12">12</xref>
+				], here we just include the corresponding result for comparison.
+			</p>
+			<p>
+				The remainder of the paper is organized as follows. In Sec. II, we briefly introduce the SDFDM model and calculate its one-loop effects on five SM processes (
+				<inline-formula>
+					<tex-math>
+						<?CDATA $e^+e^- \rightarrow \mu^+ \mu^-$?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_Z-20220615153210.jpg" xlink:type="simple" />
+				</inline-formula>
+				,
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Zh, \; W^+W^-, \; ZZ $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M25.jpg" xlink:type="simple" />
+				</inline-formula>
+				, and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Z \gamma $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M26.jpg" xlink:type="simple" />
+				</inline-formula>
+				) at the CEPC. The combined 95% confidence results at the CEPC are also shown. In Sec. III, we show the results of the DTFDM model. Conclusions and discussions are provided in Sec. IV.
+			</p>
+		</sec>
+		<sec id="cpc_46_9_093112_s02">
+			<label>II.</label>
+			<title>SINGLET-DOUBLET FERMIONIC DARK MATTER MODEL</title>
+			<sec id="cpc_46_9_093112_s02-01">
+				<label>A.</label>
+				<title>Model details</title>
+				<p>
+					In the SDFDM model [
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib9">9</xref>
+					–
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib13">13</xref>
+					], the dark sector contains one singlet Weyl spinor
+					<italic toggle="yes">S</italic>
+					and two doublet Weyl spinors
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ D_i $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M27.jpg" xlink:type="simple" />
+					</inline-formula>
+					(
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ i=1,2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M28.jpg" xlink:type="simple" />
+					</inline-formula>
+					) obeying the following
+					<inline-formula>
+						<tex-math>
+							<?CDATA $S U(2)_L \times U(1)_Y$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M29.jpg" xlink:type="simple" />
+					</inline-formula>
+					gauge transformations:
+				</p>
+				<p>
+					<disp-formula>
+						<label>1</label>
+						<tex-math id="cpc_46_9_093112_E1">
+							<?CDATA $ \begin{aligned}[b] & S\in( {1}, 0) ,\; \; \; \; \; \; D_1=\left( \begin{array}{l} D^0_1 \\ D^-_1 \end{array} \right)\in( {2}, -1) ,\; \; \; \; \; \; \\ & D_2=\left( \begin{array}{l} D^+_2 \\ D^0_2 \end{array} \right) \in( {2}, 1). \end{aligned} $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E1.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					The hypercharge signs of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ D_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M30.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ D_2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M31.jpg" xlink:type="simple" />
+					</inline-formula>
+					are opposite, which guarantees that the SDFDM model is anomaly free. The gauge invariant Lagrangians are given by
+				</p>
+				<p>
+					<disp-formula>
+						<label>2</label>
+						<tex-math id="cpc_46_9_093112_E2">
+							<?CDATA $ \begin{aligned}[b] {\cal{L}}_S = & {\rm i} S^+ \bar{\sigma^{\mu}}D_{\mu}S - \frac{1}{2}(m_s S^T(-\epsilon)S + {\rm h.c.}) , \\ {\cal{L}}_D = & {\rm i} D_1^+ \bar{\sigma^{\mu}}D_{\mu}D_1 +{\rm i} D_2^+ \bar{\sigma^{\mu}}D_{\mu}D_2 \\ & + (m_D D^{iT}_1 (-\epsilon)D^j_2 + {\rm h.c.}) , \\ {\cal{L}}_Y = & y_1 S D_1^i H_i - y_2 S D_2^i \tilde{H_i} + {\rm h.c.}, \end{aligned} $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E2.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<inline-formula>
+						<tex-math>
+							<?CDATA $D_\mu=\partial_\mu -{\rm i} g t^j A^j_\mu -{\rm i} \dfrac{g'}{2}YB_\mu$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M32.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the covariant derivative,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ t^j $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M33.jpg" xlink:type="simple" />
+					</inline-formula>
+					are the generators of the corresponding representation of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $S U(2)_L$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M34.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<italic toggle="yes">Y</italic>
+					is the hypercharge,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $\epsilon \equiv {\rm i}\sigma^2$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M35.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_S $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M36.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M37.jpg" xlink:type="simple" />
+					</inline-formula>
+					are the mass parameters of the singlet and doublets, respectively, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M38.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M39.jpg" xlink:type="simple" />
+					</inline-formula>
+					are two Yukawa couplings between the dark sector particles and Higgs boson. Consequently, this model has four independent parameters:
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_S $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M40.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M41.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M42.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M43.jpg" xlink:type="simple" />
+					</inline-formula>
+					.
+				</p>
+				<p>
+					After EWSB, the Higgs field acquires the vacuum expectation value
+					<italic toggle="yes">v</italic>
+					and can be expressed in the unitary gauge as
+				</p>
+				<p>
+					<disp-formula>
+						<label>3</label>
+						<tex-math id="cpc_46_9_093112_E3">
+							<?CDATA $ \begin{array}{*{20}{l}} H=\dfrac{1}{\sqrt{2}} \left( \begin{array}{c} 0 \\ v+h \end{array} \right),\; \; \; \; \; \; \; \; \; \; \tilde{H}=\dfrac{1}{\sqrt{2}} \left( \begin{array}{c} v+h \\ 0 \end{array} \right). \end{array} $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E3.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>Subsequently, the Yukawa couplings result in mixing between the singlet Weyl spinor and doublet Weyl spinors. The mass terms of the dark sector particles are given by</p>
+				<p>
+					<disp-formula>
+						<label>4</label>
+						<tex-math id="cpc_46_9_093112_E4">
+							<?CDATA $ \begin{aligned}[b] {\cal{L}}_m & = -\frac{1}{2}(S, D_1^0, D_2^0)M_n (-\epsilon) \left( \begin{array}{c} S \\ D_1^0 \\ D_2^0 \end{array} \right) - M_D D_1^- (-\epsilon)D_2^+ + {\rm h.c.} = -\frac{1}{2} m_{\chi^0_i} \sum \chi_i^0 (-\epsilon) \chi_i^0 - m_{\chi^{\pm}} \chi^- (-\epsilon) \chi^+ + {\rm h.c.} , \end{aligned} $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E4.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>where</p>
+				<p>
+					<disp-formula>
+						<label>5</label>
+						<tex-math id="cpc_46_9_093112_E5">
+							<?CDATA $ \begin{array}{*{20}{l}} M_n = \begin{pmatrix} M_S & \dfrac{1}{\sqrt{2}} y_1 v & \dfrac{1}{\sqrt{2}} y_2 v \\ \dfrac{1}{\sqrt{2}} y_1 v & 0 & -M_D \\ \dfrac{1}{\sqrt{2}} y_2 v & -M_D & 0 \\ \end{pmatrix} \end{array} $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E5.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					is the mass matrix of the neutral particles,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^0_i \; (i = 1,\; 2,\; 3) $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M44.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^\pm $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M45.jpg" xlink:type="simple" />
+					</inline-formula>
+					are the mass eigenstates,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_{\chi^0_i} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M46.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_{\chi^\pm} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M47.jpg" xlink:type="simple" />
+					</inline-formula>
+					are the masses of the corresponding mass eignestates. The mass eigenstates of the neutral particles
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi_i^0 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M48.jpg" xlink:type="simple" />
+					</inline-formula>
+					are connected to the gauge eigenstates through the mixing matrix
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ {\cal{N}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M49.jpg" xlink:type="simple" />
+					</inline-formula>
+					. That is,
+				</p>
+				<p>
+					<disp-formula>
+						<label>6</label>
+						<tex-math id="cpc_46_9_093112_E6">
+							<?CDATA $ \begin{array}{*{20}{l}} {\cal{N}}^T M_n {\cal{N}} = {{\rm{diag}}}(m_{\chi^0_1},m_{\chi^0_2},m_{\chi^0_3}), \; \; \; \begin{pmatrix} S \\ D_1^0 \\ D_2^0 \\ \end{pmatrix} = {\cal{N}} \begin{pmatrix} \chi_1^0 \\ \chi_2^0 \\ \chi_3^0 \\ \end{pmatrix}. \end{array} $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E6.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					For convenience, we adopt the mass orders
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_{\chi^0_1} \leq m_{\chi^0_2} \leq m_{\chi^0_3} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M50.jpg" xlink:type="simple" />
+					</inline-formula>
+					, which can be realized by adjusting
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ {\cal{N}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M51.jpg" xlink:type="simple" />
+					</inline-formula>
+					. Because of the discrete
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Z_2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M52.jpg" xlink:type="simple" />
+					</inline-formula>
+					symmetry, the lightest neutral fermion
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^0_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M53.jpg" xlink:type="simple" />
+					</inline-formula>
+					is stable and can be considered a DM candidate. Moreover, we can construct four-component Dirac spinors from two-component Weyl spinors:
+				</p>
+				<p>
+					<disp-formula>
+						<label>7</label>
+						<tex-math id="cpc_46_9_093112_E7">
+							<?CDATA $ \begin{array}{*{20}{l}} \Psi _i = \begin{pmatrix} \chi_i^0 \\ \epsilon (\chi_i^0)^{\dagger T} \\ \end{pmatrix}, \;\;\; \Psi^+ = \begin{pmatrix} \chi^+ \\ \epsilon (\chi^-)^{\dagger T} \end{pmatrix}. \end{array} $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E7.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>Thus, the mass terms and interaction terms of the SDFDM model can be rewritten as</p>
+				<p>
+					<disp-formula>
+						<label>8</label>
+						<tex-math id="cpc_46_9_093112_E8">
+							<?CDATA $ \begin{aligned}[b] {\cal{L}}_{{\rm{SDFDM}}} = & -\frac{1}{2} m_{\chi^0_i} \overline{ \Psi_i} \Psi_i - m_{\chi^\pm} \overline{\Psi^+}\Psi^+ \\ & + -\frac{1}{\sqrt{2}} (y_1 {\cal{N}}_{1i} {\cal{N}}_{2j} + y_2 {\cal{N}}_{1i} {\cal{N}}_{3j}) h \overline{ \Psi_i} \Psi_j \\ & + e A_\mu \overline{\Psi^+}\gamma^\mu \Psi^+ + (g\cos\theta - \frac{g\sin^2\theta}{\cos\theta})Z_\mu \overline{\Psi^+}\gamma^\mu \Psi^+ \\ & + \frac{g}{4\cos\theta} ( {\cal{N}}_{2i}^* {\cal{N}}_{2j} - {\cal{N}}_{3i}^* {\cal{N}}_{3j} ) Z_\mu \overline{\Psi_i^0}\gamma^\mu P_L\Psi_j^0 \\ & - \frac{g}{4\cos\theta} ( {\cal{N}}_{2i}^* {\cal{N}}_{2j} - {\cal{N}}_{3i}^* {\cal{N}}_{3j} ) Z_\mu \overline{\Psi_j^0}\gamma^\mu P_R\Psi_i^0 \\ & - \frac{g}{\sqrt{2}} {\cal{N}}_{2i} W^- \overline{\Psi_i^0}\gamma^\mu P_R \Psi^+ + \frac{g}{\sqrt{2}} {\cal{N}}_{3i}^* W^- \overline{\Psi_i^0}\gamma^\mu P_L \Psi^+ \\ & - \frac{g}{\sqrt{2}} {\cal{N}}_{2i}^* W^+ \overline{\Psi^+}\gamma^\mu P_R \Psi_i^0 + \frac{g}{\sqrt{2}} {\cal{N}}_{3i} W^+ \overline{\Psi^+}\gamma^\mu P_L \Psi_i^0. \end{aligned} $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E8.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+			</sec>
+			<sec id="cpc_46_9_093112_s02-02">
+				<label>B.</label>
+				<title>Detection sensitivity of the CEPC</title>
+				<p>
+					Although the dark sector particle
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi = \{\chi^0_i,\; \chi^\pm\} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M54.jpg" xlink:type="simple" />
+					</inline-formula>
+					cannot be directly produced at the collider when
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 2m_{\chi} \gt \sqrt{s} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M55.jpg" xlink:type="simple" />
+					</inline-formula>
+					, it can still affect the cross sections of the SM processes through loop effects, which means that the hint of dark sector particles may be revealed through precision measurements. In this paper, we focus on five processes,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+ e^- \rightarrow \mu^+\mu^-, \; Zh, \; W^+W^-, \; ZZ, $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M56.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Z\gamma $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M57.jpg" xlink:type="simple" />
+					</inline-formula>
+					at the CEPC, and calculate the deviation of the cross section induced by the dark sector particles from the SM prediction at the one-loop level. The corresponding Feynman diagrams of one-loop contributions are given in Appendix A. By utilizing the high precision of the CEPC, these deviations can consequently provide effective constraints on the parameter space of the new physical model. In our calculations, the Packages FeynArts 3.10 [
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib30">30</xref>
+					], FormCalc 9.7 [
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib31">31</xref>
+					], and LoopTools 2.15 [
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib31">31</xref>
+					] are used to generate Feynman diagrams and derive the numerical results. Note that the entire calculation is performed under the on-shell renormalization scheme.
+				</p>
+				<p>The cross section at the next to leading order with the EW correction can be expressed as</p>
+				<p>
+					<disp-formula>
+						<label>9</label>
+						<tex-math id="cpc_46_9_093112_E9">
+							<?CDATA $ \begin{array}{*{20}{l}} \sigma = \sigma_{{{\rm{LO}}}}+\sigma_{{\rm{NLO}}}^{{\rm{EW}}}+\sigma_{{\rm{NLO}}}^{{\rm{Soft}}}, \end{array} $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E9.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sigma_{{{\rm{LO}}}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M58.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the tree-level cross section,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sigma_{{\rm{NLO}}}^{{\rm{EW}}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M59.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the EW correction at the one-loop level.
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sigma_{{\rm{NLO}}}^{{\rm{Soft}}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M60.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the contribution from the soft bremsstrahlung diagrams, which cancels the infrared divergences originating from the diagrams with the exchange of virtual photons. The deviation of the cross-section from the SM prediction can be expressed as
+				</p>
+				<p>
+					<disp-formula>
+						<label>10</label>
+						<tex-math id="cpc_46_9_093112_E10">
+							<?CDATA $ \frac{\Delta\sigma}{\sigma_0} = \frac{\mid \sigma_{{{\rm{SDFDM}}}}-\sigma_{{{\rm{SM}}}} \mid}{\sigma_{{{\rm{SM}}}}}, $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E10.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sigma_{{{\rm{SDFDM}}}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M61.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sigma_{{{\rm{SM}}}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M62.jpg" xlink:type="simple" />
+					</inline-formula>
+					are the one-loop cross sections of the SDFDM model and SM, respectively (see (9)). For the five processes considered here, the leading contributions to
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \Delta \sigma $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M63.jpg" xlink:type="simple" />
+					</inline-formula>
+					result from the interferences between the SM amplitudes at the leading order and the amplitudes involving the particles in the dark sector.
+				</p>
+				<p>
+					Note that for the process
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+ e^- \to Z \gamma $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M64.jpg" xlink:type="simple" />
+					</inline-formula>
+					, the cross section contains collinear divergence even at the tree-level. However, considering that the collinear photons cannot be detected owing to the blind spot of the detector, the collinear divergence can be removed by excluding the collinear photons. Here, we calculate the cross section with
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ |\cos\theta_{\gamma}| \lt 0.99 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M65.jpg" xlink:type="simple" />
+					</inline-formula>
+					, where
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \theta_{\gamma} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M66.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the angle between the photon and beam.
+				</p>
+				<p>
+					The precision of the CEPC is determined by the statistical and systematic uncertainties. In this analysis, we treat these uncertainties as independent numbers. The statistical uncertainty can be estimated from the predicted event numbers
+					<italic toggle="yes">N</italic>
+					, that is,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sim 1/\sqrt{N} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M67.jpg" xlink:type="simple" />
+					</inline-formula>
+					, whereas the systematic uncertainties are primarily from the uncertainty of integrated luminosity and the misidentification of final states. Thereinto, the integrated luminosity uncertainty at the CEPC is
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sim 0.1\% $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M68.jpg" xlink:type="simple" />
+					</inline-formula>
+					[
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib5">5</xref>
+					]. For the process of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+ e^- \to \mu^+ \mu^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M69.jpg" xlink:type="simple" />
+					</inline-formula>
+					, the misidentification uncertainty can be ignored owing to the excellent capability of the muon reconstruction. Note that the leptonic and semileptonic decays of the gauge bosons can also be well reconstructed, whereas distinguishing the two jets from one gauge boson in the pure hadronic decay is difficult. For simplicity, in our analysis, we consider only the cross sections from leptonic and semileptonic decays; thus, the reconstruction of the gauge bosons would have a high efficiency. In this case, we assume that the systematic uncertainties of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+ e^- \to W^+W^-,\; ZZ $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M70.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Z\gamma $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M71.jpg" xlink:type="simple" />
+					</inline-formula>
+					are only from integrated luminosity
+					<sup>
+						<xref ref-type="fn" rid="cpc_46_9_093112_pn2">②</xref>
+					</sup>
+					.
+				</p>
+				<p>
+					According to the number of events in Sec. I, the statistical uncertainties of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+ e^- \to \mu^+ \mu^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M73.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ W^+W^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M74.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ ZZ $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M75.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Z\gamma $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M76.jpg" xlink:type="simple" />
+					</inline-formula>
+					are estimated as 0.032%,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 0.014\% $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M77.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 0.059\% $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M78.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 0.014\% $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M79.jpg" xlink:type="simple" />
+					</inline-formula>
+					, respectively. Combined with the systematic uncertainties, the corresponding precision of these processes are about
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 0.1\% $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M80.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 0.1\% $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M81.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 0.12\% $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M82.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 0.1\% $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M83.jpg" xlink:type="simple" />
+					</inline-formula>
+					. The precision of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+ e^- \to Zh $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M84.jpg" xlink:type="simple" />
+					</inline-formula>
+					is given as 0.5% by Ref. [
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib5">5</xref>
+					].
+				</p>
+			</sec>
+			<sec id="cpc_46_9_093112_s02-03">
+				<label>C.</label>
+				<title>Numerical results</title>
+				<p>
+					In this section, we study the capability of the CEPC to probe the parameter space of the SDFDM model. Considering that the SDFDM model has four free parameters, i.e.,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_1,\; y_2,\; m_S, $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M85.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M86.jpg" xlink:type="simple" />
+					</inline-formula>
+					, we propose to show the calculation results of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \Delta \sigma/\sigma_{{\rm{SM}}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M87.jpg" xlink:type="simple" />
+					</inline-formula>
+					on the Yukawa plane (
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_1-y_2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M88.jpg" xlink:type="simple" />
+					</inline-formula>
+					) or/and mass plane (
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_S-m_D $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M89.jpg" xlink:type="simple" />
+					</inline-formula>
+					). Here, we select three sets of benchmark parameters: (1)
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_1 = 1.0 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M90.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_2 = 0.5 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M91.jpg" xlink:type="simple" />
+					</inline-formula>
+					; (2)
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ M_S = 100 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M92.jpg" xlink:type="simple" />
+					</inline-formula>
+					GeV and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ M_D = 400 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M93.jpg" xlink:type="simple" />
+					</inline-formula>
+					GeV; (3)
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ M_S = 400 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M94.jpg" xlink:type="simple" />
+					</inline-formula>
+					GeV and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ M_D = 200 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M95.jpg" xlink:type="simple" />
+					</inline-formula>
+					GeV. Considering that the Yukawa interaction induced mass mixing between the singlet and doublets (see Eq. (2)) are at the order of the EWSB scale
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sim {\cal{O}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M96.jpg" xlink:type="simple" />
+					</inline-formula>
+					(100) GeV, the benchmark parameters (2) and (3) represent the DM candidate
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^0_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M97.jpg" xlink:type="simple" />
+					</inline-formula>
+					that is roughly singlet-dominated and doublet-dominated, respectively. The corresponding results are shown in
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					,
+					<xref ref-type="fig" rid="cpc_46_9_093112_f3">Fig. 3</xref>
+					, and
+					<xref ref-type="fig" rid="cpc_46_9_093112_f4">Fig. 4</xref>
+					.
+				</p>
+				<fig id="cpc_46_9_093112_f1" orientation="portrait" position="float">
+					<label>Fig. 1</label>
+					<caption id="cpc_46_9_093112_fc1">
+						<p>
+							(color online) Heat maps for the relative deviation of
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ e^+e^- \to \mu^+\mu^-,\; Zh,\; W^+W^-, \; ZZ $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M98.jpg" xlink:type="simple" />
+							</inline-formula>
+							, and
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ Z\gamma $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M99.jpg" xlink:type="simple" />
+							</inline-formula>
+							are shown in (a)
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \sim $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M100.jpg" xlink:type="simple" />
+							</inline-formula>
+							(e). The colored regions indicate that
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \Delta \sigma/\sigma_0 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M101.jpg" xlink:type="simple" />
+							</inline-formula>
+							is larger than the expected sensitivities of the CEPC. The dot dashed lines in (c) (d) (e) correspond to a conservative estimate with
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \Delta \sigma/\sigma_0 = 0.5 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M102.jpg" xlink:type="simple" />
+							</inline-formula>
+							%. The combined result of all these channels at the 95% confidence level is shown in (f), where the dot dashed line represents the mass contour of
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ \chi^0_1 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M103.jpg" xlink:type="simple" />
+							</inline-formula>
+							. The regions below the dotted black line are excluded by the search for charged particles at the LEP [
+							<xref ref-type="bibr" rid="cpc_46_9_093112_bib32">32</xref>
+							]. The solid black lines indicate constraints from conservative estimation. All these results are derived with fixed Yukawa couplings of
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ y_1 = 1.0 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M104.jpg" xlink:type="simple" />
+							</inline-formula>
+							and
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ y_2 = 0.5 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M105.jpg" xlink:type="simple" />
+							</inline-formula>
+							.
+						</p>
+					</caption>
+					<graphic content-type="print" id="cpc_46_9_093112_f1_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_f1.eps" xlink:type="simple" />
+					<graphic content-type="online" id="cpc_46_9_093112_f1_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_f1.jpg" xlink:type="simple" />
+				</fig>
+				<fig id="cpc_46_9_093112_f3" orientation="portrait" position="float">
+					<label>Fig. 3</label>
+					<caption id="cpc_46_9_093112_fc3">
+						<p>
+							(color online) Same as
+							<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+							, but in the
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ y_1-y_2 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M108.jpg" xlink:type="simple" />
+							</inline-formula>
+							plane with the fixed mass parameters of
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ M_S = 100 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M109.jpg" xlink:type="simple" />
+							</inline-formula>
+							GeV and
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ M_D = 400 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M110.jpg" xlink:type="simple" />
+							</inline-formula>
+							GeV.
+						</p>
+					</caption>
+					<graphic content-type="print" id="cpc_46_9_093112_f3_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_f3.eps" xlink:type="simple" />
+					<graphic content-type="online" id="cpc_46_9_093112_f3_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_f3.jpg" xlink:type="simple" />
+				</fig>
+				<fig id="cpc_46_9_093112_f4" orientation="portrait" position="float">
+					<label>Fig. 4</label>
+					<caption id="cpc_46_9_093112_fc4">
+						<p>
+							(color online) Same as
+							<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+							, but in the
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ y_1-y_2 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M111.jpg" xlink:type="simple" />
+							</inline-formula>
+							plane with the fixed mass parameters of
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ M_S = 400 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M112.jpg" xlink:type="simple" />
+							</inline-formula>
+							GeV and
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ M_D = 200 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M113.jpg" xlink:type="simple" />
+							</inline-formula>
+							GeV.
+						</p>
+					</caption>
+					<graphic content-type="print" id="cpc_46_9_093112_f4_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_f4.eps" xlink:type="simple" />
+					<graphic content-type="online" id="cpc_46_9_093112_f4_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_f4.jpg" xlink:type="simple" />
+				</fig>
+				<p>
+					In
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					, we show the results of first set of benchmark parameters, where
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					(a)
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sim $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M114.jpg" xlink:type="simple" />
+					</inline-formula>
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					(e) represent the processes
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+e^- \to \mu^+ \mu^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M115.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Zh $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M116.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ W^+W^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M117.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ ZZ $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M118.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Z \gamma $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M119.jpg" xlink:type="simple" />
+					</inline-formula>
+					, respectively.
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					(f) represents the combined result of all these channels at the 95% confidence level (see details below). The colored parameter regions indicate that
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \Delta \sigma/\sigma_0 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M120.jpg" xlink:type="simple" />
+					</inline-formula>
+					is larger than the precision of the CEPC and can thus be explored in a future measurement. For a conservative estimate, we also consider a precision of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 0.5\% $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M121.jpg" xlink:type="simple" />
+					</inline-formula>
+					for the processes of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+e^-\to W^+W^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M122.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ ZZ $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M123.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Z \gamma $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M124.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and show the corresponding results in
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					,
+					<xref ref-type="fig" rid="cpc_46_9_093112_f3">Fig. 3</xref>
+					, and
+					<xref ref-type="fig" rid="cpc_46_9_093112_f4">Fig. 4</xref>
+					.
+				</p>
+				<p>
+					In comparison with other channels, the result of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+ e^- \to \mu^+ \mu^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M125.jpg" xlink:type="simple" />
+					</inline-formula>
+					(see
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					(a)) is relatively simpler. We observe that the colored regions are strongly dependent on
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M126.jpg" xlink:type="simple" />
+					</inline-formula>
+					and almost independent of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_S $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M127.jpg" xlink:type="simple" />
+					</inline-formula>
+					. Considering that the dark sector particles in the SDFDM model do not interact with leptons, the deviation of this process is dominantly induced by the corrections to the propagators, i.e.,
+					<italic toggle="yes">Z</italic>
+					and/or
+					<italic toggle="yes">γ</italic>
+					, as shown in Appendix A. For the charged particle
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^\pm $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M128.jpg" xlink:type="simple" />
+					</inline-formula>
+					(pure doublet), its coupling to
+					<italic toggle="yes">Z</italic>
+					and
+					<italic toggle="yes">γ</italic>
+					is constant (see Eq. (8)); thus, the corrections induced by
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^\pm $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M129.jpg" xlink:type="simple" />
+					</inline-formula>
+					only depend on
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M130.jpg" xlink:type="simple" />
+					</inline-formula>
+					. For the neutral particles
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^0_i $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M131.jpg" xlink:type="simple" />
+					</inline-formula>
+					, the results are similar for
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D \ll m_S $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M132.jpg" xlink:type="simple" />
+					</inline-formula>
+					, because in this case, the lighter neutral particles
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^0_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M133.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^0_2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M134.jpg" xlink:type="simple" />
+					</inline-formula>
+					are also doublet dominated. Our calculation shows that the contribution of the SDFDM model to
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+e^- \to \mu^+ \mu^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M135.jpg" xlink:type="simple" />
+					</inline-formula>
+					is dominated by doublets, which is consistent with
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					(a). Moreover, the corrections from the NP particles in the loop would change dramatically when some mass conditions are fulfilled. These mass threshold effects might partially explain the structures in
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					.
+				</p>
+				<p>
+					In
+					<xref ref-type="fig" rid="cpc_46_9_093112_f2">Fig. 2</xref>
+					, we show some typical mass conditions with
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_1 = 1.0 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M136.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_2 = 0.5 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M137.jpg" xlink:type="simple" />
+					</inline-formula>
+					, e.g.,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_{\chi^0_1}+m_{\chi^0_1}(m_{\chi^0_2})=\sqrt{s} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M138.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $2m_{\chi^-}= \sqrt{s}$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M139.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_{\chi^0_1}+m_{\chi^0_1}(m_{\chi^0_2})=m_Z $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M140.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 2m_{\chi^-}=m_Z $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M141.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $m_{\chi^0_i}+m_{\chi^-}= m_{W^-}$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M142.jpg" xlink:type="simple" />
+					</inline-formula>
+					. For
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+e^- \to \mu^+ \mu^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M143.jpg" xlink:type="simple" />
+					</inline-formula>
+					, we observe that the NP correction reaches a maximum value at
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D \sim 45 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M144.jpg" xlink:type="simple" />
+					</inline-formula>
+					GeV with
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 2m_{\chi_1^0}\sim m_Z $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M145.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 2m_{\chi_-}\sim m_Z $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M146.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and then with the increase in
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M147.jpg" xlink:type="simple" />
+					</inline-formula>
+					, the NP correction rapidly decreases to zero and changes to an opposite sign until the next mass threshold appears. This behavior could explain the gray band of
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					(a) within 50 GeV
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \lesssim m_D \lesssim 80 \; {{\rm{GeV}}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M148.jpg" xlink:type="simple" />
+					</inline-formula>
+					, where the correction of NP is too small to detect. When the next threshold appears at
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D \sim 120 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M149.jpg" xlink:type="simple" />
+					</inline-formula>
+					GeV with
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ 2m_{\chi^-}=\sqrt{s} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M150.jpg" xlink:type="simple" />
+					</inline-formula>
+					, the NP correction reaches a minimum value and thus
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \Delta \sigma/\sigma_0 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M151.jpg" xlink:type="simple" />
+					</inline-formula>
+					reaches a new maximum value. When
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D \gtrsim 120 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M152.jpg" xlink:type="simple" />
+					</inline-formula>
+					GeV, the absolute value of the correction is suppressed by the large masses of the NP particles in loops. Another striking feature is that the results of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+ e^- \to W^+W^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M153.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ ZZ $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M154.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Z\gamma $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M155.jpg" xlink:type="simple" />
+					</inline-formula>
+					are similar (see
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					(c)
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sim $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M156.jpg" xlink:type="simple" />
+					</inline-formula>
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					(e)). We observe that the contributions from the triangle loops connecting to three gauge bosons for these processes are actually sub-dominant. The main NP corrections are provided by the t-channel diagrams with the insertion of the counter terms, which involve the contributions of the NP particles, into the vertex between the gauge boson and leptons. The related Feynman diagrams are provided in Appendix A.
+				</p>
+				<fig id="cpc_46_9_093112_f2" orientation="portrait" position="float">
+					<label>Fig. 2</label>
+					<caption id="cpc_46_9_093112_fc2">
+						<p>
+							(color online) Contours for the mass threshold conditions with
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ y_1 = 1.0 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M106.jpg" xlink:type="simple" />
+							</inline-formula>
+							and
+							<inline-formula>
+								<tex-math>
+									<?CDATA $ y_2 = 0.5 $?>
+								</tex-math>
+								<inline-graphic xlink:href="cpc_46_9_093112_M107.jpg" xlink:type="simple" />
+							</inline-formula>
+							.
+						</p>
+					</caption>
+					<graphic content-type="print" id="cpc_46_9_093112_f2_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_f2.eps" xlink:type="simple" />
+					<graphic content-type="online" id="cpc_46_9_093112_f2_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_f2.jpg" xlink:type="simple" />
+				</fig>
+				<p>
+					For the second benchmark case, i.e.,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_S = 100\; {\rm{GeV}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M157.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D = 400\; {\rm{GeV}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M158.jpg" xlink:type="simple" />
+					</inline-formula>
+					, the corresponding results are shown in
+					<xref ref-type="fig" rid="cpc_46_9_093112_f3">Fig. 3</xref>
+					. In this case, the
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^0_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M159.jpg" xlink:type="simple" />
+					</inline-formula>
+					is dominated by the singlet and is much lighter than the other NP particles. Therefore, for the process
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+ e^- \to \mu^+\mu^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M160.jpg" xlink:type="simple" />
+					</inline-formula>
+					, the NP correction significantly depends on the
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Z\chi^0_1\chi^0_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M161.jpg" xlink:type="simple" />
+					</inline-formula>
+					coupling. We observe that
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ |y_1| = |y_2| $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M162.jpg" xlink:type="simple" />
+					</inline-formula>
+					results in a vanishing
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Z\chi^0_1\chi^0_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M163.jpg" xlink:type="simple" />
+					</inline-formula>
+					coupling; thus, the NP correction induced by
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^0_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M164.jpg" xlink:type="simple" />
+					</inline-formula>
+					is highly suppressed, which rends a non-detectable parameter region around
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ |y_1| \approx |y_2| $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M165.jpg" xlink:type="simple" />
+					</inline-formula>
+					at the CEPC (see
+					<xref ref-type="fig" rid="cpc_46_9_093112_f3">Fig. 3</xref>
+					(a)). The structures for the processes of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+ e^- \to W^+W^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M166.jpg" xlink:type="simple" />
+					</inline-formula>
+					,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ ZZ $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M167.jpg" xlink:type="simple" />
+					</inline-formula>
+					, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ Z\gamma $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M168.jpg" xlink:type="simple" />
+					</inline-formula>
+					are also similar. However, the parameter regions with
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \mid y_1 \mid \approx \mid y_2 \mid \gtrsim 1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M169.jpg" xlink:type="simple" />
+					</inline-formula>
+					can be detected at the CEPC, which is different from the process
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+ e^- \to \mu^+\mu^- $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M170.jpg" xlink:type="simple" />
+					</inline-formula>
+					.
+				</p>
+				<p>
+					For the third benchmark case, i.e.,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_S = 400\; {\rm{GeV}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M171.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_D = 200\; {\rm{GeV}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M172.jpg" xlink:type="simple" />
+					</inline-formula>
+					, the results are shown in
+					<xref ref-type="fig" rid="cpc_46_9_093112_f4">Fig. 4</xref>
+					. Both the neutral particles
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M173.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi_2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M174.jpg" xlink:type="simple" />
+					</inline-formula>
+					are doublet-dominated, whereas
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi_3 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M175.jpg" xlink:type="simple" />
+					</inline-formula>
+					is singlet-dominated. In this case,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^0_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M176.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^0_2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M177.jpg" xlink:type="simple" />
+					</inline-formula>
+					would provide a comparable contribution to the deviation. However, comparing this with the second benchmark case, the masses of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_{\chi^0_1} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M178.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_{\chi^0_2} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M179.jpg" xlink:type="simple" />
+					</inline-formula>
+					are heavier, which rends a relatively smaller detectable parameter regions.
+				</p>
+				<p>
+					From the results shown in subfigures (a)
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sim $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M180.jpg" xlink:type="simple" />
+					</inline-formula>
+					(e) of
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					,
+					<xref ref-type="fig" rid="cpc_46_9_093112_f3">Fig. 3</xref>
+					, and
+					<xref ref-type="fig" rid="cpc_46_9_093112_f4">Fig. 4</xref>
+					, we observe that for different channels, the parameter space that can be explored by the CEPC are actually complementary. Therefore, we propose to combine all these five processes and perform a likelihood analysis to obtain a more efficient constraint on the parameter space [
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib23">23</xref>
+					,
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib27">27</xref>
+					]. We define a
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M181.jpg" xlink:type="simple" />
+					</inline-formula>
+					function as
+				</p>
+				<p>
+					<disp-formula>
+						<label>11</label>
+						<tex-math id="cpc_46_9_093112_E11">
+							<?CDATA $ \chi^2 = \sum\limits_i \frac{(\mu_i^{\rm NP} - \mu_i^{\rm obs})^2}{\sigma^2_{\mu_i}}\simeq \sum\limits_i \frac{(\Delta \sigma/\sigma_0)^2}{\sigma^2_{\mu_i}}, $?>
+						</tex-math>
+						<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E11.jpg" xlink:type="simple" />
+					</disp-formula>
+				</p>
+				<p>
+					where
+					<inline-formula>
+						<tex-math>
+							<?CDATA $\mu_i^{\rm NP} = \sigma^{\rm NP}_i/\sigma^{\rm SM}_i$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M182.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the ratio of the NLO cross section between NP and the SM,
+					<inline-formula>
+						<tex-math>
+							<?CDATA $\mu_i^{\rm obs}$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M183.jpg" xlink:type="simple" />
+					</inline-formula>
+					is assumed to be 1, and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sigma_{\mu_i} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M184.jpg" xlink:type="simple" />
+					</inline-formula>
+					is the estimated CEPC precision for the
+					<italic toggle="yes">i</italic>
+					-th process (see Sec. II.B). For a two-parameter fitting, the corresponding
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \delta \chi^2=\chi^2-\chi_{{{\rm{min}}}}^2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M185.jpg" xlink:type="simple" />
+					</inline-formula>
+					at the 95% confidence level is 5.99. The corresponding combined results are shown in
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					(f),
+					<xref ref-type="fig" rid="cpc_46_9_093112_f3">Fig. 3</xref>
+					(f), and
+					<xref ref-type="fig" rid="cpc_46_9_093112_f4">Fig. 4</xref>
+					(f), respectively. For instance, when
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M186.jpg" xlink:type="simple" />
+					</inline-formula>
+					= 1.0 and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M187.jpg" xlink:type="simple" />
+					</inline-formula>
+					= 0.5, the precision measurements at the CEPC could explore the mass of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \chi^0_1 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M188.jpg" xlink:type="simple" />
+					</inline-formula>
+					nearly up to
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_{\chi_1^0} \sim 150\; {\rm{GeV}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M189.jpg" xlink:type="simple" />
+					</inline-formula>
+					at the 95% confidence level.
+				</p>
+				<p>
+					For the lightest chargino search in supersymmetric models at the LEP, the mass of new charged particles less than 103.5 GeV has been almost excluded [
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib32">32</xref>
+					]. We impose this limit on
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_{\chi^{\pm}} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M190.jpg" xlink:type="simple" />
+					</inline-formula>
+					in the SDFDM model here and show the corresponding results in
+					<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+					(f). Ref. [
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib12">12</xref>
+					] observed that at the LHC, the monojet+
+					<inline-formula>
+						<tex-math>
+							<?CDATA $\not E_{\rm{T}}$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M191.jpg" xlink:type="simple" />
+					</inline-formula>
+					channel could set more strict constraints than other channels, such as
+					<inline-formula>
+						<tex-math>
+							<?CDATA $2\ell + \not E_{\rm{T}}$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M192.jpg" xlink:type="simple" />
+					</inline-formula>
+					and
+					<inline-formula>
+						<tex-math>
+							<?CDATA $3\ell + \not E_{\rm{T}}$?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M193.jpg" xlink:type="simple" />
+					</inline-formula>
+					. Such constraints on
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ m_{\chi^0_1} $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M194.jpg" xlink:type="simple" />
+					</inline-formula>
+					are not stronger than
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ \sim 100 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M195.jpg" xlink:type="simple" />
+					</inline-formula>
+					GeV. The detectability of the CEPC would be complementary to the LEP and LHC in some parameter regions.
+				</p>
+				<p>
+					Ref. [
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib12">12</xref>
+					] also observed that the constraints from the DM relic abundance and direct detection are generally more stringent in a large portion of the parameter space. In this paper, we do not repeat all the analyses from other experiments and only demonstrate the constraints from the DM relic abundance and direct detection in Appendix B. We observe that the DM direct detection experiments have set very stringent constraints on the parameter space. However, some allowed parameter regions with
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ y_1\sim y_2 $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M196.jpg" xlink:type="simple" />
+					</inline-formula>
+					can still be tested by the CEPC.
+				</p>
+			</sec>
+		</sec>
+		<sec id="cpc_46_9_093112_s03">
+			<label>III.</label>
+			<title>DOUBLET-TRIPLET FERMIONIC DARK MATTER MODEL</title>
+			<p>
+				In the DTFDM model [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib11">11</xref>
+				–
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib14">14</xref>
+				], the dark sector contains one triplet Weyl spinor
+				<italic toggle="yes">T</italic>
+				and two doublet Weyl spinors
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ D_i $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M197.jpg" xlink:type="simple" />
+				</inline-formula>
+				(
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ i=1,2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M198.jpg" xlink:type="simple" />
+				</inline-formula>
+				) obeying the following
+				<inline-formula>
+					<tex-math>
+						<?CDATA $S U(2)_L \times U(1)_Y$?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M199.jpg" xlink:type="simple" />
+				</inline-formula>
+				gauge transformations:
+			</p>
+			<p>
+				<disp-formula>
+					<label>12</label>
+					<tex-math id="cpc_46_9_093112_E12">
+						<?CDATA $ \begin{aligned}[b] & D_1=\left( \begin{array}{l} D^0_1 \\ D^-_1 \end{array} \right)\in( {2}, -1) ,\; \; \; \; \; \; D_2=\left( \begin{array}{l} D^+_2 \\ D^0_2 \end{array} \right) \in( {2}, 1) ,\\ & T = \left( \begin{array}{l} T^+ \\ T^0 \\ -T^- \end{array} \right) \in( {3}, 0) . \end{aligned} $?>
+					</tex-math>
+					<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E12.jpg" xlink:type="simple" />
+				</disp-formula>
+			</p>
+			<p>The gauge invariant Lagrangians of the dark sector particles are given by</p>
+			<p>
+				<disp-formula>
+					<label>13</label>
+					<tex-math id="cpc_46_9_093112_E13">
+						<?CDATA $ \begin{aligned}[b] {\cal{L}}_T = & {\rm i} T^+ \bar{\sigma^{\mu}}D_{\mu}T + \frac{1}{2}(m_T T^T(-\epsilon)T + {\rm h.c.}), \\ {\cal{L}}_D = & {\rm i} D_1^+ \bar{\sigma^{\mu}}D_{\mu}D_1 + {\rm i} D_2^+ \bar{\sigma^{\mu}}D_{\mu}D_2 \\ & + (m_D D^{iT}_1 (-\epsilon)D^j_2 + {\rm h.c.}), \\ {\cal{L}}_Y = & y_1 T D_1^i H_i + y_2 T D_2^i \tilde{H_i} + {\rm h.c.}. \end{aligned} $?>
+					</tex-math>
+					<graphic orientation="portrait" position="float" xlink:href="cpc_46_9_093112_E13.jpg" xlink:type="simple" />
+				</disp-formula>
+			</p>
+			<p>
+				Similarly, the model also has four free parameters, including two mass parameters,
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_T $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M200.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_D $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M201.jpg" xlink:type="simple" />
+				</inline-formula>
+				, and two Yukawa couplings,
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M202.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M203.jpg" xlink:type="simple" />
+				</inline-formula>
+				. The EWSB results in the mixing between the triplet and two doublets. In the base of mass eigenstate, we obtain three neutral Majorana fermions
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi^0_i $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M204.jpg" xlink:type="simple" />
+				</inline-formula>
+				(
+				<inline-formula>
+					<tex-math>
+						<?CDATA $i = $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_Z-20220615153549.jpg" xlink:type="simple" />
+				</inline-formula>
+				1, 2, 3) and two charged Dirac fermions
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi_i^\pm $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M205.jpg" xlink:type="simple" />
+				</inline-formula>
+				(
+				<inline-formula>
+					<tex-math>
+						<?CDATA $i= $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_Z-20220615153605.jpg" xlink:type="simple" />
+				</inline-formula>
+				1, 2). The full Lagrangians expressed in the terms of four-component spinors can are provided in Ref. [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib12">12</xref>
+				].
+			</p>
+			<p>
+				Compared with the SDFDM model, the DTFDM model contains one more charged particle, which would induce a relatively larger
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \Delta \sigma/\sigma_0 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M206.jpg" xlink:type="simple" />
+				</inline-formula>
+				. In
+				<xref ref-type="fig" rid="cpc_46_9_093112_f5">Fig. 5</xref>
+				, we show the combined constraints from the five processes in the
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_1-y_2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M207.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_D-m_T $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M208.jpg" xlink:type="simple" />
+				</inline-formula>
+				planes, where the yellow regions can be explored by the CEPC at the 95% confidence level.
+			</p>
+			<fig id="cpc_46_9_093112_f5" orientation="portrait" position="float">
+				<label>Fig. 5</label>
+				<caption id="cpc_46_9_093112_fc5">
+					<p>
+						(color online) Same as subfigures (f) of
+						<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+						,
+						<xref ref-type="fig" rid="cpc_46_9_093112_f3">Fig. 3</xref>
+						, and
+						<xref ref-type="fig" rid="cpc_46_9_093112_f4">Fig. 4</xref>
+						, but for the DTFDM model.
+					</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_9_093112_f5_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_f5.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_9_093112_f5_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_f5.jpg" xlink:type="simple" />
+			</fig>
+			<p>
+				In
+				<xref ref-type="fig" rid="cpc_46_9_093112_f5">Fig. 5</xref>
+				(a), we observe that the parameter regions with small
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_D $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M209.jpg" xlink:type="simple" />
+				</inline-formula>
+				or
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_T $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M210.jpg" xlink:type="simple" />
+				</inline-formula>
+				can be explored by the CEPC. Similar to the results of the SDFDM model for
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_D \lesssim $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M211.jpg" xlink:type="simple" />
+				</inline-formula>
+				100 GeV, the deviation induced by the DTFDM model can be probed, because two lighter neutral NP particles are doublet dominated and have small masses. However, unlike the results of the SDFDM model for
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_D \gt 1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M212.jpg" xlink:type="simple" />
+				</inline-formula>
+				TeV and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_s \lesssim $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M213.jpg" xlink:type="simple" />
+				</inline-formula>
+				100 GeV, the deviation induced by the DTFDM model for
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_D \gt 1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M214.jpg" xlink:type="simple" />
+				</inline-formula>
+				TeV and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_T \lesssim $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M215.jpg" xlink:type="simple" />
+				</inline-formula>
+				100 GeV can still be probed. This is because, in this parameter region, except for the lightest neutral NP particles, the lighter charged particles are dominated by the triplet components and have small masses. In
+				<xref ref-type="fig" rid="cpc_46_9_093112_f5">Fig. 5</xref>
+				(a) we also show the mass contour of
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi_1^0 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M216.jpg" xlink:type="simple" />
+				</inline-formula>
+				as in
+				<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+				,
+				<xref ref-type="fig" rid="cpc_46_9_093112_f3">Fig. 3</xref>
+				, and
+				<xref ref-type="fig" rid="cpc_46_9_093112_f4">Fig. 4</xref>
+				. We observe that the CEPC has the capability to indirectly detect
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_{\chi^0_1} $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M217.jpg" xlink:type="simple" />
+				</inline-formula>
+				up to 450 GeV.
+			</p>
+			<p>
+				For the fixed mass parameters
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_D = $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M218.jpg" xlink:type="simple" />
+				</inline-formula>
+				100 GeV and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_T = $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M219.jpg" xlink:type="simple" />
+				</inline-formula>
+				400 GeV, almost all the parameter regions with
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ |y_1| \lt 2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M220.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ |y_2| \lt 2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M221.jpg" xlink:type="simple" />
+				</inline-formula>
+				can be excluded by the CEPC, as shown in
+				<xref ref-type="fig" rid="cpc_46_9_093112_f5">Fig. 5</xref>
+				(b). This is because
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi^0_1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M222.jpg" xlink:type="simple" />
+				</inline-formula>
+				,
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi^0_2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M223.jpg" xlink:type="simple" />
+				</inline-formula>
+				, and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi^\pm_1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M224.jpg" xlink:type="simple" />
+				</inline-formula>
+				are doublet dominated and provide significant contributions to the NP correction owing to small masses. The result for the fixed mass parameters
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_D = $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M225.jpg" xlink:type="simple" />
+				</inline-formula>
+				400 GeV and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_T = $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M226.jpg" xlink:type="simple" />
+				</inline-formula>
+				200 GeV is shown in
+				<xref ref-type="fig" rid="cpc_46_9_093112_f5">Fig. 5</xref>
+				(c). In this case, the triplet dominated
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi^0_1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M227.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi^\pm_1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M228.jpg" xlink:type="simple" />
+				</inline-formula>
+				have relatively large masses in the parameter region with
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_1\approx y_2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M229.jpg" xlink:type="simple" />
+				</inline-formula>
+				, where the couplings
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Z\chi^0_i\chi^0_i $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M230.jpg" xlink:type="simple" />
+				</inline-formula>
+				are suppressed. Thus, a larger region cannot be detected by the CEPC compared with the previous case. Other constraints on the DTFDM model are simialr to those on the SDFDM model. We provide the constraints on the parameter space of the DTFDM model set by the DM relic density and the direct detection in Appendix B.
+			</p>
+		</sec>
+		<sec id="cpc_46_9_093112_s04">
+			<label>IV.</label>
+			<title>CONCLUSIONS</title>
+			<p>
+				In this paper, we study the effects of the EW multiplet fermionic dark matter models through precision measurements at the future electron-positron collider, the CEPC. As a Higgs factory, the CEPC will significantly increase the accuracy of the EW measurements owing to its relatively clean environment and large luminosity
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sim5.6 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M231.jpg" xlink:type="simple" />
+				</inline-formula>
+				ab
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ ^{-1} $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M232.jpg" xlink:type="simple" />
+				</inline-formula>
+				. In particular, the sensitivity of
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ e^+e^- \to \mu^+\mu^-, \; Zh, \; W^+W^-, \; ZZ $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M233.jpg" xlink:type="simple" />
+				</inline-formula>
+				, and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Z\gamma $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M234.jpg" xlink:type="simple" />
+				</inline-formula>
+				can even reach a sub-percentage level. Thus, any possible deviations from the SM prediction can be considered a hint of NP.
+			</p>
+			<p>
+				We focus on two fermionic dark matter models, namely the SDFDM and DTFDM models. In these models, two types of fermionic multiplets under the
+				<inline-formula>
+					<tex-math>
+						<?CDATA $S U(2)_L$?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M235.jpg" xlink:type="simple" />
+				</inline-formula>
+				representation are introduced based on the SM. We calculate the one-loop deviations induced by the NP particles for the abovementioned five SM processes and investigate the parameter regions that can be detected by the CEPC. Considering that the results of these channels are complementary for both models, we adopt a combined analysis and obtain a more efficient constraint on the model parameter space. For
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M236.jpg" xlink:type="simple" />
+				</inline-formula>
+				= 1.0 and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M237.jpg" xlink:type="simple" />
+				</inline-formula>
+				= 0.5, we observe that the CEPC can probe
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_{\chi^0_1} $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M238.jpg" xlink:type="simple" />
+				</inline-formula>
+				up to
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sim 150\; {\rm{GeV}} $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M239.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \sim 450 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M240.jpg" xlink:type="simple" />
+				</inline-formula>
+				GeV at the 95% confidence level for the SDFDM and DTFDM models, respectively.
+			</p>
+		</sec>
+		<sec id="cpc_46_9_093112_s05">
+			<title>ACKNOWLEDGMENTS</title>
+			<p>
+				<italic toggle="yes">The authors would like to thank Manqi Ruan for helpful discussions.</italic>
+			</p>
+		</sec>
+		<sec id="cpc_46_9_093112_s06">
+			<title>APPENDIX A: FEYNMAN DIAGRAMS</title>
+			<p>
+				Feynman diagrams contributed by the new particles in the loop for the SDFDM and DTFDM models are provided here. For the SDFDM model, the new particles contain
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi^0_i $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M242.jpg" xlink:type="simple" />
+				</inline-formula>
+				(
+				<italic toggle="yes">i</italic>
+				=1,2,3) and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi^{\pm}_j $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M243.jpg" xlink:type="simple" />
+				</inline-formula>
+				(
+				<italic toggle="yes">j</italic>
+				=1). For the DTFDM model, the new particles contain
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi^0_i $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M244.jpg" xlink:type="simple" />
+				</inline-formula>
+				(
+				<italic toggle="yes">i</italic>
+				=1,2,3) and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \chi^{\pm}_j $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M245.jpg" xlink:type="simple" />
+				</inline-formula>
+				(
+				<italic toggle="yes">j</italic>
+				=1,2).
+				<xref ref-type="fig" rid="cpc_46_9_093112_fA1">Fig. A1</xref>
+				,
+				<xref ref-type="fig" rid="cpc_46_9_093112_fA2">Fig. A2</xref>
+				,
+				<xref ref-type="fig" rid="cpc_46_9_093112_fA3">Fig. A3</xref>
+				,
+				<xref ref-type="fig" rid="cpc_46_9_093112_fA4">Fig. A4</xref>
+				, and
+				<xref ref-type="fig" rid="cpc_46_9_093112_fA5">Fig. A</xref>
+				<xref ref-type="fig" rid="cpc_46_9_093112_fA6">5</xref>
+				correspond to the processes
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ e^+e^- \to \mu^+\mu^-, \; Zh, \; W^+W^-, \; ZZ $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M246.jpg" xlink:type="simple" />
+				</inline-formula>
+				, and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Z\gamma $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M247.jpg" xlink:type="simple" />
+				</inline-formula>
+				, respectively. For
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ e^+e^- \to \; W^+W^- $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M248.jpg" xlink:type="simple" />
+				</inline-formula>
+				,
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ZZ $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_Z-20220615153956.jpg" xlink:type="simple" />
+				</inline-formula>
+				, and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Z\gamma $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M249.jpg" xlink:type="simple" />
+				</inline-formula>
+				, we also show the Feynman diagrams of the
+				<italic toggle="yes">t</italic>
+				-channel processes with the insertion of the counter terms into the vertex between the gauge boson and leptons. These diagrams with the counter terms involving the NP contributions provide leading corrections to the related cross sections.
+			</p>
+			<fig id="cpc_46_9_093112_fA1" orientation="portrait" position="float">
+				<label>Fig. A1</label>
+				<caption id="cpc_46_9_093112_fcA1">
+					<p>
+						Feynman diagrams for the propagator (a, b) corrections to
+						<inline-formula>
+							<tex-math>
+								<?CDATA $ e^+ e^- \to \mu^+ \mu^- $?>
+							</tex-math>
+							<inline-graphic xlink:href="cpc_46_9_093112_M250.jpg" xlink:type="simple" />
+						</inline-formula>
+						due to the dark sector in both models.
+					</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_9_093112_fA1_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA1.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_9_093112_fA1_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA1.jpg" xlink:type="simple" />
+			</fig>
+			<fig id="cpc_46_9_093112_fA2" orientation="portrait" position="float">
+				<label>Fig. A2</label>
+				<caption id="cpc_46_9_093112_fcA2">
+					<p>
+						Feynman diagrams for the vertex (a) and propagator (b, c) corrections to
+						<inline-formula>
+							<tex-math>
+								<?CDATA $ e^+ e^- \to Z H $?>
+							</tex-math>
+							<inline-graphic xlink:href="cpc_46_9_093112_M251.jpg" xlink:type="simple" />
+						</inline-formula>
+						.
+					</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_9_093112_fA2_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA2.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_9_093112_fA2_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA2.jpg" xlink:type="simple" />
+			</fig>
+			<fig id="cpc_46_9_093112_fA3" orientation="portrait" position="float">
+				<label>Fig. A3</label>
+				<caption id="cpc_46_9_093112_fcA3">
+					<p>
+						Feynman diagrams for the vertex (a,b) and propagator (c, d) corrections to
+						<inline-formula>
+							<tex-math>
+								<?CDATA $ e^+ e^- \to W^+ W^- $?>
+							</tex-math>
+							<inline-graphic xlink:href="cpc_46_9_093112_M252.jpg" xlink:type="simple" />
+						</inline-formula>
+						.
+					</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_9_093112_fA3_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA3.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_9_093112_fA3_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA3.jpg" xlink:type="simple" />
+			</fig>
+			<fig id="cpc_46_9_093112_fA4" orientation="portrait" position="float">
+				<label>Fig. A4</label>
+				<caption id="cpc_46_9_093112_fcA4">
+					<p>
+						Feynman diagrams for the vertex (a,b) corrections to
+						<inline-formula>
+							<tex-math>
+								<?CDATA $ e^+ e^- \to Z Z $?>
+							</tex-math>
+							<inline-graphic xlink:href="cpc_46_9_093112_M253.jpg" xlink:type="simple" />
+						</inline-formula>
+						.
+					</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_9_093112_fA4_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA4.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_9_093112_fA4_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA4.jpg" xlink:type="simple" />
+			</fig>
+			<fig id="cpc_46_9_093112_fA5" orientation="portrait" position="float">
+				<label>Fig. A5</label>
+				<caption id="cpc_46_9_093112_fcA5">
+					<p>
+						Feynman diagrams for the vertex corrections to
+						<inline-formula>
+							<tex-math>
+								<?CDATA $ e^+ e^- \to Z \gamma $?>
+							</tex-math>
+							<inline-graphic xlink:href="cpc_46_9_093112_M254.jpg" xlink:type="simple" />
+						</inline-formula>
+						.
+					</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_9_093112_fA5_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA5.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_9_093112_fA5_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA5.jpg" xlink:type="simple" />
+			</fig>
+			<fig id="cpc_46_9_093112_fA6" orientation="portrait" position="float">
+				<label>Fig. A6</label>
+				<caption id="cpc_46_9_093112_fcA6">
+					<p>
+						Feynman diagrams of
+						<italic toggle="yes">t</italic>
+						-channel (a, b, c) containing the counter terms, that involve the contributions of the NP particles, for the processes
+						<inline-formula>
+							<tex-math>
+								<?CDATA $ e^+ e^- \to W^+ W^-, Z Z $?>
+							</tex-math>
+							<inline-graphic xlink:href="cpc_46_9_093112_M255.jpg" xlink:type="simple" />
+						</inline-formula>
+						, and
+						<inline-formula>
+							<tex-math>
+								<?CDATA $ Z \gamma $?>
+							</tex-math>
+							<inline-graphic xlink:href="cpc_46_9_093112_M256.jpg" xlink:type="simple" />
+						</inline-formula>
+						, respectively.
+					</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_9_093112_fA6_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA6.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_9_093112_fA6_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fA6.jpg" xlink:type="simple" />
+			</fig>
+		</sec>
+		<sec id="cpc_46_9_093112_s07">
+			<title>APPENDIX B:CONSTRAINTS FROM THE DM RELIC ABUNDANCE AND DIRECT DETECTION</title>
+			<p>
+				In
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">Fig. B1</xref>
+				and
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB2">Fig. B2</xref>
+				, we show the constraints from the DM relic abundance and direct detection for the SDFDM and DTFDM models, respectively. For the relic abundance, the effects of all the annihilation and coannihilation channels are calculated using the package MadDM [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib33">33</xref>
+				]. The blue regions are excluded because of the predicted DM relic abundance is larger than the observed value with
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ \Omega h^2 \gt 0.12 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M257.jpg" xlink:type="simple" />
+				</inline-formula>
+				[
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib34">34</xref>
+				]. For comparison, we have selected the same parameters in
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">Fig. B1</xref>
+				(a),
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">B1</xref>
+				(b),
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">B1</xref>
+				(c),
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB2">B2</xref>
+				(a),
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB2">B2</xref>
+				(b), and
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB2">B2</xref>
+				(c) as in
+				<xref ref-type="fig" rid="cpc_46_9_093112_f1">Fig. 1</xref>
+				(f),
+				<xref ref-type="fig" rid="cpc_46_9_093112_f3">3</xref>
+				(f),
+				<xref ref-type="fig" rid="cpc_46_9_093112_f4">4</xref>
+				(f),
+				<xref ref-type="fig" rid="cpc_46_9_093112_f5">5</xref>
+				(a),
+				<xref ref-type="fig" rid="cpc_46_9_093112_f5">5</xref>
+				(b), and
+				<xref ref-type="fig" rid="cpc_46_9_093112_f5">5</xref>
+				(c). We also consider the constraints from the DM direct detection and show the excluded parameter regions in
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">Fig. B1</xref>
+				and
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB2">Fig. B2</xref>
+				. The experimental limits on the spin-independent (SI) and spin-dependent (SD) DM-nucleon scatterings are obtained from the results of PandaX-4T [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib35">35</xref>
+				] and PICO-60 [
+				<xref ref-type="bibr" rid="cpc_46_9_093112_bib36">36</xref>
+				], respectively. The DM-nucleon scattering cross sections are also calculated using MadDM.
+			</p>
+			<fig id="cpc_46_9_093112_fB1" orientation="portrait" position="float">
+				<label>Fig. B1</label>
+				<caption id="cpc_46_9_093112_fcB1">
+					<p>
+						(color online) DM constraints in the
+						<inline-formula>
+							<tex-math>
+								<?CDATA $ m_S-m_D $?>
+							</tex-math>
+							<inline-graphic xlink:href="cpc_46_9_093112_M258.jpg" xlink:type="simple" />
+						</inline-formula>
+						(a) and
+						<inline-formula>
+							<tex-math>
+								<?CDATA $ y_1-y_2 $?>
+							</tex-math>
+							<inline-graphic xlink:href="cpc_46_9_093112_M259.jpg" xlink:type="simple" />
+						</inline-formula>
+						(b, c) planes for the SDFDM model. The blue regions represent the parameter regions, where the predicted DM relic abundance is larger than the observed value [
+						<xref ref-type="bibr" rid="cpc_46_9_093112_bib34">34</xref>
+						] with
+						<inline-formula>
+							<tex-math>
+								<?CDATA $ \Omega h^2 \gt{0.12} $?>
+							</tex-math>
+							<inline-graphic xlink:href="cpc_46_9_093112_M260.jpg" xlink:type="simple" />
+						</inline-formula>
+						. The orange and purple lines represent the constraints set by the direct detection PandaX-4T [
+						<xref ref-type="bibr" rid="cpc_46_9_093112_bib35">35</xref>
+						] for the SI scattering and PICO-60 [
+						<xref ref-type="bibr" rid="cpc_46_9_093112_bib36">36</xref>
+						] for the SD scattering, respectively. The arrows denote the directions for exclusion.
+					</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_9_093112_fB1_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fB1.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_9_093112_fB1_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fB1.jpg" xlink:type="simple" />
+			</fig>
+			<fig id="cpc_46_9_093112_fB2" orientation="portrait" position="float">
+				<label>Fig. B2</label>
+				<caption id="cpc_46_9_093112_fcB2">
+					<p>
+						(color online) Same as
+						<xref ref-type="fig" rid="cpc_46_9_093112_fB1">Fig. B1</xref>
+						, but for the DTFDM model.
+					</p>
+				</caption>
+				<graphic content-type="print" id="cpc_46_9_093112_fB2_eps" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fB2.eps" xlink:type="simple" />
+				<graphic content-type="online" id="cpc_46_9_093112_fB2_online" orientation="portrait" position="float" xlink:href="cpc_46_9_093112_fB2.jpg" xlink:type="simple" />
+			</fig>
+			<p>
+				The DM overproduction limit excludes the parameter regions in which the DM annihilation cross section is excessively small. For the SDFDM model,
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_D \gtrsim 1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M261.jpg" xlink:type="simple" />
+				</inline-formula>
+				TeV in
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">Fig. B1</xref>
+				(a) can be excluded by the DM overproduction limit. This is because when
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_D $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M262.jpg" xlink:type="simple" />
+				</inline-formula>
+				is large, the DM annihilation cross section would be significantly suppressed owing to the small doublet components in the DM. In
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">Fig. B1</xref>
+				(b), although
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_D $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M263.jpg" xlink:type="simple" />
+				</inline-formula>
+				is not very large, small
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ m_S $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M264.jpg" xlink:type="simple" />
+				</inline-formula>
+				,
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M265.jpg" xlink:type="simple" />
+				</inline-formula>
+				, and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M266.jpg" xlink:type="simple" />
+				</inline-formula>
+				may also result in a DM dominated by the singlet component. Moreover, in
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">Fig. B1</xref>
+				(b) and
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">B1</xref>
+				(c), if
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M267.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M268.jpg" xlink:type="simple" />
+				</inline-formula>
+				have opposite signs, a parameter region may occur in which the DM is very light owing to the large mass splitting term. These parameter regions are excluded by the overproduction limit because the DM particles do not have a significant annihilation cross section.
+			</p>
+			<p>
+				The couplings of
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ h\chi_1^0\chi_1^0 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M269.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Z\chi_1^0\chi_1^0 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M270.jpg" xlink:type="simple" />
+				</inline-formula>
+				result in SI and SD DM-nucleon scatterings in DM detection experiments, respectively. As shown in
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">Fig. B1</xref>
+				(a),
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">B1</xref>
+				(b), and
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">B1</xref>
+				(c), both the DM direct detection experiments for the SI and SD interactions set very stringent limits on the parameter space, and the two effects can be complementary in some parameter regions. We can observe that some parameter regions are still permitted by the direct detection with
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_1\sim y_2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M271.jpg" xlink:type="simple" />
+				</inline-formula>
+				. In this case, the
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ h\chi_1^0\chi_1^0 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M272.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Z\chi_1^0\chi_1^0 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M273.jpg" xlink:type="simple" />
+				</inline-formula>
+				couplings are suppressed.
+			</p>
+			<p>
+				The results of the DTFDM model shown in
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB2">Fig. B2</xref>
+				are similar to those of the SDFDM model in
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">Fig. B1</xref>
+				. Since both the doublets and triplet participate in the weak interaction, the DM in the DTFDM model would always have a significant annihilation cross section. When DM is not very light, a small DM relic density can be easily achieved in the DTFDM model. If
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ M_S $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M274.jpg" xlink:type="simple" />
+				</inline-formula>
+				is replaced by
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ M_T $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M275.jpg" xlink:type="simple" />
+				</inline-formula>
+				, the mass matrix
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ M_N $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M276.jpg" xlink:type="simple" />
+				</inline-formula>
+				of the neutral NP particles in the DTFDM model is identical to that in the SDFDM Eq. (5). Thus, the couplings of
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ h\chi_1^0\chi_1^0 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M277.jpg" xlink:type="simple" />
+				</inline-formula>
+				and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ Z\chi_1^0\chi_1^0 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M278.jpg" xlink:type="simple" />
+				</inline-formula>
+				in these two models are equal when
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ M_S=M_T $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M279.jpg" xlink:type="simple" />
+				</inline-formula>
+				for the same
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_1 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M280.jpg" xlink:type="simple" />
+				</inline-formula>
+				,
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ y_2 $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M281.jpg" xlink:type="simple" />
+				</inline-formula>
+				, and
+				<inline-formula>
+					<tex-math>
+						<?CDATA $ M_D $?>
+					</tex-math>
+					<inline-graphic xlink:href="cpc_46_9_093112_M282.jpg" xlink:type="simple" />
+				</inline-formula>
+				. Therefore, the excluded regions set by the direct detection are the same in
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB1">Fig. B1</xref>
+				(a) and
+				<xref ref-type="fig" rid="cpc_46_9_093112_fB2">Fig. B2</xref>
+				(a).
+			</p>
+		</sec>
+	</body>
+	<back>
+		<fn-group>
+			<fn id="cpc_46_9_093112_pn1">
+				<p>
+					Note that the process of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+e^- \to Zh $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M24.jpg" xlink:type="simple" />
+					</inline-formula>
+					has been studied in Ref. [
+					<xref ref-type="bibr" rid="cpc_46_9_093112_bib12">12</xref>
+					], here we just include the corresponding result for comparison.
+				</p>
+			</fn>
+			<fn id="cpc_46_9_093112_pn2">
+				<p>
+					Other systematic uncertainties of these channels may result from the backgrounds and reconstructions. The exact value depending on the efficiency and purity of the simulation and have not been provided yet. However, it is expected that the realistic systematic uncertainties of these processes are smaller than that of
+					<inline-formula>
+						<tex-math>
+							<?CDATA $ e^+e^-\to Zh $?>
+						</tex-math>
+						<inline-graphic xlink:href="cpc_46_9_093112_M72.jpg" xlink:type="simple" />
+					</inline-formula>
+					at least, because of the better reconstruction and larger statistics of the gauge bosons.
+				</p>
+			</fn>
+		</fn-group>
+		<ref-list>
+			<title>References</title>
+			<ref id="cpc_46_9_093112_bib1">
+				<label>[1]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Aad . (ATLAS Collaboration)</surname>
+							<given-names>G.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Lett. B</source>
+					<year>2012</year>
+					<volume>716</volume>
+					<fpage>1</fpage>
+					<lpage>29</lpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1207.7214" xlink:type="simple">1207.7214</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib2">
+				<label>[2]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Chatrchyan . (CMS Collaboration)</surname>
+							<given-names>S.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Lett. B</source>
+					<year>2012</year>
+					<volume>716</volume>
+					<fpage>30</fpage>
+					<lpage>61</lpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1207.7235" xlink:type="simple">1207.7235</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib3">
+				<label>[3]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>L. Feng</surname>
+							<given-names>J.</given-names>
+						</name>
+					</person-group>
+					<source>Ann. Rev. Astron. Astrophys.</source>
+					<year>2010</year>
+					<volume>48</volume>
+					<fpage>495</fpage>
+					<lpage>545</lpage>
+					<pub-id pub-id-type="doi">10.1146/annurev-astro-082708-101659</pub-id>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1003.0904[astro-ph.CO]" xlink:type="simple">1003.0904[astro-ph.CO]</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib4">
+				<label>[4]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Bertone</surname>
+							<given-names>G.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Hooper</surname>
+							<given-names>D.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Silk</surname>
+							<given-names>J.</given-names>
+						</name>
+					</person-group>
+					<source>Phys. Rept.</source>
+					<year>2005</year>
+					<volume>405</volume>
+					<fpage>279</fpage>
+					<lpage>390</lpage>
+					<pub-id pub-id-type="doi">10.1016/j.physrep.2004.08.031</pub-id>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0404175" xlink:type="simple">hep-ph/0404175</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib5">
+				<label>[5]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						M. Dong and G. Li
+						<italic toggle="yes">et al.</italic>
+						(CEPC Study Group Collaboration),
+						<italic toggle="yes">CEPC Conceptual Design Report: Volume 2 - Physics &amp; Detector</italic>
+						, arXiv: 1811.10545[hep-ex]
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib6">
+				<label>[6]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						A. Abada
+						<italic toggle="yes">et al</italic>
+						. (FCC Collaboration),
+						<italic toggle="yes">Future Circular Collider</italic>
+						, CERN-ACC-2018-0057
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib7">
+				<label>[7]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						H. Baer, T. Barklow, K. Fujii
+						<italic toggle="yes">et al</italic>
+						.,
+						<italic toggle="yes">The International Linear Collider Technical Design Report - Volume 2: Physics</italic>
+						, arXiv: 1306.6352[hep-ph]
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib8">
+				<label>[8]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Cirelli</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Fornengo</surname>
+							<given-names>N.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Strumia</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<source>Nucl. Phys. B</source>
+					<year>2006</year>
+					<volume>753</volume>
+					<fpage>178</fpage>
+					<lpage>194</lpage>
+					<pub-id pub-id-type="doi">10.1016/j.nuclphysb.2006.07.012</pub-id>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0512090" xlink:type="simple">hep-ph/0512090</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib9">
+				<label>[9]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>E. Yaguna</surname>
+							<given-names>C.</given-names>
+						</name>
+					</person-group>
+					<source>Phys. Rev. D</source>
+					<year>2015</year>
+					<volume>92</volume>
+					<fpage>115002</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1510.06151" xlink:type="simple">1510.06151</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib10">
+				<label>[10]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Calibbi</surname>
+							<given-names>L.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Mariotti</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Tziveloglou</surname>
+							<given-names>P.</given-names>
+						</name>
+					</person-group>
+					<source>JHEP</source>
+					<year>2015</year>
+					<volume>10</volume>
+					<fpage>116</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1505.03867" xlink:type="simple">1505.03867</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib11">
+				<label>[11]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Cai</surname>
+							<given-names>C.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Yu</surname>
+							<given-names>Z.-H.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Zhang</surname>
+							<given-names>H.-H.</given-names>
+						</name>
+					</person-group>
+					<source>Nucl. Phys. B</source>
+					<year>2017</year>
+					<volume>921</volume>
+					<fpage>181</fpage>
+					<lpage>210</lpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1611.02186" xlink:type="simple">1611.02186</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib12">
+				<label>[12]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Xiang</surname>
+							<given-names>Q.-F.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Bi</surname>
+							<given-names>X.-J.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Yin</surname>
+							<given-names>P.-F.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Rev. D</source>
+					<year>2018</year>
+					<volume>97</volume>
+					<fpage>055004</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1707.03094" xlink:type="simple">1707.03094</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib13">
+				<label>[13]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Wang</surname>
+							<given-names>J.-W.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Bi</surname>
+							<given-names>X.-J.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Yin</surname>
+							<given-names>P.-F.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Rev. D</source>
+					<year>2019</year>
+					<volume>99</volume>
+					<fpage>055009</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1811.08743" xlink:type="simple">1811.08743</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib14">
+				<label>[14]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Dedes</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Karamitros</surname>
+							<given-names>D.</given-names>
+						</name>
+					</person-group>
+					<source>Phys. Rev. D</source>
+					<year>2014</year>
+					<volume>89</volume>
+					<fpage>115002</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1403.7744" xlink:type="simple">1403.7744</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib15">
+				<label>[15]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						M. McCullough,
+						<italic toggle="yes">An Indirect Model-Dependent Probe of the Higgs Self-Coupling</italic>
+						, Phys. Rev. D
+						<bold>90</bold>
+						,
+						<bold />
+						015001 (2014) arXiv: 1312.3322[hep-ph] [Erratum: Phys. Rev.D
+						<bold>92</bold>
+						(3), 039903 (2015)]
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib16">
+				<label>[16]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Cao</surname>
+							<given-names>J.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Heng</surname>
+							<given-names>Z.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Li</surname>
+							<given-names>D.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>JHEP</source>
+					<year>2014</year>
+					<volume>08</volume>
+					<fpage>138</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1405.4489" xlink:type="simple">1405.4489</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib17">
+				<label>[17]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Beneke</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Boito</surname>
+							<given-names>D.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Wang</surname>
+							<given-names>Y.-M.</given-names>
+						</name>
+					</person-group>
+					<source>JHEP</source>
+					<year>2014</year>
+					<volume>11</volume>
+					<fpage>028</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1406.1361" xlink:type="simple">1406.1361</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib18">
+				<label>[18]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Shen</surname>
+							<given-names>C.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Zhu</surname>
+							<given-names>S.-h.</given-names>
+						</name>
+					</person-group>
+					<source>Phys. Rev. D</source>
+					<year>2015</year>
+					<volume>92</volume>
+					<fpage>094001</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1504.05626" xlink:type="simple">1504.05626</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib19">
+				<label>[19]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>P. Huang</surname>
+							<given-names>F.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Gu</surname>
+							<given-names>P.-H.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Yin</surname>
+							<given-names>P.-F.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Rev. D</source>
+					<year>2016</year>
+					<volume>93</volume>
+					<fpage>103515</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1511.03969" xlink:type="simple">1511.03969</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib20">
+				<label>[20]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Kobakhidze</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Liu</surname>
+							<given-names>N.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Wu</surname>
+							<given-names>L.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Rev. D</source>
+					<year>2017</year>
+					<volume>95</volume>
+					<fpage>015016</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1610.06676" xlink:type="simple">1610.06676</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib21">
+				<label>[21]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Wang</surname>
+							<given-names>J.-W.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Bi</surname>
+							<given-names>X.-J.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Xiang</surname>
+							<given-names>Q.-F.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Rev. D</source>
+					<year>2018</year>
+					<volume>97</volume>
+					<fpage>035021</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1711.05622" xlink:type="simple">1711.05622</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib22">
+				<label>[22]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						N. Chen, T. Han, S. Li
+						<italic toggle="yes">et al</italic>
+						.,
+						<italic toggle="yes">Type-I 2HDM under the Higgs and Electroweak Precision Measurements</italic>
+						, arXiv: 1912.01431[hep-ph]
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib23">
+				<label>[23]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Chen</surname>
+							<given-names>N.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Han</surname>
+							<given-names>T.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Su</surname>
+							<given-names>S.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>JHEP</source>
+					<year>2019</year>
+					<volume>03</volume>
+					<fpage>023</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1808.02037" xlink:type="simple">1808.02037</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib24">
+				<label>[24]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Cai</surname>
+							<given-names>C.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Yu</surname>
+							<given-names>Z.-H.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Zhang</surname>
+							<given-names>H.-H.</given-names>
+						</name>
+					</person-group>
+					<source>Nucl. Phys. B</source>
+					<year>2017</year>
+					<volume>924</volume>
+					<fpage>128</fpage>
+					<lpage>152</lpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1705.07921" xlink:type="simple">1705.07921</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib25">
+				<label>[25]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Liu</surname>
+							<given-names>N.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Wu</surname>
+							<given-names>L.</given-names>
+						</name>
+					</person-group>
+					<source>Eur. Phys. J. C</source>
+					<year>2017</year>
+					<volume>77</volume>
+					<fpage>868</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1705.02534" xlink:type="simple">1705.02534</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib26">
+				<label>[26]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>V. Andreev</surname>
+							<given-names>V.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Moortgat-Pick</surname>
+							<given-names>G.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Osland</surname>
+							<given-names>P.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Eur. Phys. J. C</source>
+					<year>2012</year>
+					<volume>72</volume>
+					<fpage>2147</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1205.0866" xlink:type="simple">1205.0866</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib27">
+				<label>[27]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						K. Harigaya, K. Ichikawa, A. Kundu
+						<italic toggle="yes">et al</italic>
+						.,
+						<italic toggle="yes">Indirect probe of electroweak-interacting particles at future lepton colliders</italic>
+						, Journal of High Energy Physics
+						<bold>2015</bold>
+						(Sep, 2015)
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib28">
+				<label>[28]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						Q.-H. Cao, Y. Li, B. Yan
+						<italic toggle="yes">et al</italic>
+						.,
+						<italic toggle="yes">Probing dark particles indirectly at the CEPC</italic>
+						, Nucl. Phys. B
+						<bold>909</bold>
+						, 197-217 (2016)
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib29">
+				<label>[29]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Gulov</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<source>Int. J. Mod. Phys. A</source>
+					<year>2014</year>
+					<volume>29</volume>
+					<fpage>1450161</fpage>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1308.4837" xlink:type="simple">1308.4837</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib30">
+				<label>[30]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Hahn</surname>
+							<given-names>T.</given-names>
+						</name>
+					</person-group>
+					<source>Comput. Phys. Commun.</source>
+					<year>2001</year>
+					<volume>140</volume>
+					<fpage>418</fpage>
+					<lpage>431</lpage>
+					<pub-id pub-id-type="doi">10.1016/S0010-4655(01)00290-9</pub-id>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0012260" xlink:type="simple">hep-ph/0012260</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib31">
+				<label>[31]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Hahn</surname>
+							<given-names>T.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Perez-Victoria</surname>
+							<given-names>M.</given-names>
+						</name>
+					</person-group>
+					<source>Comput. Phys. Commun.</source>
+					<year>1999</year>
+					<volume>118</volume>
+					<fpage>153</fpage>
+					<lpage>165</lpage>
+					<pub-id pub-id-type="doi">10.1016/S0010-4655(98)00173-8</pub-id>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/9807565" xlink:type="simple">hep-ph/9807565</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib32">
+				<label>[32]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Abdallah . (DELPHI Collaboration)</surname>
+							<given-names>J.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Eur. Phys. C. J</source>
+					<year>2003</year>
+					<volume>31</volume>
+					<fpage>421</fpage>
+					<lpage>479</lpage>
+					<pub-id pub-id-type="doi">10.1140/epjc/s2003-01355-5</pub-id>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ex/0311019" xlink:type="simple">hep-ex/0311019</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib33">
+				<label>[33]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Ambrogi</surname>
+							<given-names>F.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Arina</surname>
+							<given-names>C.</given-names>
+						</name>
+						<name name-style="western">
+							<surname>Backovic</surname>
+							<given-names>M.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Dark Univ.</source>
+					<year>2019</year>
+					<volume>24</volume>
+					<fpage>100249</fpage>
+					<pub-id pub-id-type="doi">10.1016/j.dark.2018.11.009</pub-id>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1804.00044" xlink:type="simple">1804.00044</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib34">
+				<label>[34]</label>
+				<element-citation publication-type="other" xlink:type="simple">
+					<comment>
+						N. Aghanim
+						<italic toggle="yes">et al</italic>
+						. (Planck Collaboration),
+						<italic toggle="yes">Planck 2018 results. VI. Cosmological parameters,</italic>
+						Astron. Astrophys
+						<italic toggle="yes">.</italic>
+						<bold>641</bold>
+						, A6 (2020), arXiv: 1807.06209[astro-ph.CO] [Erratum: Astron. Astrophys.
+						<bold>652</bold>
+						, C4 (2021)]
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib35">
+				<label>[35]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Meng . (PandaX-4T Collaboration)</surname>
+							<given-names>Y.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Rev. Lett.</source>
+					<year>2021</year>
+					<volume>127</volume>
+					<fpage>261802</fpage>
+					<pub-id pub-id-type="doi">10.1103/PhysRevLett.127.261802</pub-id>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2107.13438" xlink:type="simple">2107.13438</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+			<ref id="cpc_46_9_093112_bib36">
+				<label>[36]</label>
+				<element-citation publication-type="journal" xlink:type="simple">
+					<person-group person-group-type="author">
+						<name name-style="western">
+							<surname>Amole . (PICO Collaboration)</surname>
+							<given-names>C.</given-names>
+						</name>
+						<etal>et al</etal>
+					</person-group>
+					<source>Phys. Rev. D</source>
+					<year>2019</year>
+					<volume>100</volume>
+					<fpage>022001</fpage>
+					<pub-id pub-id-type="doi">10.1103/PhysRevD.100.022001</pub-id>
+					<comment>
+						arXiv:
+						<ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1902.04031[astro-ph.CO]" xlink:type="simple">1902.04031[astro-ph.CO]</ext-link>
+					</comment>
+				</element-citation>
+			</ref>
+		</ref-list>
+	</back>
+</article>

--- a/tests/units/iop/data/without_doi.xml
+++ b/tests/units/iop/data/without_doi.xml
@@ -1,0 +1,7110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" xml:lang="en">
+   <front>
+      <journal-meta>
+         <journal-id journal-id-type="publisher-id">cpc</journal-id>
+         <journal-title-group>
+            <journal-title xml:lang="en">Chinese Physics C</journal-title>
+         </journal-title-group>
+         <issn pub-type="ppub">1674-1137</issn>
+         <publisher>
+            <publisher-name>Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+                        </publisher-name>
+         </publisher>
+      </journal-meta>
+      <article-meta>
+         <article-id pub-id-type="publisher-id">cpc_46_10_103101</article-id>
+         <article-id pub-id-type="manuscript">ac763c</article-id>
+         <article-categories>
+            <subj-group subj-group-type="display-article-type">
+               <subject>Paper</subject>
+            </subj-group>
+            <subj-group subj-group-type="section">
+               <subject>Particles and fields</subject>
+            </subj-group>
+         </article-categories>
+         <title-group>
+            <article-title>
+               Lepton and quark mixing patterns with generalized
+               <italic toggle="yes">CP</italic>
+               transformations
+            </article-title>
+         </title-group>
+         <contrib-group>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Ganguly</surname>
+                  <given-names>Joy</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <email>ph18resch11009@iith.ac.in</email>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Hundi</surname>
+                  <given-names>Raghavendra Srikanth</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <email>rshundi@phy.iith.ac.in</email>
+            </contrib>
+            <aff id="affiliation01">
+               <label>1</label>
+               <institution xlink:type="simple">Department of Physics, Indian Institute of Technology Hyderabad</institution>
+               , Kandi - 502 284,
+               <country>India</country>
+            </aff>
+         </contrib-group>
+         <pub-date pub-type="ppub">
+            <day>01</day>
+            <month>10</month>
+            <year>2022</year>
+         </pub-date>
+         <pub-date pub-type="open-access">
+            <day>29</day>
+            <month>7</month>
+            <year>2022</year>
+         </pub-date>
+         <volume>46</volume>
+         <issue>10</issue>
+         <elocation-id content-type="artnum">103101</elocation-id>
+         <history>
+            <date date-type="received">
+               <day>15</day>
+               <month>4</month>
+               <year>2022</year>
+            </date>
+            <date date-type="published-online">
+               <day>29</day>
+               <month>7</month>
+               <year>2022</year>
+            </date>
+            <date date-type="oa-requested">
+               <day>15</day>
+               <month>4</month>
+               <year>2022</year>
+            </date>
+         </history>
+         <permissions>
+            <copyright-statement>© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</copyright-statement>
+            <copyright-year>2022</copyright-year>
+            <license license-type="cc-by" xlink:href="http://creativecommons.org/licenses/by/3.0/" xlink:type="simple">
+               <license-p>
+                  <graphic content-type="online" orientation="portrait" position="float" xlink:href="cpc_46_10_103101_ccby.tif" xlink:type="simple" />
+                  Content from this work may be used under the terms of the
+                  <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/3.0" xlink:type="simple">Creative Commons Attribution 3.0 licence</ext-link>
+                  . Any further distribution of this work must maintain attribution to the author(s) and the title of the work, journal citation and DOI. Article funded by SCOAP
+                  <sup>3</sup>
+                  and published under licence by Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+               </license-p>
+            </license>
+         </permissions>
+         <self-uri content-type="pdf" xlink:href="cpc_46_10_103101.pdf" xlink:type="simple" />
+         <abstract>
+            <title>Abstract</title>
+            <p>
+               In this study, we modify a scenario, originally proposed by Grimus and Lavoura, in order to obtain maximal values for the atmospheric mixing angle and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M1.jpg" xlink:type="simple" />
+               </inline-formula>
+               , violating the Dirac phase of the lepton sector. To achieve this, we employ
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M2.jpg" xlink:type="simple" />
+               </inline-formula>
+               and some discrete symmetries in a type II seesaw model. To make predictions about the neutrino mass ordering and smallness of the reactor angle, we establish some conditions on the elements of the neutrino mass matrix of our model. Finally, we study the quark masses and mixing pattern within the framework of our model.
+            </p>
+         </abstract>
+         <kwd-group kwd-group-type="author">
+            <kwd>neutrino physics</kwd>
+            <kwd>nuetrino mass and mixing model</kwd>
+            <kwd>quark mass and mixing</kwd>
+            <kwd>analysis of scalar potential</kwd>
+         </kwd-group>
+         <funding-group>
+            <open-access>
+               <p content-type="scoap3">
+                  Article funded by SCOAP
+                  <sup>3</sup>
+               </p>
+            </open-access>
+         </funding-group>
+         <counts>
+            <page-count count="18" />
+         </counts>
+         <custom-meta-group>
+            <custom-meta xlink:type="simple">
+               <meta-name>arxivppt</meta-name>
+               <meta-value>2107.07275</meta-value>
+            </custom-meta>
+         </custom-meta-group>
+      </article-meta>
+   </front>
+   <body>
+      <sec id="cpc_46_10_103101_s01">
+         <label>I.</label>
+         <title>INTRODUCTION</title>
+         <p>
+            According to the global fits to neutrino oscillation data [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], it is well known that the three mixing angles in the lepton sector are close to the tribimaximal (TBM) mixing [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib2">2</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib4">4</xref>
+            ]. In the TBM pattern, the values of the three mixing angles are as follows:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{12}={1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M3.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{23}={1}/{2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M4.jpg" xlink:type="simple" />
+            </inline-formula>
+            , and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{13}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M5.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In contrast, the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M6.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating Dirac phase,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{ CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M7.jpg" xlink:type="simple" />
+            </inline-formula>
+            , in the lepton sector is yet to be measured precisely. However, from the global fits to neutrino oscillation data [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], the best fit value for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M8.jpg" xlink:type="simple" />
+            </inline-formula>
+            is around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $\pi({3}/{2}\pi)$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M9.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the case of normal (inverted) ordering of neutrino masses. The TBM value for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M10.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP}=({3}/{2})\pi $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M11.jpg" xlink:type="simple" />
+            </inline-formula>
+            are still allowed in the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M12.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges for these observables in the current neutrino oscillation data [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ]. The aforementioned values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M13.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M14.jpg" xlink:type="simple" />
+            </inline-formula>
+            are considered to be maximal. To explain these maximal values for
+            <italic toggle="yes">θ</italic>
+            <sub>23</sub>
+            and
+            <italic toggle="yes">
+               δ
+               <sub>CP</sub>
+            </italic>
+            , Harrison and Scott have proposed the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M17.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry in combination with
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${C P}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M18.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, together  called
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M19.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib5">5</xref>
+            ]. For further works regarding the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M20.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${ C P}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M21.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetries, see Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib6">6</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib12">12</xref>
+            ]. Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib6">6</xref>
+            ] is a review article.
+         </p>
+         <p>
+            In the work by Grimus and Lavoura [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], it is shown that a mass matrix for light left-handed neutrinos has the following form [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib14">14</xref>
+            ]:
+         </p>
+         <p>
+            <disp-formula>
+               <label>1</label>
+               <tex-math id="cpc_46_10_103101_E1">
+                  <?CDATA $ \begin{equation} {\cal M}_\nu=\left(\begin{array}{ccc} a & r & r^* \\ r & s & b \\ r^* & b & s^* \end{array}\right) \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E1.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            which can yield maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M22.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M23.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In the above equation,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ a,b $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M24.jpg" xlink:type="simple" />
+            </inline-formula>
+            are real and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ r,s $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M25.jpg" xlink:type="simple" />
+            </inline-formula>
+            are complex. Further, in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], a model is constructed, which is based on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M26.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry and softly broken lepton numbers, to obtain a mass matrix of the same form as in Eq. (1) for light neutrinos. In this model, three Higgs doublets are introduced and light neutrinos acquire masses via type I seesaw mechanism [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib15">15</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib16">16</xref>
+            ]. The lepton number is softly broken by the mass terms for right-handed neutrinos in this model. However, in the absence of parameter fine tuning in the model, muon and tau leptons can have masses of the same order. To explain the hierarchy in the masses for these leptons,
+            <italic toggle="yes">K</italic>
+            symmetry is introduced, under which the muon is massless [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. Realistic masses for muon and tau leptons are explained in the above mentioned scenario with the soft breaking of the
+            <italic toggle="yes">K</italic>
+            symmetry [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ]. The work done together in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ], which is based on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M27.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, consistently explains the mixing pattern in lepton sector and also the masses for charged leptons.
+         </p>
+         <p>
+            Although the work done in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ] gives a consistent picture about masses and mixing pattern in the lepton sector, it suffers from a few limitations, as explained below. It is argued in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ] that the mass matrix of Eq. (1), which is obtained from
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M28.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, cannot give predictions about neutrino mass ordering and the mixing angle
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M29.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Moreover, in the case of maximal
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M30.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the mass matrix of Eq. (1) can make no predictions regarding
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M31.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. From the current neutrino oscillation data, it is known that neutrinos can have either normal or inverted mass ordering, where
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{12}\sim{1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M32.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{13}\sim10^{-2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M33.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ]. Apart from the above mentioned limitations, in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], mixing pattern in the quark sector was not addressed. Nonetheless, the mixing pattern in the quark sector [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ] is known to be different from that of lepton sector. The interest would be to know whether the same framework could be used to understand the mixing patterns for both quark and lepton sectors.
+         </p>
+         <p>
+            As stated above, in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], a model, which is based on type I seesaw mechanism and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M34.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, is presented with the aim of obtaining the neutrino mass matrix of the same form as Eq. (1). In this work, we rather aim at investigation whether the matrix in Eq. (1) can be obtained with type II seesaw mechanism [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib19">19</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib21">21</xref>
+            ] in the framework of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M35.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry. To achieve this, we construct a model, which has three Higgs doublets and one scalar Higgs triplet. In our model, right-handed neutrinos do not exist, and hence, neutrinos acquire masses when the Higgs triplet get vacuum expectation value (VEV). The purpose of Higgs doublets is to give masses to charged leptons via Yukawa couplings. With the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M36.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry in our model, if the VEV of Higgs triplet is real, we show that mass matrix for the light neutrinos will have the form of Eq. (1). To show whether the VEV of the Higgs triplet could be real, we analyze the scalar potential of our model. We demonstrate that by using an extra discrete symmetry, the VEV of Higgs triplet can be real. In parallel to that, we also address the problem of hierarchy in the masses of muon and tau leptons. In the literature, models have been constructed in order to achieve maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M37.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M38.jpg" xlink:type="simple" />
+            </inline-formula>
+            using type II seesaw mechanism [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib22">22</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib23">23</xref>
+            ]. However, in these models, multiple Higgs triplets have been introduced in addition to the three Higgs doublets. Hence, our model  proposed here is economical compared to the aforementioned models.
+         </p>
+         <p>
+            As stated previously, the mass matrix form given in Eq. (1) can predict maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M39.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M40.jpg" xlink:type="simple" />
+            </inline-formula>
+            . However, this matrix cannot make predictions about neutrino mass ordering and the mixing angles
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{12},\theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M41.jpg" xlink:type="simple" />
+            </inline-formula>
+            . As already pointed before, we have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{13}\sim10^{-2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M42.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], which means that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M43.jpg" xlink:type="simple" />
+            </inline-formula>
+            is a small angle. In this work, we perform an analysis, based on approximation procedures [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib24">24</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib25">25</xref>
+            ], and derive some conditions on the elements of neutrino mass matrix which can make predictions about the neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M44.jpg" xlink:type="simple" />
+            </inline-formula>
+            , apart from giving maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M45.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M46.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In this analysis, we assume
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{12}\sim{1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M47.jpg" xlink:type="simple" />
+            </inline-formula>
+            . To achieve the above mentioned conditions, new mechanisms should be proposed. In this work, we have attempted to provide one mechanism to achieve one of those conditions.
+         </p>
+         <p>
+            In our model three Higgs doublets give masses to charged leptons. Thus, it is worth knowing whether these scalar doublets can also generate masses and mixing pattern for quarks. Due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M48.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry in the lepton sector, it is found that these Higgs doublets should transform non-trivially under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M49.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. As a result, we propose
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M50.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations for quarks in such a way that the corresponding Yukawa couplings are invariant under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M51.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. A large hierarchy among the masses of quarks is known. Hence, to explain the mixing pattern for quarks, their Yukawa couplings should be hierarchically suppressed [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib26">26</xref>
+            ]. To explain the realistic mixing pattern for quarks through hierarchically suppressed Yukawa couplings, we followed the work done in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ]. For more information regarding other works on quark and lepton mixings with generalized
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M52.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations, see Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib29">29</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib30">30</xref>
+            ]. Additional works addressing quark and lepton mixings with other symmetries could be found in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib31">31</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib33">33</xref>
+            ].
+         </p>
+         <p>
+            The paper is organized as follows. In the next section, we propose a model for lepton mixing, where maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M53.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M54.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be predicted if the VEV of triplet Higgs is real. In Sec. III, we analyze the scalar potential of our model and show that the VEV of triplet Higgs can be real if we introduce additional discrete symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M55.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In Sec. IV, we obtain some conditions on the elements of the neutrino mass matrix of our model, which enable predictions about the neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M56.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In Sec. VI, we investigate quark masses and mixing patterns and demonstrate that they can be explained in the framework of our model. Conclusions are presented in the last section. In the Appendix, we attempt to describe a mechanism for achieving normal order of neutrino masses.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s02">
+         <label>II.</label>
+         <title>A MODEL FOR LEPTON MIXING</title>
+         <p>
+            The model we propose for lepton mixing is similar to that in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. We propose scalar Higgs doublets
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_i=(\phi_i^+,\phi_i^0)^T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M57.jpg" xlink:type="simple" />
+            </inline-formula>
+            , where
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ i=1,2,3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M58.jpg" xlink:type="simple" />
+            </inline-formula>
+            , in order to give masses to charged leptons. We denote the lepton doublets and singlets by
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{\alpha {\rm L}}=(\nu_{\alpha {\rm L}},\alpha_{\rm L})^T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M59.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \alpha_R $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M60.jpg" xlink:type="simple" />
+            </inline-formula>
+            , where
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \alpha=e,\mu,\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M61.jpg" xlink:type="simple" />
+            </inline-formula>
+            , respectively. The
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M62.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations on the lepton fields and Higgs doublets are defined as [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>2</label>
+               <tex-math id="cpc_46_10_103101_E2">
+                  <?CDATA $ \begin{aligned}[b] & D_{\alpha {\rm L}}\to {\rm i}S_{ \alpha\beta}\gamma^0C\bar{D}_{\beta {\rm L}}^T,\quad \alpha_{\rm R}\to {\rm i}S_{ \alpha\beta}\gamma^0C\bar{\beta}_{\rm R}^T, \\ & S=\left(\begin{array}{ccc} 1 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & 1 & 0 \end{array} \right), \quad \phi_{1,2}\to\phi_{1,2}^*,\quad \phi_3\to -\phi_3^*. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E2.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <italic toggle="yes">C</italic>
+            is the charge conjugation matrix. In addition to the invariance under the above mentioned
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M63.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations, one needs to impose conservation of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M64.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M65.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetries. Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M66.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the lepton number symmetry for the individual family of leptons. Under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M67.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, only the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ e_{\rm R} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M68.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M69.jpg" xlink:type="simple" />
+            </inline-formula>
+            change sign. Considering the aforementioned charge assignments, the invariant Lagrangian for charged lepton Yukawa couplings is given by [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>3</label>
+               <tex-math id="cpc_46_10_103101_E3">
+                  <?CDATA $ \begin{equation} {\cal L}_{\rm Y} = -y_e\bar{D}_{e{\rm L}}\phi_1e_{\rm R}-\sum\limits_{j=2}^3\sum\limits_{\alpha=\mu,\tau} g_{j\alpha}\bar{D}_{\alpha {\rm L}}\phi_j\alpha_{\rm R} +{\rm h.c}.. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E3.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In order for the Lagrangian in Eq. (3) to be invariant under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M70.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, we should have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ y_e $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M71.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be real,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ g_{2\mu}=g_{2\tau}^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M72.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ g_{3\mu}=-g_{3\tau}^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M73.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Since the mass of electron should be real, we take the VEV of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M74.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be real. In contrast, the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M75.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be complex, which give masses to muon and tau leptons, whose forms are given below [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ].
+         </p>
+         <p>
+            <disp-formula>
+               <label>4</label>
+               <tex-math id="cpc_46_10_103101_E4">
+                  <?CDATA $ \begin{equation} m_\mu=|g_{2\mu}v_2+g_{3\mu}v_3|,\quad m_\tau=|g^*_{2\mu}v_2-g^*_{3\mu}v_3|. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E4.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In this work, we take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle\phi_i^0\rangle=v_i $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M76.jpg" xlink:type="simple" />
+            </inline-formula>
+            for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ i=1,2,3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M77.jpg" xlink:type="simple" />
+            </inline-formula>
+            . As an a priori assumption, the VEVs of all Higgs doublets are of the same order. Hence, from the above equations, we notice that some fine tuning is necessary in order to explain the hierarchy in the muon and tau lepton masses. To reduce this fine tuning,
+            <italic toggle="yes">K</italic>
+            symmetry is introduced, under which the non-trivial transformations of the fields are given below [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>5</label>
+               <tex-math id="cpc_46_10_103101_E5">
+                  <?CDATA $ \begin{equation} \mu_R\to -\mu_R,\quad \phi_2\leftrightarrow\phi_3. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E5.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            After imposing this
+            <italic toggle="yes">K</italic>
+            symmetry in the above model, one can see that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ g_{2\mu}=-g_{3\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M78.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Using this in Eq. (4), we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>6</label>
+               <tex-math id="cpc_46_10_103101_E6">
+                  <?CDATA $ \begin{equation} \frac{m_\mu}{m_\tau}=\left|\frac{v_2-v_3}{v_2+v_3}\right|. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E6.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Since the scalar potential of this model should also respect the
+            <italic toggle="yes">K</italic>
+            symmetry, we should get
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_2=v_3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M79.jpg" xlink:type="simple" />
+            </inline-formula>
+            , and hence,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M80.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, to explain a non-zero but small
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M81.jpg" xlink:type="simple" />
+            </inline-formula>
+            , soft breaking of
+            <italic toggle="yes">K</italic>
+            symmetry can be introduced into the scalar potential of this model [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ]. The analysis related to this is presented in the next section.
+         </p>
+         <p>To explain the masses for neutrinos in the above described framework, we introduce the following Higgs triplet into the model.</p>
+         <p>
+            <disp-formula>
+               <label>7</label>
+               <tex-math id="cpc_46_10_103101_E7">
+                  <?CDATA $ \begin{equation} \Delta=\left(\begin{array}{cc} \dfrac{\Delta^+}{\sqrt{2}} & \Delta^{++} \\ -\Delta^0 & -\dfrac{\Delta^+}{\sqrt{2}} \end{array}\right). \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E7.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Δ is singlet under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M82.jpg" xlink:type="simple" />
+            </inline-formula>
+            , but otherwise transform under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M83.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry as
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta\to\Delta^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M84.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, the Yukawa couplings for neutrinos can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <label>8</label>
+               <tex-math id="cpc_46_10_103101_E8">
+                  <?CDATA $ \begin{equation} {\cal L}_Y=\frac{1}{2}\sum\limits_{\alpha,\,\beta=e,\,\mu,\,\tau}Y^\nu_{\alpha\beta} \bar{D}^c_{\alpha {\rm L}}{\rm i}\sigma_2\Delta D_{\beta {\rm L}}+{\rm h.c}.. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E8.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{\alpha {\rm L}}^c $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M85.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the charge conjugated doublet for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{\alpha {\rm L}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M86.jpg" xlink:type="simple" />
+            </inline-formula>
+            , and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sigma_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M87.jpg" xlink:type="simple" />
+            </inline-formula>
+            is a Pauli matrix. We can notice that the terms in the above Lagrangian break the lepton number symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M88.jpg" xlink:type="simple" />
+            </inline-formula>
+            explicitly. This can be considered technically natural, since the neutrino masses become zero in this model in the limit that the symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M89.jpg" xlink:type="simple" />
+            </inline-formula>
+            is exact. Hence, to explain the smallness of neutrino masses, the symmetry of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M90.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be broken by small amounts. Therefore, here, the neutrino Yukawa couplings
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\alpha\beta} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M91.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be small. Due to the invariance under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M92.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, these Yukawa couplings should satisfy
+         </p>
+         <p>
+            <disp-formula>
+               <label>9</label>
+               <tex-math id="cpc_46_10_103101_E9">
+                  <?CDATA $ \begin{equation} SY^\nu S=(Y^\nu)^*. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E9.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            After electroweak symmetry breaking, we can have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle\Delta^0\rangle=v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M93.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, from Eq. (8), we get the mass matrix for neutrinos, which is given by
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu=Y^\nu v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M94.jpg" xlink:type="simple" />
+            </inline-formula>
+            . If
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M95.jpg" xlink:type="simple" />
+            </inline-formula>
+            is real, using Eq. (9), we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>10</label>
+               <tex-math id="cpc_46_10_103101_E10">
+                  <?CDATA $ \begin{equation} SM_\nu S=M_\nu^*. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E10.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In order to satisfy the above relation, the form for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M96.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be the same as in Eq. (1). Hence, in the above proposed model, the mixing angle
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M97.jpg" xlink:type="simple" />
+            </inline-formula>
+            and the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M98.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating phase
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M99.jpg" xlink:type="simple" />
+            </inline-formula>
+            are maximal. However, to satisfy the relation in Eq. (10),
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M100.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real. In the next section, we present an analysis of the scalar potential in our model, where we demonstrate that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M101.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be real.
+         </p>
+         <p>
+            Now, we estimate the value of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M102.jpg" xlink:type="simple" />
+            </inline-formula>
+            in our work. As stated above, the neutrino mass matrix is
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu=Y^\nu v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M103.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Since the couplings
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M104.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be small, because they break the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M105.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry by a small amount, we take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu\sim 10^{-3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M106.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, by fitting
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M107.jpg" xlink:type="simple" />
+            </inline-formula>
+            to neutrino masses, which are obtained from the neutrino oscillation data, an estimation of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M108.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be obtained. Using the neutrino oscillation data, the following mass-square differences have been found [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], where we have given the best fit values.
+         </p>
+         <p>
+            <disp-formula>
+               <label>11</label>
+               <tex-math id="cpc_46_10_103101_E11">
+                  <?CDATA $ \begin{aligned}[b] & m_s^2\equiv m_2^2-m_1^2=7.5\times10^{-5}\; {\rm eV}^2,\\ & m_a^2\equiv\left\{\begin{array}{c} m_3^2-m_1^2=2.55\times10^{-3}\; {\rm eV}^2\; \; {\rm (NO)}\\ m_1^2-m_3^2=2.45\times10^{-3}\; {\rm eV}^2\; \; {\rm (IO)} \end{array}\right.. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E11.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{1,2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M109.jpg" xlink:type="simple" />
+            </inline-formula>
+            are neutrino mass eigenvalues and NO(IO) represents normal (inverted) ordering. Using the above values, we get
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_s\sim0.0087 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M110.jpg" xlink:type="simple" />
+            </inline-formula>
+            eV and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_a\sim0.05 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M111.jpg" xlink:type="simple" />
+            </inline-formula>
+            eV, which correspond to solar and atmospheric neutrino mass scales, respectively. To fit these neutrino mass scales in our work, we can take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta\sim1-10 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M112.jpg" xlink:type="simple" />
+            </inline-formula>
+            eV.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s03">
+         <label>III.</label>
+         <title>ANALYSIS OF SCALAR POTENTIAL</title>
+         <p>
+            The scalar fields of the model proposed in the previous section are charged under the symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ C P\times Z_2\times K $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M113.jpg" xlink:type="simple" />
+            </inline-formula>
+            . The invariant scalar potential of this model can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <label>12</label>
+               <tex-math id="cpc_46_10_103101_E12">
+                  <?CDATA $ \begin{equation} V_{\rm inv}=V_D+V_T. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E12.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_D $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M114.jpg" xlink:type="simple" />
+            </inline-formula>
+            contains potential terms only for the Higgs doublets.
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M115.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the scalar potential for the triplet Higgs in our model. The form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_D $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M116.jpg" xlink:type="simple" />
+            </inline-formula>
+            is given by [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>13</label>
+               <tex-math id="cpc_46_10_103101_E13">
+                  <?CDATA $ \begin{aligned}[b] V_D= & -M_1^2\phi_1^\dagger\phi_1 -M_2^2(\phi_2^\dagger\phi_2+\phi_3^\dagger\phi_3) +\lambda_1(\phi_1^\dagger\phi_1)^2 \\ & +\lambda_2\left[(\phi_2^\dagger\phi_2)^2+(\phi_3^\dagger\phi_3)^2\right] \\ & +\lambda_3(\phi_1^\dagger\phi_1)(\phi_2^\dagger\phi_2+\phi_3^\dagger\phi_3) +\lambda_4(\phi_2^\dagger\phi_2)(\phi_3^\dagger\phi_3) \\ & +\lambda_5\left[(\phi_1^\dagger\phi_2)(\phi_2^\dagger\phi_1) +(\phi_1^\dagger\phi_3)(\phi_3^\dagger\phi_1)\right] \\ & +\lambda_6\left[(\phi_2^\dagger\phi_3)(\phi_3^\dagger\phi_2)\right] +\lambda_7\left[(\phi_2^\dagger\phi_3)^2+(\phi_3^\dagger\phi_2)^2\right] \\ & +\lambda_8\left[(\phi_1^\dagger\phi_2)^2+(\phi_1^\dagger\phi_3)^2 +(\phi_2^\dagger\phi_1)^2+(\phi_3^\dagger\phi_1)^2\right] \\ & +{\rm i}\lambda_9\left[(\phi_1^\dagger\phi_2)(\phi_1^\dagger\phi_3) -(\phi_2^\dagger\phi_1)(\phi_3^\dagger\phi_1)\right] \\ & +{\rm i}\lambda_{10}(\phi_2^\dagger\phi_3-\phi_3^\dagger\phi_2) (\phi_2^\dagger\phi_2-\phi_3^\dagger\phi_3). \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E13.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above equation, all parameters are real due to either hermiticity or
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M117.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry of the potential. To obtain
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M118.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we have followed the work in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib34">34</xref>
+            ]. The form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M119.jpg" xlink:type="simple" />
+            </inline-formula>
+            is given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>14</label>
+               <tex-math id="cpc_46_10_103101_E14">
+                  <?CDATA $ \begin{aligned}[b] V_T= & m_\Delta^2{\rm Tr}(\Delta^\dagger\Delta) +\frac{1}{2}\lambda_\Delta[{\rm Tr}(\Delta^\dagger\Delta)]^2 \\ & +\lambda_{11}\phi_1^\dagger\phi_1{\rm Tr}(\Delta^\dagger\Delta) +\lambda_{12}(\phi_2^\dagger\phi_2+\phi_3^\dagger\phi_3) {\rm Tr}(\Delta^\dagger\Delta) \\ & +\lambda_{13}{\rm Tr}(\Delta^\dagger\Delta^\dagger){\rm Tr}(\Delta\Delta) +\lambda_{14}\phi_1^\dagger\Delta^\dagger\Delta\phi_1 \\ & +\lambda_{15}(\phi_2^\dagger\Delta^\dagger\Delta\phi_2 +\phi_3^\dagger\Delta^\dagger\Delta\phi_3) \\ & +\kappa_1(\tilde{\phi}_1^T{\rm i}\sigma_2\Delta\tilde{\phi}_1+{\rm h.c}.) \\ & +\kappa_2(\tilde{\phi}_2^T{\rm i}\sigma_2\Delta\tilde{\phi}_2 +\tilde{\phi}_3^T{\rm i}\sigma_2\Delta\tilde{\phi}_3+{\rm h.c}.) \\ & +{\rm i}\kappa_3(\tilde{\phi}_2^T{\rm i}\sigma_2\Delta\tilde{\phi}_3-{\rm h.c}.) \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E14.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \tilde{\phi}_k={\rm i}\sigma_2\phi_k^*,\;k=1,2,3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M120.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Similarly, all parameters in the above equation are real, due to either hermiticity or
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M121.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry of the potential.
+         </p>
+         <p>
+            As described in the previous section, the VEV of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M122.jpg" xlink:type="simple" />
+            </inline-formula>
+            is real, whereas the VEVs for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M123.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be complex. Although all parameters in Eq. (14) are real, due to complex VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M124.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the trilinear terms containing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M125.jpg" xlink:type="simple" />
+            </inline-formula>
+            can contribute complex VEV to Δ. However, it may happen that the phases of the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M126.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be fine tuned in such a way that the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M127.jpg" xlink:type="simple" />
+            </inline-formula>
+            -terms can give a real VEV to Δ. We study these points by minimizing the scalar potential of our model. Nonetheless, we first have to estimate the order of magnitudes for the unknown parameters in Eqs. (13) and (14). From the naturalness argument, we take all dimensionless
+            <italic toggle="yes">λ</italic>
+            parameters to be
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {\cal O}(1) $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M128.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Since the VEVs of Higgs doublets should be around the electroweak scale of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_{\rm EW}= $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M129.jpg" xlink:type="simple" />
+            </inline-formula>
+            174 GeV, we take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_1^2,M_2^2\sim v_{\rm EW}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M130.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, we have to determine the order of magnitudes for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M131.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa_{1,2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M132.jpg" xlink:type="simple" />
+            </inline-formula>
+            . This is explained below. After minimizing the potential of Eq. (14) with respect to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M133.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>15</label>
+               <tex-math id="cpc_46_10_103101_E15">
+                  <?CDATA $ \begin{equation} v_\Delta\sim\frac{\kappa v_{\rm EW}^2}{m_\Delta^2+\lambda v_{\rm EW}^2}. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E15.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa\sim\kappa_{1,2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M134.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \lambda\sim\lambda_{11,12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M135.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In the above equation, we have used
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta\ll v_{\rm EW} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M136.jpg" xlink:type="simple" />
+            </inline-formula>
+            . To get a very small
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M137.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we can consider the following two cases.
+         </p>
+         <p>
+            <disp-formula>
+               <label>16</label>
+               <tex-math id="cpc_46_10_103101_E16">
+                  <?CDATA $ \begin{aligned}[b] & {\rm case\; I}:\quad m_\Delta\gg v_{\rm EW},\quad \kappa\sim m_\Delta. \\ & {\rm case\; II}:\quad m_\Delta\sim v_{\rm EW},\quad \kappa\sim v_\Delta. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E16.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In case I, the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M138.jpg" xlink:type="simple" />
+            </inline-formula>
+            is explained by considering a large value for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M139.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 10^{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M140.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV. In case II, by suppressing the
+            <italic toggle="yes">κ</italic>
+            parameters, one can understand the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M141.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In case I, the value of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M142.jpg" xlink:type="simple" />
+            </inline-formula>
+            is close to the breaking scale of supersymmetry in supergravity models [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib35">35</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib36">36</xref>
+            ]. Hence, one can motivate case I from supersymmetry. In contrast, in case II, one has to find a mechanism for the suppression of
+            <italic toggle="yes">κ</italic>
+            parameters. From the phenomenology point of view, case II can be tested in the LHC experiment, since the masses for the components of scalar triplet Higgs can be around few 100 GeV.
+         </p>
+         <p>
+            In case I, we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_D\rangle\sim\langle V_T\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M143.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Only the terms containing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M144.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <italic toggle="yes">κ</italic>
+            parameters in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_T\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M145.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be of the same order as
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_D\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M146.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Other terms in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_T\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M147.jpg" xlink:type="simple" />
+            </inline-formula>
+            give negligibly small contribution in comparison to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_D\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M148.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In contrast, in case II,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_T\rangle\ll\langle V_D\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M149.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Because of this difference in the contribution of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M150.jpg" xlink:type="simple" />
+            </inline-formula>
+            in both these cases, we minimize the scalar potential of our model separately for these two cases.
+         </p>
+         <sec id="cpc_46_10_103101_s03-01">
+            <label>A.</label>
+            <title>Case I</title>
+            <p>We parametrize the VEVs of scalar fields as follows.</p>
+            <p>
+               <disp-formula>
+                  <label>17</label>
+                  <tex-math id="cpc_46_10_103101_E17">
+                     <?CDATA $ \begin{aligned}[b] & \langle\phi_1^0\rangle=v_1,\quad \langle\phi_2^0\rangle=v_2=v\cos\sigma {\rm e}^{{\rm i}\alpha},\\ & \langle\phi_3^0\rangle=v_3=v\sin\sigma {\rm e}^{{\rm i}\beta},\quad \langle\Delta^0\rangle=v_\Delta=v^\prime {\rm e}^{{\rm i}\theta}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E17.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_1,\;v,\;v^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M151.jpg" xlink:type="simple" />
+               </inline-formula>
+               are real. We plug the above parametrizations in the scalar potential of Eq. (12). Since we want
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle\Delta^0\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M152.jpg" xlink:type="simple" />
+               </inline-formula>
+               to be real, and moreover,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M153.jpg" xlink:type="simple" />
+               </inline-formula>
+               respect
+               <italic toggle="yes">K</italic>
+               symmetry, we look for a minimum at
+            </p>
+            <p>
+               <disp-formula>
+                  <label>18</label>
+                  <tex-math id="cpc_46_10_103101_E18">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4},\quad\alpha=\beta=\omega,\quad\theta=0. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E18.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Now, we take first derivatives of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M154.jpg" xlink:type="simple" />
+               </inline-formula>
+               with respect to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta,\;\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M155.jpg" xlink:type="simple" />
+               </inline-formula>
+               at the values mentioned in Eq. (18). Thereafter, we get the following two conditions.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>19</label>
+                  <tex-math id="cpc_46_10_103101_E19">
+                     <?CDATA $ \begin{array}{*{20}{l}} & & 2\lambda_8\sin2\omega+\lambda_9\cos2\omega=0, \end{array} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E19.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>20</label>
+                  <tex-math id="cpc_46_10_103101_E20">
+                     <?CDATA $ \begin{array}{*{20}{l}} & & 2\kappa_2\sin2\omega=\kappa_3\cos2\omega. \end{array} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E20.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               By satisfying the above two conditions, Eq. (18) gives a minimum to our scalar potential. We justify that this a minimum, after computing the second derivatives of the potential. This analysis is presented shortly later. However, with the minimum of Eq. (18), we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_2=v_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M156.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Hence,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M157.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which follows from Eq. (6). To get non-zero and small
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M158.jpg" xlink:type="simple" />
+               </inline-formula>
+               , one should add
+               <italic toggle="yes">K</italic>
+               -violating terms in our model, which break the
+               <italic toggle="yes">K</italic>
+               symmetry explicitly by a small amount. Here, we can see the analogy between
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U_{L_\alpha} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M159.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <italic toggle="yes">K</italic>
+               symmetries of our model. Both of these symmetries are broken explicitly by a small amount in order to generate small masses for neutrinos and muon.
+            </p>
+            <p>
+               After including the
+               <italic toggle="yes">K</italic>
+               -violating terms, the procedure we follow for minimization of the scalar potential is similar to that in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ]. However, in this work, we write a more general form for
+               <italic toggle="yes">K</italic>
+               -violating terms as compared to that in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ]. In Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], only the soft terms, which break the
+               <italic toggle="yes">K</italic>
+               symmetry, are considered. The general form for
+               <italic toggle="yes">K</italic>
+               -violating terms in our model, which respects the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ CP\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M160.jpg" xlink:type="simple" />
+               </inline-formula>
+               , is given by
+            </p>
+            <p>
+               <disp-formula>
+                  <label>21</label>
+                  <tex-math id="cpc_46_10_103101_E21">
+                     <?CDATA $ \begin{aligned}[b]V_{\not{K}}= & {\rm i}\delta M_s^2(\phi_2^\dagger\phi_3-\phi_3^\dagger\phi_2) +\delta M_2^2\phi_2^\dagger\phi_2+\delta M_3^2\phi_3^\dagger\phi_3 \\ & +\delta\kappa_2(\tilde{\phi}_2^T{\rm i}\sigma_2\Delta\tilde{\phi}_2+{\rm h.c}.) +\delta\kappa_2^\prime(\tilde{\phi}_3^T{\rm i}\sigma_2\Delta\tilde{\phi}_3+{\rm h.c}.) \\ & +\delta\lambda_2(\phi_2^\dagger\phi_2)^2 +\delta\lambda_2^\prime(\phi_3^\dagger\phi_3)^2 +\delta\lambda_3(\phi_1^\dagger\phi_1)(\phi_2^\dagger\phi_2) \\ & +\delta\lambda_3^\prime(\phi_1^\dagger\phi_1)(\phi_3^\dagger\phi_3) \\ & +\delta\lambda_5(\phi_1^\dagger\phi_2)(\phi_2^\dagger\phi_1) +\delta\lambda_5^\prime(\phi_1^\dagger\phi_3)(\phi_3^\dagger\phi_1) \\ & +\delta\lambda_8\left[(\phi_1^\dagger\phi_2)^2+(\phi_2^\dagger\phi_1)^2\right] +\delta\lambda_8^\prime\left[(\phi_1^\dagger\phi_3)^2 +(\phi_3^\dagger\phi_1)^2\right] \\ & +{\rm i}\delta\lambda_{10}(\phi_2^\dagger\phi_2)(\phi_2^\dagger\phi_3 -\phi_3^\dagger\phi_2) \\ & +{\rm i}\delta\lambda_{10}^\prime(\phi_3^\dagger\phi_3)(\phi_2^\dagger\phi_3 -\phi_3^\dagger\phi_2) \\ & +{\rm i}\delta\lambda_s(\phi_1^\dagger\phi_1)(\phi_2^\dagger\phi_3 -\phi_3^\dagger\phi_2) \\ & +{\rm i}\delta\lambda_s^\prime\left[(\phi_1^\dagger\phi_2)(\phi_3^\dagger\phi_1) -(\phi_2^\dagger\phi_1)(\phi_1^\dagger\phi_3)\right] \\ & +\delta\lambda_{12}\phi_2^\dagger\phi_2{\rm Tr}(\Delta^\dagger\Delta) +\delta\lambda_{12}^\prime\phi_3^\dagger\phi_3{\rm Tr}(\Delta^\dagger\Delta) \\ & +\delta\lambda_{15}\phi_2^\dagger\Delta^\dagger\Delta\phi_2 +\delta\lambda_{15}^\prime\phi_3^\dagger\Delta^\dagger\Delta\phi_3 \\ & +{\rm i}\delta\lambda_t(\phi_2^\dagger\phi_3-\phi_3^\dagger\phi_2) {\rm Tr}(\Delta^\dagger\Delta) \\ & +{\rm i}\delta\lambda_t^\prime(\phi_2^\dagger\Delta^\dagger\Delta\phi_3 -\phi_3^\dagger\Delta^\dagger\Delta\phi_2). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E21.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               All parameters in the above equation are real, due to either hermiticity or
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M161.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry of the potential. Terms in the first and second lines are quadratic and trilinear, respectively. Rest of the terms in the above equation are quartic.
+            </p>
+            <p>
+               In Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], only the soft terms which are quadratic are given. Moreover, the last two terms in the first line of Eq. (21) are given in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], but by taking
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta M_2^2=-\delta M_3^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M162.jpg" xlink:type="simple" />
+               </inline-formula>
+               . We notice that if
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta M_2^2 =\delta M_3^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M163.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the sum of the corresponding terms in Eq. (21) is
+               <italic toggle="yes">K</italic>
+               -symmetric. Hence, as long as
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta M_2^2\neq\delta M_3^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M164.jpg" xlink:type="simple" />
+               </inline-formula>
+               , each of these corresponding terms in Eq. (21) is
+               <italic toggle="yes">K</italic>
+               -violating but conserving
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times Z_2$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M165.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Based on this observation, we have constructed other
+               <italic toggle="yes">K</italic>
+               -violating terms in Eq. (21). Since the terms in Eq. (21) break
+               <italic toggle="yes">K</italic>
+               symmetry by a small amount, their corresponding parameters should be small compared to the corresponding parameters of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M166.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               After including the
+               <italic toggle="yes">K</italic>
+               -violating terms, the total scalar potential of our model is
+            </p>
+            <p>
+               <disp-formula>
+                  <label>22</label>
+                  <tex-math id="cpc_46_10_103101_E22">
+                     <?CDATA $ \begin{equation} V_{\rm total}=V_{\rm inv}+V_{\not{K}}. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E22.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Previously, we minimized
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M167.jpg" xlink:type="simple" />
+               </inline-formula>
+               and argued that the minimum can be at Eq. (18). Now, due to the presence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M168.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the above minimum can be shifted by a small amount. Consequently, the minimum for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M169.jpg" xlink:type="simple" />
+               </inline-formula>
+               in terms of small deviations
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\delta_+,\delta_-,\delta_\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M170.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be written as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>23</label>
+                  <tex-math id="cpc_46_10_103101_E23">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4}-\frac{\delta_0}{2},\quad \alpha=\omega+\delta_++\frac{\delta_-}{2},\quad \beta=\omega+\delta_+-\frac{\delta_-}{2},\quad \theta=0+\delta_\theta. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E23.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Now, we express
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle V_{\rm inv}\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M171.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle V_{\not{K}}\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M172.jpg" xlink:type="simple" />
+               </inline-formula>
+               as a series summation up to second and first order, respectively, in the aforementioned small deviations. After neglecting the constant terms, we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>24</label>
+                  <tex-math id="cpc_46_10_103101_E24">
+                     <?CDATA $ \begin{equation} \langle V_{\rm total}\rangle=\frac{1}{2}\sum\limits_{a,b}{\cal F}_{ab}\delta_a\delta_b +\sum\limits_{a}f_a\delta_a. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E24.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M173.jpg" xlink:type="simple" />
+               </inline-formula>
+               is symmetric in the indices
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ a,b $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M174.jpg" xlink:type="simple" />
+               </inline-formula>
+               , corresponding to  the second derivatives of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M175.jpg" xlink:type="simple" />
+               </inline-formula>
+               calculated in Eq. (18). Non-vanishing elements of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M176.jpg" xlink:type="simple" />
+               </inline-formula>
+               are given below.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>25</label>
+                  <tex-math id="cpc_46_10_103101_E25">
+                     <?CDATA $ \begin{aligned}[b]{\cal F}_{++}= & (-8\lambda_8\cos2\omega+4\lambda_9\sin2\omega)v_1^2v^2 \\ & +(8\kappa_2\cos2\omega+4\kappa_3\sin2\omega)v^2v^\prime, \\ {\cal F}_{–}= & -2\lambda_7v^4-2\lambda_8v_1^2v^2\cos2\omega +2\kappa_2v^2v^\prime\cos2\omega, \\ {\cal F}_{00}= & -\frac{1}{2}\tilde{\lambda}v^4 +(\lambda_9v_1^2+\kappa_3v^\prime)v^2\sin2\omega, \\ {\cal F}_{\theta\theta}= & 2\kappa_1v_1^2v^\prime+2\kappa_2v^2v^\prime \cos2\omega+\kappa_3v^2v^\prime\sin2\omega, \\ {\cal F}_{0-}= & -2\lambda_8v_1^2v^2\sin2\omega+\lambda_{10}v^4 +2\kappa_2v^2v^\prime\sin2\omega, \\ {\cal F}_{+\theta}= & -2(2\kappa_2\cos2\omega+\kappa_3\sin2\omega)v^2v^\prime. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E25.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \tilde{\lambda}=-2\lambda_2+\lambda_4+\lambda_6+2\lambda_7 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M177.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The expressions for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_a $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M178.jpg" xlink:type="simple" />
+               </inline-formula>
+               are given below.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>26</label>
+                  <tex-math id="cpc_46_10_103101_E26">
+                     <?CDATA $ \begin{aligned}[b] f_0= & \frac{1}{2}(\delta M_2^2-\delta M_3^2)v^2 -(\delta\kappa_2-\delta\kappa_2^\prime)v^2v^\prime\cos2\omega \\ & +\frac{1}{2}(\delta\lambda_2-\delta\lambda_2^\prime)v^4 +\frac{1}{2}[\delta\lambda_3-\delta\lambda_3^\prime +\delta\lambda_5\\ & -\delta\lambda_5^\prime +2(\delta\lambda_8-\delta\lambda_8^\prime)\cos2\omega](v_1v)^2 \\ & +\frac{1}{2}(\delta\lambda_{12}-\delta\lambda_{12}^\prime)(vv^\prime)^2, \\f_-= & \delta M_s^2v^2+(\delta\kappa_2-\delta\kappa_2^\prime) v^2v^\prime\sin2\omega \\ & -(\delta\lambda_8-\delta\lambda_8^\prime)\sin2\omega(v_1v)^2 +\frac{1}{2}(\delta\lambda_{10}+\delta\lambda_{10}^\prime)v^4 \\ & +(\delta\lambda_s-\delta\lambda_s^\prime)(v_1v)^2 +\delta\lambda_t(vv^\prime)^2, \\ f_+= & 2(\delta\kappa_2+\delta\kappa_2^\prime)v^2v^\prime\sin2\omega -2(\delta\lambda_8+\delta\lambda_8^\prime)\sin2\omega(v_1v)^2, \\ f_\theta= & -(\delta\kappa_2+\delta\kappa_2^\prime)v^2v^\prime\sin2\omega. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E26.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Using Eq. (24), the small deviations in the minimum of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M179.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be obtained as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>27</label>
+                  <tex-math id="cpc_46_10_103101_E27">
+                     <?CDATA $ \begin{equation} \delta=-{\cal F}^{-1}f. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E27.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta=(\delta_0,\delta_-,\delta_+,\delta_\theta)^T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M180.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f=(f_0,f_-,f_+,f_\theta)^T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M181.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M182.jpg" xlink:type="simple" />
+               </inline-formula>
+               is a matrix containing the elements
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M183.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               Since some elements of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M184.jpg" xlink:type="simple" />
+               </inline-formula>
+               are zero, Eq. (27) can be decomposed into
+            </p>
+            <p>
+               <disp-formula>
+                  <label>28</label>
+                  <tex-math id="cpc_46_10_103101_E28">
+                     <?CDATA $ \begin{aligned}[b] & \left(\begin{array}{c}\delta_0 \\ \delta_-\end{array}\right) =-{\cal F}_1^{-1}\left(\begin{array}{c}f_0 \\ f_-\end{array}\right),\quad {\cal F}_1=\left(\begin{array}{cc} {\cal F}_{00} & {\cal F}_{0-} \\ {\cal F}_{0-} & {\cal F}_{–} \end{array}\right), \\ & \left(\begin{array}{c}\delta_+ \\ \delta_\theta\end{array}\right) =-{\cal F}_2^{-1}\left(\begin{array}{c}f_+ \\ f_\theta\end{array}\right),\quad {\cal F}_2=\left(\begin{array}{cc} {\cal F}_{++} & {\cal F}_{+\theta} \\ {\cal F}_{+\theta} & {\cal F}_{\theta\theta}\end{array}\right). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E28.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               We can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M185.jpg" xlink:type="simple" />
+               </inline-formula>
+               is in block diagonal form containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M186.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M187.jpg" xlink:type="simple" />
+               </inline-formula>
+               . As stated earlier, the elements of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M188.jpg" xlink:type="simple" />
+               </inline-formula>
+               correspond to second derivatives of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $V_{\rm inv}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M189.jpg" xlink:type="simple" />
+               </inline-formula>
+               calculated in Eq. (18). It follows that, if the eigenvalues of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M190.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M191.jpg" xlink:type="simple" />
+               </inline-formula>
+               are positive, then Eq. (18) gives minimum to the scalar potential in the absence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M192.jpg" xlink:type="simple" />
+               </inline-formula>
+               . One can see that the unknown
+               <italic toggle="yes">λ</italic>
+               and
+               <italic toggle="yes">κ</italic>
+               parameters of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{1,2} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M193.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be chosen in such a way that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{1,2} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M194.jpg" xlink:type="simple" />
+               </inline-formula>
+               yields positive eigenvalues. However, in the presence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M195.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the minimum of the scalar potential in our model is shifted to Eq. (23). The small deviations of Eq. (23) can be computed from Eq. (28), from which we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_-,\delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M196.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Hence,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_2\neq v_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M197.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Using the expressions for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_-,\delta_+ $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M198.jpg" xlink:type="simple" />
+               </inline-formula>
+               in Eq. (6), we can get the required hierarchy between
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M199.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\tau $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M200.jpg" xlink:type="simple" />
+               </inline-formula>
+               , provided the parameters of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M201.jpg" xlink:type="simple" />
+               </inline-formula>
+               are small. It can be noticed that the parametrizations used in Eq. (23) are similar to those in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], in whichit has been pointed out that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_+=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M202.jpg" xlink:type="simple" />
+               </inline-formula>
+               . In our work, we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M203.jpg" xlink:type="simple" />
+               </inline-formula>
+               , since
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M204.jpg" xlink:type="simple" />
+               </inline-formula>
+               . This difference is due to the fact that in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ],
+               <italic toggle="yes">K</italic>
+               -violating quartic terms are not considered.
+            </p>
+            <p>
+               We have described that using the
+               <italic toggle="yes">K</italic>
+               -violating terms of our model, we can explain the required hierarchy between muon and tau lepton masses. However, in doing so, from Eq. (28) we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_\theta\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M205.jpg" xlink:type="simple" />
+               </inline-formula>
+               , makes
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M206.jpg" xlink:type="simple" />
+               </inline-formula>
+               complex. One can fine tune the parameters in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_2,f_+, f_\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M207.jpg" xlink:type="simple" />
+               </inline-formula>
+               in such a way that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_\theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M208.jpg" xlink:type="simple" />
+               </inline-formula>
+               . In contrast, to get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_\theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M209.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we can take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{+\theta}=0=f_\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M210.jpg" xlink:type="simple" />
+               </inline-formula>
+               . After using Eq. (20),
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{+\theta}=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M211.jpg" xlink:type="simple" />
+               </inline-formula>
+               implies that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \kappa_2=\kappa_3=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M212.jpg" xlink:type="simple" />
+               </inline-formula>
+               . To make
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_\theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M213.jpg" xlink:type="simple" />
+               </inline-formula>
+               , either we can take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta\kappa_2=-\delta\kappa_2^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M214.jpg" xlink:type="simple" />
+               </inline-formula>
+               or forbid the trilinear terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M215.jpg" xlink:type="simple" />
+               </inline-formula>
+               . From the above observations,  to make
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M216.jpg" xlink:type="simple" />
+               </inline-formula>
+               real in case I, without fine tuning the parameters, the trilinear terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M217.jpg" xlink:type="simple" />
+               </inline-formula>
+               containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M218.jpg" xlink:type="simple" />
+               </inline-formula>
+               should be forbidden.
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103101_s03-02">
+            <label>B.</label>
+            <title>Case II</title>
+            <p>
+               As explained before, in this case, terms involving triplet Higgs give very small contribution in comparison to that involving only doublet Higgses. As a result, the minimization of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M219.jpg" xlink:type="simple" />
+               </inline-formula>
+               in this case proceeds in two steps. First, we minimize
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M220.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which contains only doublet Higgses and thereby determine the VEVs of these fields. Later, after using the VEVs of doublet Higgses, we minimize the potential containing the triplet Higgs field. In the first step of minimization, we can neglect
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M221.jpg" xlink:type="simple" />
+               </inline-formula>
+               in comparison to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_D $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M222.jpg" xlink:type="simple" />
+               </inline-formula>
+               and the terms in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M223.jpg" xlink:type="simple" />
+               </inline-formula>
+               containing the triplet Higgs field. In this case, we parametrize the VEVs for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{1,2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M224.jpg" xlink:type="simple" />
+               </inline-formula>
+               and Δ as given in Eq. (17). After minimizing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_D $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M225.jpg" xlink:type="simple" />
+               </inline-formula>
+               with respect to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\alpha,\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M226.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the minimum is given by Eq. (18) with the condition of Eq. (19). Since this minimum gives
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M227.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we introduce
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M228.jpg" xlink:type="simple" />
+               </inline-formula>
+               and parametrize the deviations in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\alpha,\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M229.jpg" xlink:type="simple" />
+               </inline-formula>
+               , as given by Eq. (23). Consequently, one can notice that the above mentioned deviations can be found from Eq. (27), where, in this case,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M230.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <italic toggle="yes">f</italic>
+               are 3
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \times $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M231.jpg" xlink:type="simple" />
+               </inline-formula>
+               3 and 3
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \times $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M232.jpg" xlink:type="simple" />
+               </inline-formula>
+               1 matrices, respectively. The components of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M233.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <italic toggle="yes">f</italic>
+               can be found from Eqs. (25) and (26), where the terms containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M234.jpg" xlink:type="simple" />
+               </inline-formula>
+               should be omitted, leading to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_-,\delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M235.jpg" xlink:type="simple" />
+               </inline-formula>
+               . After using this in Eq. (6), we get small and non-zero
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M236.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               Since the VEVs of doublet Higgses are determined, we now minimize
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M237.jpg" xlink:type="simple" />
+               </inline-formula>
+               and try to see if
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M238.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be real. After using Eq. (17) in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M239.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>29</label>
+                  <tex-math id="cpc_46_10_103101_E29">
+                     <?CDATA $ \begin{aligned}[b] \langle V_T\rangle= & (m_\Delta^2+\lambda_{11}v_1^2+\lambda_{12}v^2)v^{\prime^2} +\frac{1}{2}\lambda_\Delta v^{\prime^4}-2\kappa_1v_1^2v^\prime\cos\theta \\ & -2\kappa_2v^2v^\prime[\cos^2\sigma\cos(\theta-2\alpha) +\sin^2\sigma\cos(\theta-2\beta)] \\ & +\kappa_3v^2v^\prime\sin2\sigma\sin(\theta-\alpha-\beta). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E29.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since we are looking for a minimum at
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M240.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we do
+            </p>
+            <p>
+               <disp-formula>
+                  <label>30</label>
+                  <tex-math id="cpc_46_10_103101_E30">
+                     <?CDATA $ \begin{aligned}[b] \left.\frac{\partial\langle V_T\rangle}{\partial\theta}\right|_{\theta=0}= & 0 \Rightarrow -2\kappa_2[\cos^2\sigma\sin2\alpha+\sin^2\sigma\sin2\beta] \\ & +\kappa_3\sin2\sigma\cos(\alpha+\beta)=0. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E30.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               As stated earlier, we have determined
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M241.jpg" xlink:type="simple" />
+               </inline-formula>
+               up to the first order in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_-,\;\delta_+ $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M242.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Plugging the parametrizations for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M243.jpg" xlink:type="simple" />
+               </inline-formula>
+               in the above equation and expanding the terms up to the first order in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\delta_-,\delta_+ $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M244.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>31</label>
+                  <tex-math id="cpc_46_10_103101_E31">
+                     <?CDATA $ \begin{equation} 2\kappa_2\sin2\omega-\kappa_3\cos2\omega +2(2\kappa_2\cos2\omega+\kappa_3\sin2\omega)\delta_+=0. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E31.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since we have
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M245.jpg" xlink:type="simple" />
+               </inline-formula>
+               , after equating the leading and subleading terms of the above equation to zero, we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \kappa_2=\kappa_3=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M246.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Hence, in case II, one has to forbid the trilinear terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M248.jpg" xlink:type="simple" />
+               </inline-formula>
+               containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M249.jpg" xlink:type="simple" />
+               </inline-formula>
+               to make
+               <italic toggle="yes">v</italic>
+               <sub>Δ</sub>
+               real.
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103101_s03-03">
+            <label>C.</label>
+            <title>
+               Imposing an extra
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA ${\boldsymbol Z}_{\bf 3}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M250.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry
+            </title>
+            <p>
+               From the analysis of the previous two subsections, we have seen that the trilinear terms in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M251.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which contain
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M252.jpg" xlink:type="simple" />
+               </inline-formula>
+               , should be forbidden in order to make
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M253.jpg" xlink:type="simple" />
+               </inline-formula>
+               real. To achieve this, we impose the discrete symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M254.jpg" xlink:type="simple" />
+               </inline-formula>
+               in our model. Under this symmetry, the non-trivial transformations are as follows.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>32</label>
+                  <tex-math id="cpc_46_10_103101_E32">
+                     <?CDATA $ \begin{aligned}[b] & \phi_2\to\Omega\phi_2,\quad\phi_3\to\Omega\phi_3, \\ & \mu_{\rm R}\to\Omega^2\mu_{\rm R},\quad\tau_{\rm R}\to\Omega^2\tau_{\rm R}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E32.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \Omega={\rm e}^{2\pi {\rm i}/3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M255.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Under the above transformations, the Yukawa couplings for leptons are invariant, whereas the following couplings in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M256.jpg" xlink:type="simple" />
+               </inline-formula>
+               are forbidden:
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \lambda_{8,9},\;\kappa_{2,3}, \delta\kappa,\;\delta\kappa^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M257.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Now, after using the parametrizations of Eq. (17) in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M258.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>33</label>
+                  <tex-math id="cpc_46_10_103101_E33">
+                     <?CDATA $ \begin{aligned}[b] \langle V_{\rm inv}\rangle= & \frac{1}{4}[\tilde{\lambda}-4\lambda_7\sin^2\zeta]v^4 \sin^22\sigma\\ & +\frac{1}{2}\lambda_{10}v^4\sin4\sigma\sin\zeta -2\kappa_1v_1^2v^\prime\cos\theta. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E33.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \zeta=\alpha-\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M259.jpg" xlink:type="simple" />
+               </inline-formula>
+               . In the above equation, we have neglected constant terms which do not depend on
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta,\;\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M260.jpg" xlink:type="simple" />
+               </inline-formula>
+               . We can notice from the above equation that
+               <italic toggle="yes">θ</italic>
+               do not mix with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\zeta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M261.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Moreover, due to the absence of trilinear terms in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M262.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle V_{\not{K}}\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M263.jpg" xlink:type="simple" />
+               </inline-formula>
+               do not depend on
+               <italic toggle="yes">θ</italic>
+               . As a result, we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M264.jpg" xlink:type="simple" />
+               </inline-formula>
+               is a minimum to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M265.jpg" xlink:type="simple" />
+               </inline-formula>
+               if
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \kappa_1v^\prime \gt 0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M266.jpg" xlink:type="simple" />
+               </inline-formula>
+               . This statement is true for both cases I and II. Hence, after imposing the above mentioned
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M267.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M268.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be real in our model.
+            </p>
+            <p>
+               For Eq. (33), the minimum in terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\zeta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M269.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be at
+            </p>
+            <p>
+               <disp-formula>
+                  <label>34</label>
+                  <tex-math id="cpc_46_10_103101_E34">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4},\quad\zeta=0. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E34.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \zeta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M270.jpg" xlink:type="simple" />
+               </inline-formula>
+               corresponds to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M271.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we introduce
+               <italic toggle="yes">K</italic>
+               -violating terms into the model. Consequently, the above mentioned minimum can be shifted by small deviations
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_\zeta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M272.jpg" xlink:type="simple" />
+               </inline-formula>
+               as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>35</label>
+                  <tex-math id="cpc_46_10_103101_E35">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4}-\frac{\delta_0}{2},\quad\zeta=0+\delta_\zeta. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E35.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Now, after imposing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M273.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry in Eq. (21) and after following the procedure for minimizing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M274.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which is described in Sec. III.A, we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>36</label>
+                  <tex-math id="cpc_46_10_103101_E36">
+                     <?CDATA $ \begin{aligned}[b] \left(\begin{array}{c} \delta_0\\\delta_\zeta \end{array}\right) = & {\cal F}^{-1}\left(\begin{array}{c} f_0\\f_\zeta \end{array}\right),\quad {\cal F}=\left(\begin{array}{cc} -\frac{1}{2}\tilde{\lambda} & \lambda_{10}\\\lambda_{10} & -2\lambda_7 \end{array}\right)v^4, \\ f_0= & \frac{1}{2}(\delta M_2^2-\delta M_3^2)v^2 +\frac{1}{2}(\delta\lambda_2-\delta\lambda_2^\prime)v^4 \\ & +\frac{1}{2}(\delta\lambda_3 -\delta\lambda_3^\prime+\delta\lambda_5-\delta\lambda_5^\prime)(v_1v)^2 \\ & +\frac{1}{2}(\delta\lambda_{12}-\delta\lambda_{12}^\prime)(vv^\prime)^2, \\ f_\zeta= & \delta M_s^2v^2 +\frac{1}{2}(\delta\lambda_{10}+\delta\lambda_{10}^\prime)v^4 \\ & +(\delta\lambda_s-\delta\lambda_s^\prime)(v_1v)^2 +\delta_t(vv^\prime)^2. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E36.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               We can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_\zeta\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M275.jpg" xlink:type="simple" />
+               </inline-formula>
+               . After using these in the parametrizations for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M276.jpg" xlink:type="simple" />
+               </inline-formula>
+               , from Eq. (6), we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>37</label>
+                  <tex-math id="cpc_46_10_103101_E37">
+                     <?CDATA $ \begin{equation} \frac{m_\mu}{m_\tau}=\frac{1}{2}\big|\delta_0+{\rm i}\delta_\zeta\big|. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E37.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Using the above equation, the required hierarchy between muon and tau leptons can be explained if we take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_\zeta\sim0.1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M277.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               In Sec. II, we have described our model for lepton sector by introducing additional fields and symmetries. In the current section, we have introduced one more symmetry,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M278.jpg" xlink:type="simple" />
+               </inline-formula>
+               , in order to make the triplet Higgs VEV real. In
+               <xref ref-type="table" rid="cpc_46_10_103101_t1">Table 1</xref>
+               we summarize the additional fields and symmetries, which are needed for our model, in the lepton sector.
+            </p>
+            <table-wrap id="cpc_46_10_103101_t1" orientation="portrait" position="float">
+               <label>Table 1</label>
+               <caption id="cpc_46_10_103101_tc1">
+                  <p>Additional fields and symmetries, which are introduced in the lepton sector of our model. The roles of these fields and symmetries are also described here.</p>
+               </caption>
+               <table>
+                  <thead>
+                     <tr>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Additional field</th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Role</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \phi_1 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M279.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate the mass of electron</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \phi_2 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M280.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           ,
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \phi_3 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M281.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           to generate masses for
+                           <italic toggle="yes">μ</italic>
+                           and
+                           <italic toggle="yes">τ</italic>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Δ</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate masses for neutrinos</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Additional symmetry</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Role</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $CP$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M282.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           symmetry
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           to get
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $\mu-\tau$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M283.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           form for neutrino mass matrix
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $Z_2$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M284.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           forbids unwanted Yukawa couplings among
+                           <break />
+                           charged leptons
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $U(1)_{L_\alpha}$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M285.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to get diagonal masses for charged leptons</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <italic toggle="yes">K</italic>
+                           symmetry
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to reduce the fine-tuning in muon and tau masses</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $Z_3$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M286.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to make the VEV of Δ to be real</td>
+                     </tr>
+                  </tbody>
+               </table>
+            </table-wrap>
+         </sec>
+      </sec>
+      <sec id="cpc_46_10_103101_s04">
+         <label>IV.</label>
+         <title>
+            NEUTRINO MASS ORDERING AND THE SMALLNESS OF
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {\boldsymbol \theta}_{\bf 13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M287.jpg" xlink:type="simple" />
+            </inline-formula>
+         </title>
+         <p>
+            After showing that the triplet Higgs can acquire real VEV, the neutrino mass matrix of the model proposed in Sec. II satisfy Eq. (10). As a result, after diagonalizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M288.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M289.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M290.jpg" xlink:type="simple" />
+            </inline-formula>
+            would be maximal [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. However, the form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M291.jpg" xlink:type="simple" />
+            </inline-formula>
+            does not give predictions about
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{12},\theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M292.jpg" xlink:type="simple" />
+            </inline-formula>
+            or neutrino mass ordering. In this section, we carry out an analysis and provide a procedure, which can give predictions about neutrino mass ordering and the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M293.jpg" xlink:type="simple" />
+            </inline-formula>
+            in our model.
+         </p>
+         <p>
+            In the model proposed in Sec. II, the charged lepton masses are in diagonal form. Hence, the unitary matrix which diagonalizes
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M294.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <label>38</label>
+               <tex-math id="cpc_46_10_103101_E38">
+                  <?CDATA $ \begin{array}{*{20}{l}}\\ & & U=\tilde{U}U_{\rm PMNS},\quad \tilde{U}={\rm diag}(1,1,-1), \\ & & U_{\rm PMNS} = \left(\begin{array}{ccc} c_{12}c_{13} & s_{12}c_{13} & s_{13}{\rm e}^{-{\rm i}\delta_{CP}} \\ -s_{12}c_{23}-c_{12}s_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & c_{12}c_{23}-s_{12}s_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & s_{23}c_{13} \\ s_{12}s_{23}-c_{12}c_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & -c_{12}s_{23}-s_{12}c_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & c_{23}c_{13} \end{array}\right). \\ \end{array} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E38.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ c_{ij}=\cos\theta_{ij} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M295.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{ij}=\sin\theta_{ij} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M296.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M297.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the Pontecorvo-Maki-Nakagawa-Sakata (PMNS) matrix, which is parameterized in terms of the three lepton mixing angles and the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M298.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating Dirac phase, according to the convention of PDG [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ]. Diagonal elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \tilde{U} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M299.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be absorbed into the charged lepton fields. Now, the relation for diagonalizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M300.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be expressed as
+         </p>
+         <p>
+            <disp-formula>
+               <label>39</label>
+               <tex-math id="cpc_46_10_103101_E39">
+                  <?CDATA $ \begin{equation} M_\nu=U^*{\rm diag}(m_1,m_2,m_3)U^\dagger. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E39.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            While solving the above equation, we can use an approximation procedure [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib24">24</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib25">25</xref>
+            ] related to neutrino masses and mixing angle
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M301.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is explained below.
+         </p>
+         <p>
+            In the expression for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M302.jpg" xlink:type="simple" />
+            </inline-formula>
+            one can have Majorana phases, which cannot be determined from neutrino oscillation data. However, they can affect the life-time of neutrinoless double beta decay, since neutrinos in our model are Majorana particles. Nonetheless, there is no concrete evidence for this decay so far [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ], and as a result, the Majorana phases can take any value between 0 and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 2\pi $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M303.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, in our analysis, for the sake of simplicity, we have chosen these phases to be zero. In contrast, by taking some specific values for Majorana phases in the below described procedure, one can study the conditions, which can give rise for neutrino Yukawa couplings of our model. Nevertheless, we shall reserve this study for a future work.
+         </p>
+         <p>
+            In
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M304.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we put
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23}={\pi}/{4} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M305.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP}={(3\pi)}/{2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M306.jpg" xlink:type="simple" />
+            </inline-formula>
+            . From the neutrino oscillation data, we have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2\sim{1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M307.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2\sim2\cdot10^{-2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M308.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ]. Here, we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M309.jpg" xlink:type="simple" />
+            </inline-formula>
+            is negligibly small in comparison to unity, and hence
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}\sim0.15 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M310.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be treated as a small variable. In contrast,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M311.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{23}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M312.jpg" xlink:type="simple" />
+            </inline-formula>
+            are of order one. Since
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M313.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the only small variable in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M314.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we expand
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M315.jpg" xlink:type="simple" />
+            </inline-formula>
+            up to the first order in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M316.jpg" xlink:type="simple" />
+            </inline-formula>
+            . The corresponding expression is given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>40</label>
+               <tex-math id="cpc_46_10_103101_E40">
+                  <?CDATA $ \begin{aligned}[b] U_{\rm PMNS}= & U_0+\delta U, \\ U_0= & \left(\begin{array}{ccc} c_{12} & s_{12} & 0 \\ -\dfrac{s_{12}}{\sqrt{2}} & \dfrac{c_{12}}{\sqrt{2}} & \dfrac{1}{\sqrt{2}} \\ \dfrac{s_{12}}{\sqrt{2}} & -\dfrac{c_{12}}{\sqrt{2}} & \dfrac{1}{\sqrt{2}} \end{array}\right),\\\delta U= & \left(\begin{array}{ccc} 0 & 0 & 1 \\ \dfrac{c_{12}}{\sqrt{2}} & \dfrac{s_{12}}{\sqrt{2}} & 0 \\ \dfrac{c_{12}}{\sqrt{2}} & \dfrac{s_{12}}{\sqrt{2}} & 0 \end{array}\right){\rm i}s_{13}. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E40.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            From the neutrino oscillation data, two mass-squared differences for neutrinos are found, which are given in Eq. (11). From this equation we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {m_s^2}/{m_a^2}\sim s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M317.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is negligibly small compared to unity. This indicates that an approximation with respect to neutrino masses can also be applied while solving the Eq. (39). In order to fit the mass-square differences of Eq. (11), we can take the neutrino masses as follows.
+         </p>
+         <p>
+            <disp-formula>
+               <label>41</label>
+               <tex-math id="cpc_46_10_103101_E41">
+                  <?CDATA $ \begin{aligned}[b] & {\rm NO}:\quad m_1 \lesssim m_s,\quad m_2=\sqrt{m_s^2+m_1^2},\quad m_3=\sqrt{m_a^2+m_1^2}. \\ & {\rm IO}:\quad m_3 \lesssim m_s,\quad m_1=\sqrt{m_a^2+m_3^2},\quad m_2=\sqrt{m_s^2+m_1^2}. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E41.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Now we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {m_1}/{m_a} \lesssim s_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M318.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the case of NO, whereas,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {m_1}/{m_a}\sim1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M319.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the case of IO. Similar conclusions can be made about
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${m_2}/{m_a}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M320.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${m_3}/{m_a} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M321.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            Using the approximation scheme described in the previous paragraph, we can expand
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${({1}/{m_a})}M_\nu$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M322.jpg" xlink:type="simple" />
+            </inline-formula>
+            in powers of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13},\;{m_s}/{m_a} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M323.jpg" xlink:type="simple" />
+            </inline-formula>
+            . After neglecting the second and higher order corrections in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13},\;{m_s}/{m_a} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M324.jpg" xlink:type="simple" />
+            </inline-formula>
+            , for both  NO and IO cases, the elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${({1}/{m_a})}M_\nu$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M325.jpg" xlink:type="simple" />
+            </inline-formula>
+            are given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>42</label>
+               <tex-math id="cpc_46_10_103101_E42">
+                  <?CDATA $ \begin{aligned}[b] & \frac{1}{m_a}M_\nu=\frac{1}{2m_a}\left(\begin{array}{ccc} x & z & z^*\\ z & w & y\\ z^* & y & w^* \end{array}\right), \\ {\rm NO}:\;\; & x=2c_{12}^2m_1+2 s_{12}^2 m_2,\\ & z=\sqrt{2} c_{12}s_{12}(m_2-m_1)-{\rm i}\sqrt{2}m_3s_{13}, \\ & w=m_3+c_{12}^2m_2+s_{12}^2m_1,\\ & y=-m_3+c_{12}^2m_2+s_{12}^2m_1. \\ {\rm IO}:\;\; & x=2m_1,\quad z=-\sqrt{2} {\rm i} s_{13}m_1,\\ & w=m_1+m_3,\quad y=m_1-m_3. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E42.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Using the above relations, in order for the matrix
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M326.jpg" xlink:type="simple" />
+            </inline-formula>
+            to make predictions about neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M327.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the Yukawa couplings in Eq. (8) should satisfy the following conditions.
+         </p>
+         <p>
+            ● To predict NO and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M328.jpg" xlink:type="simple" />
+            </inline-formula>
+            :
+         </p>
+         <p>
+            (i)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee},Y^\nu_{e\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M329.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be suppressed by approximately 0.1 compared to that of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\mu\mu},Y^\nu_{\mu\tau} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M330.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            (ii)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\mu\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M331.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real.
+         </p>
+         <p>
+            ● To predict IO and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M332.jpg" xlink:type="simple" />
+            </inline-formula>
+            :
+         </p>
+         <p>
+            (i)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{e\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M333.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be purely imaginary and its magnitude is suppressed by approximately 0.1 compared to other elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M334.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            (ii)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\mu\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M335.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real.
+         </p>
+         <p>
+            We recall that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M336.jpg" xlink:type="simple" />
+            </inline-formula>
+            is a symmetric matrix satisfying Eq. (9). Hence, not all elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M337.jpg" xlink:type="simple" />
+            </inline-formula>
+            are independent. As a result, while describing the above conditions, we have considered
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee},Y^\nu_{e\mu},Y^\nu_{\mu\mu},Y^\nu_{\mu\tau} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M338.jpg" xlink:type="simple" />
+            </inline-formula>
+            as independent elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M339.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Another point worth mentioning here is that the aforementioned conditions are true after neglecting second and higher order corrections in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {({1}/{m_a})}M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M340.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            The condition (ii) described for the cases of NO and IO is trivially satisfied if one uses the relations in Eq. (42). The non-trivial condition to check is the condition (i) in the NO and IO cases. The suppression factor mentioned in this condition is arising due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}\sim {({m_s}/{m_a})}\sim 0.15 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M341.jpg" xlink:type="simple" />
+            </inline-formula>
+            . We have checked this suppression factor for the case of NO by computing the following ratios:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{ee}|}/{|Y^\nu_{\mu\mu}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M342.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{ee}|}/{|Y^\nu_{\mu\tau}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M343.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\mu}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M344.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\tau}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M345.jpg" xlink:type="simple" />
+            </inline-formula>
+            . While for the case of IO, the following ratios are computed in order to check condition (i):
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{ee}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M346.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\mu}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M347.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\tau}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M348.jpg" xlink:type="simple" />
+            </inline-formula>
+            . One can notice that the neutrino Yukawa couplings are proportional to the elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M349.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which are given in Eq. (42). The neutrino masses in Eq. (42) are computed using Eq. (41) and by varying
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m^2_s,\;m^2_a $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M350.jpg" xlink:type="simple" />
+            </inline-formula>
+            over their allowed
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M351.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges. The mass of the lightest neutrino is varied from 0 to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_s $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M352.jpg" xlink:type="simple" />
+            </inline-formula>
+            in  the NO and IO cases. While computing the above mentioned ratios, we have also varied
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M353.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M354.jpg" xlink:type="simple" />
+            </inline-formula>
+            over their allowed
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M355.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges. We have listed the allowed
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M356.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges for the abovementioned variables in
+            <xref ref-type="table" rid="cpc_46_10_103101_t2">Table 2</xref>
+            .
+         </p>
+         <table-wrap id="cpc_46_10_103101_t2" orientation="portrait" position="float">
+            <label>Table 2</label>
+            <caption id="cpc_46_10_103101_tc2">
+               <p>
+                  Allowed
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 3\sigma $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103101_M357.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  ranges of the neutrino oscillation observables [
+                  <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+                  ], which are used in our analysis.
+               </p>
+            </caption>
+            <table>
+               <thead>
+                  <tr>
+                     <th align="center" colspan="1" rowspan="1" valign="middle">Parameters</th>
+                     <th align="center" colspan="1" rowspan="1" valign="middle">Allowed range</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ m_s^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M358.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        (6.94
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M359.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        8.14)
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \times 10^{-5} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M360.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        eV
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ ^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M361.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ m_a^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M362.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (NO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        (2.47
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M363.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        2.63)
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \times 10^{-3} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M364.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        eV
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ ^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M365.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ m_a^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M366.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (IO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        (2.37
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M367.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        2.53)
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \times 10^{-3} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M368.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        eV
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ ^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M369.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ s_{12}^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M370.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        0.271
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M371.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        0.369
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ s_{13}^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M372.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (NO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        0.0200
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M373.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        0.02405
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ s_{13}^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M374.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (IO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        0.02018
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M375.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        0.02424
+                     </td>
+                  </tr>
+               </tbody>
+            </table>
+         </table-wrap>
+         <p>
+            As we proceeded with above analysis, we checked if the sum of the three neutrinos is less than 0.12 eV, which is a constraint obtained from the cosmological observations [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib37">37</xref>
+            ]. As already described in the previous paragraph, the suppression in the ratios of various Yukawa couplings should be around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}\sim{({m_s}/{m_a})}\sim 0.15 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M376.jpg" xlink:type="simple" />
+            </inline-formula>
+            . However, in our analysis we have found that some of these ratios can become as large as 0.5, and thus, invalidate the approximation procedure, which we are using here. Hence, in the analysis we have restricted all these ratios to be less than or of the order of 0.2. Selected plots from this analysis are presented in
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            . From this figure we can see that the mass of lightest neutrino,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{\rm lightest} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M377.jpg" xlink:type="simple" />
+            </inline-formula>
+            , is constrained due to aforementioned restriction on the ratios of Yukawa couplings. We can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{\rm lightest} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M378.jpg" xlink:type="simple" />
+            </inline-formula>
+            has a narrow allowed region in the case of NO compared to that of IO. Apart from the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{\rm lightest} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M379.jpg" xlink:type="simple" />
+            </inline-formula>
+            in
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M380.jpg" xlink:type="simple" />
+            </inline-formula>
+            is also constrained to be in the range of 0.02 to 0.023, in the case of NO. In contrast, this variable is not constrained in the case of IO. As for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M381.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we have found that it can take the full
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M382.jpg" xlink:type="simple" />
+            </inline-formula>
+            range in both the NO and IO cases of
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            . Although we have presented selected plots in
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            , we have obtained similar plots for other ratios of Yukawa couplings, which are mentioned in the previous paragraph. These plots justify the approximation procedure, which we are using here, and verify the condition (i) for the cases of NO and IO, which are mentioned below Eq. (42).
+         </p>
+         <fig id="cpc_46_10_103101_f1" orientation="portrait" position="float">
+            <label>Fig. 1</label>
+            <caption id="cpc_46_10_103101_fc1">
+               <p>
+                  (color online) Ratios of the magnitude of Yukawa couplings versus the mass of lightest neutrino. The left- and right-hand side plots are for NO and IO, respectively. In both plots, we vary the neutrino oscillation observables over their allowed
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 3\sigma $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103101_M383.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  ranges, which are given in
+                  <xref ref-type="table" rid="cpc_46_10_103101_t2">Table 2</xref>
+                  . For other details, see the text.
+               </p>
+            </caption>
+            <graphic content-type="print" id="cpc_46_10_103101_f1_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103101_f1.pdf" xlink:type="simple" />
+            <graphic content-type="online" id="cpc_46_10_103101_f1_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103101_f1.pdf" xlink:type="simple" />
+         </fig>
+         <p>
+            The conditions mentioned below Eq. (42), for both the NO and IO cases, cannot be achieved just with the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M384.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. An additional mechanism should be proposed to satisfy these conditions. In an attempt towards this, we have proposed one mechanism to achieve condition (i) for the case of NO, where the necessary suppression in the Yukawa couplings is explained through non-renormalizable terms within the framework of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M385.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. This mechanism is presented in the Appendix. In this work, we do not have a mechanism to achieve condition (i) for the case of IO and to achieve condition (ii) for both NO and IO. These problems would be investigated in future works. As already described, with the generalized
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M386.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M387.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M388.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M389.jpg" xlink:type="simple" />
+            </inline-formula>
+            will be maximal. However, in future neutrino oscillation experiments,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M390.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M391.jpg" xlink:type="simple" />
+            </inline-formula>
+            may be found to be away from their maximal values. In such a case, one needs to device a mechanism for the breaking of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M392.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry in order to explain the non-maximal values for the above mentioned observables. However, these topics are outside the scope of the present study.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s05">
+         <label>V.</label>
+         <title>QUARK MIXING</title>
+         <p>
+            In our proposed model for lepton mixing, three Higgs doublets exist. Since they can also give masses to quarks, it is interesting to check whether quark mixing can also be explained with
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M393.jpg" xlink:type="simple" />
+            </inline-formula>
+            and other symmetries of our model. As already described in Sec. I, since there is a hierarchy among quark masses, the mixing pattern for quarks can be explained if their Yukawa couplings are hierarchically suppressed. Babu and Nandi have proposed one model [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ] for explaining quark mixing through hierarchically suppressed Yukawa couplings. Later, this model has been modified in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ], where the suppression in Yukawa couplings is explained with a singlet scalar field. We follow the work of Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ] to explain quark mixing in our framework.
+         </p>
+         <sec id="cpc_46_10_103101_s05-01">
+            <label>A.</label>
+            <title>Model for quark masses and mixing</title>
+            <p>
+               We denote the three families of quark doublets, up- and down-type singlets as
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Q_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M394.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ u_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M395.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ d_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M396.jpg" xlink:type="simple" />
+               </inline-formula>
+               , respectively. We propose a scalar field
+               <italic toggle="yes">X,</italic>
+               which is singlet under standard model gauge group. We assume all the quark fields to be singlets under the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_2\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M397.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The
+               <italic toggle="yes">X</italic>
+               field is singlet under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M398.jpg" xlink:type="simple" />
+               </inline-formula>
+               but is odd under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M399.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Both the quark and
+               <italic toggle="yes">X</italic>
+               fields transform under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M400.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>43</label>
+                  <tex-math id="cpc_46_10_103101_E43">
+                     <?CDATA $ \begin{aligned}[b] & Q_{j{\rm L}}\to {\rm i}\gamma^0C\bar{Q}_{j{\rm L}}^T,\quad u_{j{\rm R}}\to {\rm i}\gamma^0C\bar{u}_{j{\rm R}}^T, \\ & d_{j{\rm R}}\to {\rm i}\gamma^0C\bar{d}_{j{\rm R}}^T, \quad X\to X^*. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E43.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>Now, with the above mentioned transformations and fields, we consider the following effective Lagrangian for quark masses.</p>
+            <p>
+               <disp-formula>
+                  <label>44</label>
+                  <tex-math id="cpc_46_10_103101_E44">
+                     <?CDATA $ \begin{aligned}[b] {\cal L}_Y= & h^u_{33}\bar{Q}_{3{\rm L}}\tilde{\phi}_1u_{3{\rm R}} +\left(\frac{X}{M}\right)^2[h^d_{33}\bar{Q}_{3{\rm L}}\phi_1 d_{3{\rm R}} \\ & +h^u_{22}\bar{Q}_{2{\rm L}}\tilde{\phi}_1u_{2{\rm R}} +h^u_{23}\bar{Q}_{2{\rm L}}\tilde{\phi}_1u_{3{\rm R}} \\ & +h^u_{32}\bar{Q}_{3{\rm L}}\tilde{\phi}_1 u_{2{\rm R}}]+\left(\frac{X}{M}\right)^4[h^d_{22}\bar{Q}_{2{\rm L}}\phi_1 d_{2{\rm R}} \\ & +h^d_{23}\bar{Q}_{2{\rm L}}\phi_1 d_{3{\rm R}}+h^d_{32}\bar{Q}_{3{\rm L}}\phi_1 d_{2{\rm R}} \\ & +h^u_{12}\bar{Q}_{1{\rm L}}\tilde{\phi}_1u_{2{\rm R}}+h^u_{21}\bar{Q}_{2{\rm L}}\tilde{\phi}_1u_{1{\rm R}}\\ & +h^u_{13}\bar{Q}_{1{\rm L}}\tilde{\phi}_1u_{3{\rm R}}+ h^u_{31}\bar{Q}_{3{\rm L}}\tilde{\phi}_1u_{1{\rm R}}] \\ & +\left(\frac{X}{M}\right)^6[h^u_{11}\bar{Q}_{1{\rm L}}\tilde{\phi}_1u_{1{\rm R}} +h^d_{11}\bar{Q}_{1{\rm L}}\phi_1 d_{1{\rm R}}\\ & +h^d_{12}\bar{Q}_{1{\rm L}}\phi_1 d_{2{\rm R}} +h^d_{13}\bar{Q}_{1{\rm L}}\phi_1 d_{3{\rm R}}] \\ & +\left(\frac{X}{M}\right)^9[h^d_{21}\bar{Q}_{2{\rm L}}\phi_1 u_{1{\rm R}}] +\left(\frac{X}{M}\right)^{10}[h^d_{31}\bar{Q}_{3{\rm L}}\phi_1 u_{1{\rm R}}]+{\rm h.c}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E44.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               The above Lagrangian is valid below a mass scale of
+               <italic toggle="yes">M</italic>
+               . The non-renormalizable terms of this Lagrangian can be motivated by the UV completion of this model, which is presented in the next subsection. According to this UV completion, we propose a flavor symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M401.jpg" xlink:type="simple" />
+               </inline-formula>
+               and heavy vector-like quark (VLQ) fields above the scale
+               <italic toggle="yes">M</italic>
+               . After integrating the heavy fields in our model, below the scale
+               <italic toggle="yes">M</italic>
+               , the non-renormalizable terms of Eq. (44) can appear. Here we can see that
+               <italic toggle="yes">M</italic>
+               represents the mass scale of heavy VLQs. Since new particles can be probed at the LHC experiment if their masses are around 1 TeV, we take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M\sim $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M402.jpg" xlink:type="simple" />
+               </inline-formula>
+               1 TeV.
+            </p>
+            <p>
+               Due to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M403.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, the Yukawa couplings
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^{u,d}_{jk} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M404.jpg" xlink:type="simple" />
+               </inline-formula>
+               should be real in Eq. (44). After
+               <italic toggle="yes">X</italic>
+               acquires VEV, for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle X\rangle \lt M $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M405.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {X}/{M} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M406.jpg" xlink:type="simple" />
+               </inline-formula>
+               gives suppression to the effective quark Yukawa couplings. Since the Yukawa couplings of Eq. (44) are real, we assume
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle X\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M407.jpg" xlink:type="simple" />
+               </inline-formula>
+               is complex, and this can be the source for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M408.jpg" xlink:type="simple" />
+               </inline-formula>
+               violation in the quark sector. In the Lagrangian of Eq. (44), only the doublet
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M409.jpg" xlink:type="simple" />
+               </inline-formula>
+               generates Yukawa couplings for quark fields. The other doublets
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M410.jpg" xlink:type="simple" />
+               </inline-formula>
+               do not generate these Yukawa couplings due to the presence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times K$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M411.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry.
+            </p>
+            <p>After electroweak symmetry breaking, using Eq. (44), the matrices for up- and down-type quarks can be written, respectively, as</p>
+            <p>
+               <disp-formula>
+                  <label>45</label>
+                  <tex-math id="cpc_46_10_103101_E45">
+                     <?CDATA $ \begin{aligned}[b] & M_u=\left(\begin{array}{ccc} h^u_{11}\epsilon^6 & h^u_{12}\epsilon^4 & h^u_{13}\epsilon^4 \\ h^u_{21}\epsilon^4 & h^u_{22}\epsilon^2 & h^u_{23}\epsilon^2 \\ h^u_{31}\epsilon^4 & h^u_{32}\epsilon^2 & h^u_{33} \end{array}\right)v_1,\\ & M_d=\left(\begin{array}{ccc} h^d_{11}\epsilon^6 & h^d_{12}\epsilon^6 & h^d_{13}\epsilon^6 \\ h^d_{21}\epsilon^9 & h^d_{22}\epsilon^4 & h^d_{23}\epsilon^4 \\ h^d_{31}\epsilon^{10} & h^d_{32}\epsilon^4 & h^d_{33}\epsilon^2 \end{array}\right)v_1. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E45.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \epsilon=\dfrac{\langle X\rangle}{M} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M412.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The form of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M_{u,d} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M413.jpg" xlink:type="simple" />
+               </inline-formula>
+               is similar to the corresponding matrices in Refs. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+               ,
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ]. However, the only difference is that the elements 21 and 31 of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M_d $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M414.jpg" xlink:type="simple" />
+               </inline-formula>
+               are generated at a higher order compared to those in Refs. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+               ,
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ]. It is argued in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ] that the above mentioned elements do not affect quark masses and mixing if they are generated at higher order. Hence, after diagonalizing the above matrices, the masses and mixing angles for quarks, up to leading order in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon| $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M415.jpg" xlink:type="simple" />
+               </inline-formula>
+               , are given by
+            </p>
+            <p>
+               <disp-formula>
+                  <label>46</label>
+                  <tex-math id="cpc_46_10_103101_E46">
+                     <?CDATA $ \begin{aligned}[b] & (m_t,m_c,m_u)\approx(|h^u_{33}|,|h^u_{22}||\epsilon|^2, |h^u_{11}-h^u_{12}h^u_{21}/h^u_{22}||\epsilon|^6)v_1, \\ & (m_b,m_s,m_d)\approx(|h^d_{33}||\epsilon|^2, |h^d_{22}||\epsilon|^4,|h^d_{11}||\epsilon|^6)v_1, \\ & |V_{us}|\approx\left|\frac{h^d_{12}}{h^d_{22}}- \frac{h^u_{12}}{h^u_{22}}\right||\epsilon|^2, \\ & |V_{cb}|\approx\left|\frac{h^d_{23}}{h^d_{33}}- \frac{h^u_{23}}{h^u_{33}}\right||\epsilon|^2, \\ & |V_{ub}|\approx\left|\frac{h^d_{13}}{h^d_{33}}- \frac{h^u_{12}h^d_{23}}{h^u_{22}h^d_{33}}- \frac{h^u_{13}}{h^u_{33}}\right||\epsilon|^4, \\ & {\rm arg}(V_{ub})\approx4{\rm arg}(\epsilon). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E46.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Due to three Higgs doublets in our model, we have
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |v_1|^2+|v_2|^2+|v_3|^2 \approx(174\; {\rm GeV})^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M416.jpg" xlink:type="simple" />
+               </inline-formula>
+               . To satisfy this, we take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_1,v\sim174/\sqrt{2} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M417.jpg" xlink:type="simple" />
+               </inline-formula>
+               GeV. With this value for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M418.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we fit the expressions of Eq. (46) to the following best fit values [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+               ].
+            </p>
+            <p>
+               <disp-formula>
+                  <tex-math id="cpc_46_10_103101_E47-1">
+                     <?CDATA $ \begin{aligned}[b] & (m_t,m_c,m_u)=(172.76,1.27,2.16\times10^{-3})\; {\rm GeV}, \\ & (m_b,m_s,m_d)=(4.18\times10^3,93,4.67)\; {\rm MeV}, \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E47-1.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>47</label>
+                  <tex-math id="cpc_46_10_103101_E47">
+                     <?CDATA $ \begin{aligned}[b] & (|V_{us}|,|V_{cb}|,|V_{ub}|)=(0.2245,0.041,0.00382), \\ & {\rm arg}(V_{ub})=-1.196 \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E47.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               After the abovementioned fitting, we give a sample set of numerical values with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/5.5 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M419.jpg" xlink:type="simple" />
+               </inline-formula>
+               as follows.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>48</label>
+                  <tex-math id="cpc_46_10_103101_E48">
+                     <?CDATA $ \begin{aligned}[b] & (|h^u_{33}|,|h^u_{22}|, |h^u_{11}-h^u_{12}h^u_{21}/h^u_{22}|) \approx(1.4,0.31,0.49), \\ & (|h^d_{33}|,|h^d_{22}|,|h^d_{11}|)\approx (1.03,0.69,1.05), \\ & (h^d_{12},h^u_{12},h^d_{23},h^u_{23}, h^d_{13},h^u_{13})\\\approx & (1.49,-1.45,0.69,-0.8,1.12,1.0), \\ & {\rm arg}(\epsilon)\approx-0.3. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E48.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               From the numerical values given above, we can see that the magnitudes of all Yukawa couplings are less than about 1.5. We have considered numerical values with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/6 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M420.jpg" xlink:type="simple" />
+               </inline-formula>
+               . However, in this case, some of the Yukawa couplings can become larger than 2.0. Hence, with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/5.5 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M421.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal O}(1) $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M422.jpg" xlink:type="simple" />
+               </inline-formula>
+               Yukawa couplings, we can explain the quark masses and mixing pattern in our model. Since we expect new physics to appear around 1 TeV, we can take the cut-off scale of Eq. (44) to be
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M\sim $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M423.jpg" xlink:type="simple" />
+               </inline-formula>
+               1 TeV. Now, for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/5.5 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M424.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\langle X\rangle|\sim $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M425.jpg" xlink:type="simple" />
+               </inline-formula>
+               181 GeV.
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103101_s05-02">
+            <label>B.</label>
+            <title>UV completion</title>
+            <p>
+               Here, we present the UV completion for our model in order to explain the origin of non-renormalizable terms of Eq. (44). To achieve this UV completion, we follow the works of Refs. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ,
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib38">38</xref>
+               ]. The idea of this UV completion is to explain non-renormalizable terms following from a theory which is renormalizable at a high scale. Hence, we assume our model is renormalizable at and above the scale
+               <italic toggle="yes">M</italic>
+               and propose a flavor symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M426.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which is exactly above
+               <italic toggle="yes">M</italic>
+               . To generate non-renormalizable terms below
+               <italic toggle="yes">M</italic>
+               , we propose additional fields like flavons and VLQs, which transform under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M427.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The standard model quarks are charged under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M428.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry. However, the Higgs doublets and
+               <italic toggle="yes">X</italic>
+               field are singlets under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M429.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M430.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry is spontaneously broken when the flavons acquire VEVs around
+               <italic toggle="yes">M</italic>
+               , which is also the mass scale of VLQs. Here, we can see that our model should respect the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times K\times Z_2\times Z_3\times U(1)_{\rm F}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M431.jpg" xlink:type="simple" />
+               </inline-formula>
+               above the scale
+               <italic toggle="yes">M</italic>
+               . However, below
+               <italic toggle="yes">M</italic>
+               , after integrating the heavy VLQs and flavon fields, our model should generate non-renormalizable terms of Eq. (44), which respect the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times K\times Z_2\times Z_3$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M432.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               Under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M433.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we denote the charges for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Q_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M434.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ u_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M435.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ d_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M436.jpg" xlink:type="simple" />
+               </inline-formula>
+               as
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ q_{jf} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M437.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ u_{jf} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M438.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ d_{jf} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M439.jpg" xlink:type="simple" />
+               </inline-formula>
+               , respectively. We propose only two flavon fields,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ F_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M440.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ F_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M441.jpg" xlink:type="simple" />
+               </inline-formula>
+               , whose charges under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M442.jpg" xlink:type="simple" />
+               </inline-formula>
+               are
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M443.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M444.jpg" xlink:type="simple" />
+               </inline-formula>
+               , respectively. Flavons are charged under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M445.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry but are otherwise singlets under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_2\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M446.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M447.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, flavons transform like the
+               <italic toggle="yes">X</italic>
+               field of our model. Now, to generate non-renormalizable terms for up-type quarks in Eq. (44), we introduce VLQs
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M448.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M449.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which are color triplets and their hypercharges are same as those of right-handed singlet up-quarks. Analogous to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M450.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M451.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we introduce
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ G_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M452.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ G_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M453.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which generate non-renormalizable terms for down-type quarks. The above VLQs are singlets under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S U(2)$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M454.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry of the standard model and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M455.jpg" xlink:type="simple" />
+               </inline-formula>
+               . These fields are charged under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M456.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry. Under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M457.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, they transform like the quark fields.
+            </p>
+            <p>
+               After describing the field content and their charge assignments in the UV completion of our model, we further explain the generation of non-renormalizable terms of Eq. (44). The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{33} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M458.jpg" xlink:type="simple" />
+               </inline-formula>
+               term in Eq. (44) is renormalizable, which can be generated in our model by taking
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ q_{3f}=u_{3f} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M459.jpg" xlink:type="simple" />
+               </inline-formula>
+               . To generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{32} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M460.jpg" xlink:type="simple" />
+               </inline-formula>
+               term in Eq. (44), we consider the below invariant terms in the UV completion.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>49</label>
+                  <tex-math id="cpc_46_10_103101_E49">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{32}= & \bar{Q}_{3{\rm L}}\tilde{\phi}_1 K_{1{\rm R}}+ F_1^*\bar{K}_{1{\rm R}}K_{1{\rm L}}+ X \bar{K}_{1{\rm L}}K_{2{\rm R}}\\ & + F_2 \bar{K}_{2{\rm R}}K_{2{\rm L}}+ X \bar{K}_{2{\rm L}}u_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E49.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since the terms in the above equation are invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M461.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, the dimensionless Yukawa couplings should be real; these are
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal O}(1) $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M462.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which we have not written explicitly here. The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M463.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm L}},K_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M464.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be fixed in terms of corresponding charges of quarks and flavons in such a way that the above equation is invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M465.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Similarly, the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M466.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for these VLQs can be assigned such that the above equation is invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M467.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F}\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M468.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for VLQs of
+               <italic toggle="yes">K</italic>
+               -type are given in Eq. (57). When the flavons acquire VEVs, the VLQs in Eq. (49) acquire masses of the order of
+               <italic toggle="yes">M</italic>
+               . After integrating these heavy VLQs, terms in Eq. (49) generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{32} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M469.jpg" xlink:type="simple" />
+               </inline-formula>
+               term of Eq. (44).
+            </p>
+            <p>
+               By introducing more VLQs of
+               <italic toggle="yes">K</italic>
+               -type, the process described in the previous paragraph can be applied to generate other non-renormalizable terms of Eq. (44). Below we show the invariant Lagrangians of the form
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal L}^u_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M470.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M471.jpg" xlink:type="simple" />
+               </inline-formula>
+               term of Eq. (44), after integrating the heavy VLQs and flavons. The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F}\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M472.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for the VLQs in these Lagrangians can be seen in Eq. (57).
+            </p>
+            <p>
+               <disp-formula>
+                  <label>50</label>
+                  <tex-math id="cpc_46_10_103101_E50">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{31}= & \bar{Q}_{3{\rm L}}\tilde{\phi}_1 K_{1{\rm R}}+ F_1^*\bar{K}_{1{\rm R}}K_{1{\rm L}}+ X \bar{K}_{1{\rm L}}K_{2{\rm R}}+ F_2 \bar{K}_{2{\rm R}}K_{2{\rm L}}+ X \bar{K}_{2{\rm L}}K_{3{\rm R}}+ F_2 \bar{K}_{3{\rm R}}K_{3{\rm L}} + X \bar{K}_{3{\rm L}}K_{4{\rm R}}+ M \bar{K}_{4{\rm R}}K_{4{\rm L}}\\ & +X\bar{K}_{4{\rm L}}u_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E50.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>51</label>
+                  <tex-math id="cpc_46_10_103101_E51">
+                     <?CDATA $ \mathcal{L}^u_{23}= \bar{Q}_{2{\rm L}}\tilde{\phi}_1K_{5{\rm R}}+M\bar{K}_{5{\rm R}}K_{5{\rm L}}+X \bar{K}_{5{\rm L}}K_{6{\rm R}}+ F_1 \bar{K}_{6{\rm R}}K_{6{\rm L}}+X \bar{K}_{6{\rm L}}u_{3{\rm R}}+{\rm h.c}. $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E51.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>52</label>
+                  <tex-math id="cpc_46_10_103101_E52">
+                     <?CDATA $ \mathcal{L}^u_{22}= \bar{Q}_{2{\rm L}}\tilde{\phi}_1K_{5{\rm R}}+M\bar{K}_{5{\rm R}}K_{5{\rm L}}+ X\bar{K}_{5{\rm L}}K_{7{\rm R}}+F_2 \bar{K}_{7{\rm R}}K_{7{\rm L}}+X\bar{K}_{7{\rm L}}u_{2{\rm R}}+{\rm h.c}. $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E52.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>53</label>
+                  <tex-math id="cpc_46_10_103101_E53">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{21}= & \bar{Q}_{2L}\tilde{\phi}_1K_{5{\rm R}}+M\bar{K}_{5{\rm R}}K_{5{\rm L}}+X\bar{K}_{5{\rm L}}K_{7{\rm R}}+F_2 \bar{K}_{7{\rm R}}K_{7{\rm L}}+X \bar{K}_{7{\rm L}}K_{8{\rm R}}+M\bar{K}_{8{\rm R}}K_{8{\rm L}}+ +X\bar{K}_{8{\rm L}}K_{9{\rm R}}+F_2\bar{K}_{9{\rm R}}K_{9{\rm L}}\\ & +X\bar{K}_{9{\rm L}}u_{1{\rm R}}+{\rm h.c}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E53.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>54</label>
+                  <tex-math id="cpc_46_10_103101_E54">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{11}= & \bar{Q}_{1{\rm L}}\tilde{\phi}_1K_{10{\rm R}}+F_2 \bar{K}_{10{\rm R}}K_{10{\rm L}}+X\bar{K}_{10{\rm L}}K_{11{\rm R}}+F_2 \bar{K}_{11{\rm R}}K_{11{\rm L}} +X\bar{K}_{11{\rm L}}K_{12{\rm R}} F_2\bar{K}_{12{\rm R}}K_{12{\rm L}}+X\bar{K}_{12{\rm L}}K_{13{\rm R}}\\ & +F_2 \bar{K}_{13{\rm R}}K_{13{\rm L}}+X\bar{K}_{13{\rm L}}K_{14{\rm R}}+F_2 \bar{K}_{14{\rm R}}K_{14{\rm L}} + X\bar{K}_{14{\rm L}}K_{15{\rm R}}+M\bar{K}_{15{\rm R}}K_{15{\rm L}}+X\bar{K}_{15{\rm L}}u_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E54.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>55</label>
+                  <tex-math id="cpc_46_10_103101_E55">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{12}= & \bar{Q}_{1{\rm L}}\tilde{\phi}_1K_{10{\rm R}}+F_2 \bar{K}_{10{\rm R}}K_{10{\rm L}}+X\bar{K}_{10{\rm L}}K_{11{\rm R}}+F_2 \bar{K}_{11{\rm R}}K_{11{\rm L}}+X\bar{K}_{11{\rm L}}K_{12{\rm R}} +F_2\bar{K}_{12{\rm R}}K_{12{\rm L}}+X\bar{K}_{12{\rm L}}K_{13{\rm R}}\\ & +F_2 \bar{K}_{13{\rm R}}K_{13{\rm L}}+X\bar{K}_{13{\rm L}}u_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E55.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>56</label>
+                  <tex-math id="cpc_46_10_103101_E56">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{13}= & \bar{Q}_{1{\rm L}}\tilde{\phi}_1K_{10{\rm R}}+F_2 \bar{K}_{10{\rm R}}K_{10{\rm L}}+X\bar{K}_{10{\rm L}}K_{11{\rm R}}+F_2 \bar{K}_{11{\rm R}}K_{11{\rm L}}+X\bar{K}_{11{\rm L}}K_{12{\rm R}} +F_2\bar{K}_{12{\rm R}}K_{12{\rm L}}\\ & +X\bar{K}_{12{\rm L}}K_{16{\rm R}}+F_1 \bar{K}_{16{\rm R}}K_{16{\rm L}}+X\bar{K}_{16{\rm L}}u_{3{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E56.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>57</label>
+                  <tex-math id="cpc_46_10_103101_E57">
+                     <?CDATA $ \begin{aligned}[b] U(1)_{\rm F}\;:\; & K_{1{\rm R}}\rightarrow q_{3f},\quad K_{1{\rm L}}, K_{2{\rm R}}\rightarrow q_{3f}+f_1,\quad K_{2{\rm L}}, K_{3{\rm R}}\rightarrow q_{3f}+f_1-f_2, \quad K_{3{\rm L}},K_{4{\rm L}}, K_{4{\rm R}}\rightarrow q_{3f}+f_1-2f_2,\\ & K_{5{\rm R}}, K_{5{\rm L}},K_{6{\rm R}},K_{7{\rm R}}\rightarrow q_{2f} \quad K_{7{\rm L}},K_{8{\rm R}},K_{8{\rm L}},K_{9{\rm R}}\rightarrow q_{2f}-f_2,\quad K_{6{\rm L}}\rightarrow q_{2f}-f_1,\quad K_{9{\rm L}}\rightarrow q_{2f}-2 f_2, \\ & K_{10{\rm R}}\rightarrow q_{1f},\quad K_{10{\rm L}},K_{11{\rm R}}\rightarrow q_{1f}-f_2,\quad K_{11{\rm L}},K_{12{\rm R}}\rightarrow q_{1f}-2 f_2, \quad K_{12{\rm L}},K_{13{\rm R}},K_{16{\rm R}}\rightarrow q_{1f}-3 f_2, \\ & K_{13{\rm L}},K_{14{\rm R}}\rightarrow q_{1f}-4 f_2, \quad K_{14{\rm L}},K_{15{\rm R}},K_{15{\rm L}}\rightarrow q_{1f}-5 f_2,\quad K_{16{\rm L}},u_{3{\rm R}}\rightarrow q_{1f}-3 f_2-f_1. \\ Z_2 \;:\; & K_{1{\rm L}}, K_{1{\rm R}}, K_{3{\rm L}}, K_{3{\rm R}},K_{5{\rm L}}, K_{5{\rm R}},K_{8{\rm L}},K_{8{\rm R}}, K_{10{\rm L}},K_{10{\rm R}},K_{12{\rm L}},K_{12{\rm R}},K_{14{\rm L}},K_{14{\rm R}}, \rightarrow \rm{even},\\ & K_{2{\rm L}}, K_{2{\rm R}}, K_{4{\rm L}}, K_{4{\rm R}},K_{6{\rm L}},K_{6{\rm R}},K_{7{\rm L}}, K_{7{\rm R}},K_{9{\rm L}},K_{9{\rm R}},K_{11{\rm L}},K_{11{\rm R}}, K_{13{\rm L}},K_{13{\rm R}},K_{15{\rm R}},K_{15{\rm L}},K_{16{\rm L}},K_{16{\rm R}}\rightarrow \rm{odd}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E57.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since the Lagragians of Eqs. (49) –(56) are invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M473.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get relations among the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M474.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges of quarks and flavons. These relations can be consistently solved. Taking
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ q_{3f} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M475.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M476.jpg" xlink:type="simple" />
+               </inline-formula>
+               , and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M477.jpg" xlink:type="simple" />
+               </inline-formula>
+               as independent variables, the above mentioned relations can be expressed as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>58</label>
+                  <tex-math id="cpc_46_10_103101_E58">
+                     <?CDATA $ \begin{aligned}[b] & q_{2f}=q_{3f}+f_1,\quad q_{1f}=q_{3f}+f_1+3f_2,\quad u_{3f}=q_{3f},\quad \\ & u_{2f}=q_{3f}+f_1-f_2,\quad u_{1f}=q_{3f}+f_1-2f_2. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E58.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               The procedure described above has been applied in order to generate non-renormalizable terms for down-type quarks of Eq. (44). In this case, we introduce VLQs
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ G_{i{\rm R}},G_{i{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M478.jpg" xlink:type="simple" />
+               </inline-formula>
+               , where
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ i=1,\cdots,30 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M479.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Below, we give invariant Lagrangians in the form of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal L}^d_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M480.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^d_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M481.jpg" xlink:type="simple" />
+               </inline-formula>
+               term in Eq. (44), after integrating the heavy VLQs and flavons. Since these Lagrangians are invariant under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F}\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M482.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the charges of VLQs under this symmetry are fixed in terms of corresponding charges of quarks and flavons. These charges are given in Eq. (68).
+            </p>
+            <p>
+               <disp-formula>
+                  <label>59</label>
+                  <tex-math id="cpc_46_10_103101_E59">
+                     <?CDATA $ \mathcal{L}^d_{33}= \bar{Q}_{3{\rm L}}\phi_1 G_{1{\rm R}}+ F_1 \bar{G}_{1{\rm R}}G_{1{\rm L}}+X \bar{G}_{1{\rm L}}G_{2{\rm R}}+ F_1 \bar{G}_{2{\rm R}}G_{2{\rm L}}+ X \bar{G}_{2{\rm L}}d_{3{\rm R}}+{\rm h.c}.. $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E59.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>60</label>
+                  <tex-math id="cpc_46_10_103101_E60">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{32}= & \bar{Q}_{3{\rm L}}\phi_1 G_{1{\rm R}}+ F_1 \bar{G}_{1{\rm R}}G_{1{\rm L}}+ X \bar{G}_{1{\rm L}}G_{2{\rm R}}+ F_1 \bar{G}_{2{\rm R}}G_{2{\rm L}}+ X \bar{G}_{2{\rm L}}G_{3{\rm R}} + M \bar{G}_{3{\rm R}}G_{3{\rm L}} + X \bar{G}_{3{\rm L}}G_{4{\rm R}}\\ & + F_2^*\bar{G}_{4{\rm R}}G_{4{\rm L}}+ X \bar{G}_{4{\rm L}}d_{2{\rm R}}+ {\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E60.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>61</label>
+                  <tex-math id="cpc_46_10_103101_E61">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{23} = & \bar{Q}_{2{\rm L}}\phi_1 G_{5{\rm R}}+ F_1 \bar{G}_{5{\rm R}}G_{5{\rm L}}+X\bar{G}_{5{\rm L}}G_{6{\rm R}}+F_1 \bar{G}_{6{\rm R}}G_{6{\rm L}}+X \bar{G}_{6{\rm L}}G_{7{\rm R}} +F_1 \bar{G}_{7{\rm R}}G_{7{\rm L}}+ X \bar{G}_{7{\rm L}}G_{8{\rm R}}\\ & +M \bar{G}_{8{\rm R}}G_{8{\rm L}}+\bar{G}_{8{\rm L}}d_{3{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E61.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>62</label>
+                  <tex-math id="cpc_46_10_103101_E62">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{22}= & \bar{Q}_{2{\rm L}}\phi_1 G_{5{\rm R}}+ F_1 \bar{G}_{5{\rm R}}G_{5{\rm L}}+X\bar{G}_{5{\rm L}}G_{6{\rm R}}+F_1 \bar{G}_{6{\rm R}}G_{6{\rm L}}+X \bar{G}_{6{\rm L}}G_{7{\rm R}} +F_1 \bar{G}_{7{\rm R}}G_{7{\rm L}}+X\bar{G}_{7{\rm L}}G_{9{\rm R}}\\ & +F_2^* \bar{G}_{9{\rm R}}G_{9{\rm L}}+X\bar{G}_{9{\rm L}}d_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E62.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>63</label>
+                  <tex-math id="cpc_46_10_103101_E63">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{13}= & \bar{Q}_{1{\rm L}}\phi_1 G_{10{\rm R}}+F_1 \bar{G}_{10{\rm R}}G_{10{\rm L}}+X\bar{G}_{10{\rm L}}G_{11{\rm R}}+ +F_1 \bar{G}_{11{\rm R}}G_{11{\rm L}}+X\bar{G}_{11{\rm L}}G_{12{\rm R}} +F_1 \bar{G}_{12{\rm R}}G_{12{\rm L}}+X \bar{G}_{12{\rm L}}G_{13{\rm R}}\\ & +F_2 \bar{G}_{13{\rm R}}G_{13{\rm L}}+X \bar{G}_{13{\rm L}}G_{14{\rm R}}+F_2 \bar{G}_{14{\rm R}}G_{14{\rm L}}+X \bar{G}_{14{\rm L}}G_{15{\rm R}}+F_2 \bar{G}_{15{\rm R}}G_{15{\rm L}}+X\bar{G}_{15{\rm L}}d_{3{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E63.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>64</label>
+                  <tex-math id="cpc_46_10_103101_E64">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{12}= & \bar{Q}_{1{\rm L}}\phi_1 G_{10{\rm R}}+F_1 \bar{G}_{10{\rm R}}G_{10{\rm L}}+X\bar{G}_{10{\rm L}}G_{11{\rm R}}+F_1 \bar{G}_{11{\rm R}}G_{11{\rm L}}+X\bar{G}_{11{\rm L}}G_{12{\rm R}} +F_1 \bar{G}_{12{\rm R}}G_{12{\rm L}}+X \bar{G}_{12{\rm L}}G_{13{\rm R}}\\ & +F_2 \bar{G}_{13{\rm R}}G_{13{\rm L}}+X \bar{G}_{13{\rm L}}G_{14{\rm R}}+F_2 \bar{G}_{14{\rm R}}G_{14{\rm L}} X \bar{G}_{14{\rm L}}G_{16{\rm R}}+M \bar{G}_{16{\rm R}}G_{16{\rm L}}+X\bar{G}_{16{\rm L}}d_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E64.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>65</label>
+                  <tex-math id="cpc_46_10_103101_E65">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{11}= & \bar{Q}_{1{\rm L}}\phi_1 G_{10{\rm R}}+F_1 \bar{G}_{10{\rm R}}G_{10{\rm L}}+X\bar{G}_{10{\rm L}}G_{11{\rm R}} +F_1 \bar{G}_{11{\rm R}}G_{11{\rm L}}+X\bar{G}_{11{\rm L}}G_{12{\rm R}} +F_1 \bar{G}_{12{\rm R}}G_{12{\rm L}}+X\bar{G}_{12{\rm L}}G_{17{\rm R}}\\ & +F_1 \bar{G}_{17{\rm R}}G_{17{\rm L}}+X\bar{G}_{17{\rm L}}G_{18{\rm R}} +F_1\bar{G}_{18{\rm R}}G_{18{\rm L}} +X\bar{G}_{18{\rm L}}G_{19{\rm R}}+F_2^* \bar{G}_{19{\rm R}}G_{19{\rm L}}+X\bar{G}_{19{\rm L}}d_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E65.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>66</label>
+                  <tex-math id="cpc_46_10_103101_E66">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{21}= & \bar{Q}_{2L}\phi_1 M_{5R}+ F_1 \bar{G}_{5R}G_{5L}+X\bar{G}_{5L}G_{6R}+F_1 \bar{G}_{6R}G_{6L}+X \bar{G}_{6L}G_{7R}+F_1 \bar{G}_{7R}G_{7L} +X\bar{G}_{7L}G_{9R}+F_2^* \bar{G}_{9R}G_{9L} \\ & + X\bar{G}_{9L}G_{20R} + F_2^*\bar{G}_{20R}G_{20L} +X\bar{G}_{20L}G_{21R}+F_2^* \bar{G}_{21R}G_{21L} + X\bar{G}_{21L}G_{22R}+ F_2^* \bar{G}_{22R}G_{22L}\\ & + X\bar{G}_{22L}G_{23R} +F_1 \bar{G}_{23R}G_{23L} + X \bar{G}_{23L}G_{24R} + F_1\bar{G}_{24R}G_{24L} + X \bar{G}_{24L}d_{1R}+h.c.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E66.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>67</label>
+                  <tex-math id="cpc_46_10_103101_E67">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{31}= & \bar{Q}_{3{\rm L}}\phi_1 G_{1{\rm R}}+ F_1 \bar{G}_{1{\rm R}}G_{1{\rm L}}+ X \bar{G}_{1{\rm L}}G_{2{\rm R}}+ F_1 \bar{G}_{2{\rm R}}G_{2{\rm L}}+ X\bar{G}_{2{\rm L}}G_{25{\rm R}} +F_1\bar{G}_{25{\rm R}}G_{25{\rm L}} + X\bar{G}_{25{\rm L}}G_{26{\rm R}} + F_1 \bar{G}_{26{\rm R}}G_{26{\rm L}} \\ & + X\bar{G}_{26{\rm L}}G_{27{\rm R}} + F_2^*\bar{G}_{27{\rm R}}G_{27{\rm L}}+X\bar{G}_{27{\rm L}}G_{28{\rm R}}+F_2^* \bar{G}_{28{\rm R}}G_{28{\rm L}} + X\bar{G}_{28{\rm L}}G_{29{\rm R}} \\ & + F_2^*\bar{G}_{29{\rm R}}G_{29{\rm L}} +X\bar{G}_{29{\rm L}}G_{30{\rm R}} +F_2^*\bar{G}_{30{\rm R}}G_{30{\rm L}} + X \bar{G}_{30L}d_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E67.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <tex-math id="cpc_46_10_103101_E68-1">
+                     <?CDATA $ \begin{aligned}[b] U(1)_F \;\;:\;\; & G_{1{\rm R}}\rightarrow q_{3f},\quad G_{1{\rm L}},G_{2{\rm R}}\rightarrow q_{3f}-f_1\quad G_{2{\rm L}},G_{3{\rm R}},G_{3{\rm L}},G_{4{\rm R}},G_{25{\rm R}}\rightarrow q_{3f}-2f_1, \\ & G_{4{\rm L}}\rightarrow q_{3f}-2f_1+f_2,\quad G_{5{\rm R}}\rightarrow q_{2f},\quad G_{5{\rm L}},G_{6{\rm R}}\rightarrow q_{2f}-f_1, \\ & G_{6{\rm L}},G_{7{\rm R}}\rightarrow q_{2f}-2f_1,\quad G_{7{\rm L}},G_{8{\rm R}},G_{8{\rm L}},G_{9{\rm R}}\rightarrow q_{2f}-3 f_1 \\ & G_{9{\rm L}},G_{20{\rm R}}\rightarrow q_{2f}-3 f_1+f_2,\quad G_{10{\rm R}}\rightarrow q_{1f},\quad G_{10{\rm L}},G_{11{\rm R}}\rightarrow q_{1f}-f_1, \\ & G_{11{\rm L}},G_{12{\rm R}}\rightarrow q_{1f}-2 f_1,\quad G_{12{\rm L}},G_{13{\rm R}},G_{17{\rm R}}\rightarrow q_{1f}-3 f_1, \\ & G_{13{\rm L}},G_{14{\rm R}}\rightarrow q_{1f}-3 f_1-f_3,\quad G_{14{\rm L}},G_{15{\rm R}},G_{16{\rm L}},G_{16{\rm R}}\rightarrow q_{1f}-3 f_1-2 f_2 \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E68-1.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>68</label>
+                  <tex-math id="cpc_46_10_103101_E68">
+                     <?CDATA $ \begin{aligned}[b] & G_{15{\rm L}}\rightarrow q_{1f}-3 f_1-3f_3,\quad G_{17{\rm L}},G_{18{\rm R}}\rightarrow q_{1f}-4 f_1,\quad G_{18{\rm L}},G_{19{\rm R}}\rightarrow q_{1f}-5 f_1, \\ & G_{19{\rm L}}\rightarrow q_{1f}-5 f_1-f_2,\quad G_{20{\rm L}},G_{21{\rm R}}\rightarrow q_{2f}-3 f_1+2 f_2, \\ & G_{21{\rm L}},G_{22{\rm R}}\rightarrow q_{2f}-3f_1+3 f_2,\quad G_{22{\rm L}},G_{23{\rm R}}\rightarrow q_{2f}-3 f_1+4 f_2, \\ & G_{23{\rm L}},G_{24{\rm R}}\rightarrow q_{2f}–4 f_1+4 f_2,\quad G_{24{\rm L}}\rightarrow q_{2f}-5 f_1+4 f_2, \\ & G_{25{\rm L}},G_{26{\rm R}}\rightarrow q_{3f}-3 f_1,\quad G_{26{\rm L}},G_{27{\rm R}{\rm R}}\rightarrow q_{3f}-4 f_1,\quad G_{27{\rm L}}, G_{28{\rm R}}\rightarrow q_{3f}-4 f_1+f_2, \\ & G_{28{\rm L}},G_{29{\rm R}}\rightarrow q_{3f}-4 f_1+2 f_2,\quad G_{29{\rm L}},G_{30{\rm R}}\rightarrow q_{3f}-4 f_1+3 f_2, \\ & g_{30{\rm L}}\rightarrow q_{3f}-4 f_1+4 f_2. \\ Z_2 \;\;:\;\; & G_{1{\rm L}},G_{1{\rm R}}, G_{3{\rm L}}, G_{3{\rm R}}, G_{5{\rm L}}, G_{5{\rm R}}, G_{7{\rm L}}, G_{7{\rm R}}, G_{10{\rm L}}, G_{10{\rm R}},G_{12{\rm L}}, G_{12{\rm R}}, G_{14{\rm L}}, G_{14{\rm R}}, G_{18{\rm L}}, \\ & G_{18{\rm R}}, G_{20{\rm L}}, G_{20{\rm R}}, G_{22{\rm L}}, G_{22{\rm R}}, G_{24{\rm L}}, G_{24{\rm R}}, G_{25{\rm L}}, G_{25{\rm R}}, G_{27{\rm L}}, G_{27{\rm R}}, G_{29{\rm L}}, G_{29{\rm R}} \rightarrow \rm{even}. \\ & G_{2{\rm L}},G_{2{\rm R}}, G_{4{\rm L}}, G_{4{\rm R}}, G_{6{\rm L}}, G_{6{\rm R}}, G_{8{\rm L}}, G_{8{\rm R}}, G_{9{\rm L}}, G_{9{\rm R}}, G_{11{\rm L}}, G_{11R}, G_{13{\rm L}}, G_{13{\rm R}},G_{15{\rm L}}, \\ & G_{15{\rm R}}, G_{16{\rm L}}, G_{16{\rm R}}, G_{17{\rm L}}, G_{17{\rm R}}, G_{19{\rm L}}, G_{19{\rm R}}, G_{21{\rm L}}, G_{21{\rm R}}, G_{23{\rm L}}, G_{23{\rm R}}, G_{26{\rm L}}, G_{26{\rm R}}, \\ & G_{28{\rm L}}, G_{28{\rm R}}, G_{30{\rm L}}, G_{30{\rm R}} \rightarrow \rm{odd}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E68.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since the Lagrangians in Eqs. (59)–(67) are invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M483.jpg" xlink:type="simple" />
+               </inline-formula>
+               , nine relations emerge among the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M484.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges of quarks and flavons. These relations can be solved consistently along with Eq. (58). After doing this, the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M485.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges of singlet down-type quarks can be expressed as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>69</label>
+                  <tex-math id="cpc_46_10_103101_E69">
+                     <?CDATA $ \begin{equation} d_{3f}=q_{3f}-2f_1,\quad d_{2f}=q_{3f}-2f_1+f_2,\quad d_{1f}=q_{3f}-4f_1+4f_2. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E69.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               In this section, we have described our model for the quark sector as well as the UV completion to it. As part of this whole construction, we introduce extra fields and symmetries into our model, which are summarized in
+               <xref ref-type="table" rid="cpc_46_10_103101_t3">Table 3</xref>
+               .
+            </p>
+            <table-wrap id="cpc_46_10_103101_t3" orientation="portrait" position="float">
+               <label>Table 3</label>
+               <caption id="cpc_46_10_103101_tc3">
+                  <p>Additional fields and symmetry, along with their roles, in the quark sector of our model.</p>
+               </caption>
+               <table>
+                  <thead>
+                     <tr>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Additional field</th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Role</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <italic toggle="yes">X</italic>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           to generate hierarchy in quark masses and also
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $C P$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M486.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           violation in quark sector
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ F_1,F_2 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M487.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate masses for VLQs in the UV completion of our model</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $K_{i{\rm L}},K_{i{\rm R}}$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M488.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           (
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ i=1,\cdots,16 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M489.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           )
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate effective Yukawa couplings for up-type quarks from UV completion our model</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $G_{i{\rm L} },G_{i{\rm R} }$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M490.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           (
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ i=1,\cdots,30 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M491.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           )
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate effective Yukawa couplings for down-type quarks from UV completion our model</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Additional symmetry</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Role</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <italic toggle="yes">U</italic>
+                           (1)
+                           <sub>
+                              <italic toggle="yes">F</italic>
+                           </sub>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate invariant terms in the UV completion of our model</td>
+                     </tr>
+                  </tbody>
+               </table>
+            </table-wrap>
+         </sec>
+      </sec>
+      <sec id="cpc_46_10_103101_s06">
+         <label>VI.</label>
+         <title>FULL SCALAR POTENTIAL</title>
+         <p>
+            In Sec. III, we have detailed the analysis of scalar potential for the model described in Sec. II. However, the model in Sec. II addresses problems related to the masses of leptons. Later, within the framework of that model, we have addressed the hierarchy in the masses of quark fields in Sec. V. Concurrently, we have introduced additional singlet scalar fields:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,\;F_1,\;F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M492.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which can give extra terms with the doublet and triplet Higgses in the scalar potential. These extra terms may change the results derived in Sec. III. For this purpose, in this section, we give the full scalar potential of our model. After minimizing the full scalar potential, we demonstrate that the above mentioned singlet scalar fields do not change the main conclusions of the analysis made in Sec. III. We recall the following main conclusions of Sec. III: (i) triplet Higgs acquire real VEV, (ii) VEVs of doublet Higgses
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M493.jpg" xlink:type="simple" />
+            </inline-formula>
+            explain the hierarchy between
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M494.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M495.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>The full scalar potential of our model is</p>
+         <p>
+            <disp-formula>
+               <label>70</label>
+               <tex-math id="cpc_46_10_103101_E70">
+                  <?CDATA $ \begin{array}{*{20}{l}} V_{{\rm full}}=V_{\rm inv}+ V_{X,F_1,F_2}+V_{\not{K}}+V^\prime_{\not{K}}. \end{array} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E70.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M496.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the invariant scalar potential of our model, arising due to the singlet fields
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,\;F_1,\;F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M497.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V^\prime_{\not{K}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M498.jpg" xlink:type="simple" />
+            </inline-formula>
+            contains potential terms due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,\;F_1,\;F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M499.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which violate
+            <italic toggle="yes">K</italic>
+            -symmetry explicitly. Recall that the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv}+V_{\not{K}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M500.jpg" xlink:type="simple" />
+            </inline-formula>
+            has been discussed in Sec. III. First we find a minimum for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv}+V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M501.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Further, we study the shift in this minimum due to the presence of
+            <italic toggle="yes">K</italic>
+            -violating terms. In this regard, the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M502.jpg" xlink:type="simple" />
+            </inline-formula>
+            , after applying the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M503.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, has been studied in Sec. III.C. Here, we verify whether this minimization can be affected by
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M504.jpg" xlink:type="simple" />
+            </inline-formula>
+            . The form for this potential is given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>71</label>
+               <tex-math id="cpc_46_10_103101_E71">
+                  <?CDATA $ \begin{aligned}[b]\\ V_{X,F_1,F_2}= & -m_X^2 (X^*X)-m_{F_1}^2(F_1^* F_1)-m_{F_2}^2(F_2^* F_2)+\lambda_X (X^*X)^2 +\lambda_{F_1}(F_1^* F_1)^2 +\lambda_{F_2}(F_2^* F_2)^2+ A(X^2+{X^*}^2)\\ & +B(X^4+{X^*}^4)+ \lambda_X^{\prime}(X^3X^{*}+{X^*}^3X) +\lambda_{F_1F_2}(F_1^* F_1)(F_2^* F_2) +\lambda_{F_1 X}(F_1^*F_1)(X^*X) +\lambda_{F_1 X}^{\prime}(F_1^*F_1)(X^2+{X^*}^2) \\ & +\lambda_{F_2 X}(F_2^*F_2)(X^*X)+\lambda_{F_2 X}^{\prime}(F_2^*F_2)(X^2+{X^*}^2) +\lambda_{\phi_1 X}(\phi_1^{\dagger}\phi_1)(X^*X) +\lambda_{\phi_1 X}^{\prime}(\phi_1^{\dagger}\phi_1)(X^2+{X^*}^2)\\ & +\lambda_{\phi_2 X}(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3)(X^*X)+\lambda_{\phi_2 X}^{\prime}(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3)(X^2+{X^*}^2)+\lambda_{\Delta X}\rm Tr(\Delta^{\dagger}\Delta)(X^*X) +\lambda_{\Delta X}^{\prime}{\rm Tr}(\Delta^{\dagger}\Delta)(X^2+{X^*}^2)\\ & +\lambda_{F_1\phi_1}(F_1^*F_1)(\phi_1^{\dagger}\phi_1)+\lambda_{F_2\phi_1}(F_2^*F_2)(\phi_1^{\dagger}\phi_1) +\lambda_{F_1\phi_2}(F_1^*F_1)(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3)+\lambda_{F_2\phi_2}(F_2^*F_2)(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3) \\ & +\lambda_{F_1\Delta}{\rm Tr}(\Delta^{\dagger}\Delta)(F_1^*F_1)+\lambda_{F_2\Delta}{\rm Tr}(\Delta^{\dagger}\Delta)(F_2^*F_2). \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E71.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above equation, all parameters are real due to hermiticity and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M505.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry.
+         </p>
+         <p>
+            In Eq. (71),
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M506.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M507.jpg" xlink:type="simple" />
+            </inline-formula>
+            appear in the form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_1^*F_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M508.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_2^*F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M509.jpg" xlink:type="simple" />
+            </inline-formula>
+            , respectively. As a result, we can consider the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M510.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M511.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be real. Hence, we can parameterize the VEVs for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M512.jpg" xlink:type="simple" />
+            </inline-formula>
+            as
+         </p>
+         <p>
+            <disp-formula>
+               <label>72</label>
+               <tex-math id="cpc_46_10_103101_E72">
+                  <?CDATA $ \begin{array}{*{20}{l}} \langle X \rangle =v_{X}{\rm e}^{{\rm i}\theta_{X}},\quad \langle F_1 \rangle =v_{f_1},\quad \langle F_2 \rangle =v_{f_2}. \end{array} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E72.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M513.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the phase in the VEV of
+            <italic toggle="yes">X</italic>
+            . After using the above VEVs and Eq. (17) in Eq. (71), we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>73</label>
+               <tex-math id="cpc_46_10_103101_E73">
+                  <?CDATA $ \begin{aligned}[b] \langle V_{X,F_1,F_2}\rangle \ni & 2 v_X^2\Big[ A +\lambda_X^{\prime} v_X^2 +\lambda_{\phi_1 X}^{\prime}v_1^2+\lambda_{\phi_2 X}^{\prime}v^2+\lambda_{\Delta X}{v^{\prime}}^2\\ & +\lambda_{F_1 X}^{\prime}v_{f_1}^2+ +\lambda_{F_2 X}^{\prime}v_{f_2}^2\Big]\cos2\theta_X +2 B v_X^4 \cos4\theta_{X}. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E73.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above equation, we have not written constant terms which do not contain phases of the VEVs of the fields. It is possible to notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M514.jpg" xlink:type="simple" />
+            </inline-formula>
+            do not mix with the phases in the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M515.jpg" xlink:type="simple" />
+            </inline-formula>
+            and Δ. Hence, the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{\rm inv}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M516.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is presented in Sec. III.C, is not affected due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{X,F_1,F_2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M517.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Consequently, Δ can acquire a real VEV, while Eq. (34) remains valid. From the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{X,F_1,F_2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M518.jpg" xlink:type="simple" />
+            </inline-formula>
+            with respect to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M519.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>74</label>
+               <tex-math id="cpc_46_10_103101_E74">
+                  <?CDATA $ \begin{aligned}[b] \cos2\theta_{X}= & -\frac{1}{4 B v_X^2}\Big[A+\lambda_X^{\prime}v_X^2+\lambda_{\phi_1 X}^{\prime}v_1^2+\lambda_{\phi_2 X}^{\prime}v^2\\ & +\lambda_{\Delta X}^{\prime}{v^{\prime}}^2+\lambda_{F_1 X}^{\prime}v_{f_1}^2+\lambda_{F_2 X}^{\prime}v_{f_2}^2\Big]. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E74.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            The above relation corresponds to the minimum for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M520.jpg" xlink:type="simple" />
+            </inline-formula>
+            , provided the below condition is satisfied.
+         </p>
+         <p>
+            <disp-formula>
+               <label>75</label>
+               <tex-math id="cpc_46_10_103101_E75">
+                  <?CDATA $ \begin{aligned}[b] 16 B^2 v_X^4 \gt & \Big[A+\lambda_X^{\prime}v_X^2+\lambda_{\phi_1 X}^{\prime}v_1^2+\lambda_{\phi_2 X}^{\prime}v^2+\lambda_{\Delta X}^{\prime}{v^{\prime}}^2\\ & +\lambda_{F_1 X}^{\prime}v_{f_1}^2+\lambda_{F_2 X}^{\prime}v_{f_2}^2\Big]^2 . \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E75.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here we have shown that
+            <italic toggle="yes">X</italic>
+            can acquire complex VEV. This must be achieved to generate the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M521.jpg" xlink:type="simple" />
+            </inline-formula>
+            violation in the quark sector, which is discussed in Sec. V.
+         </p>
+         <p>
+            After minimizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{\rm inv}\rangle+\langle V_{X,F_1,F_2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M522.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we have shown that the minimum can be given by Eqs. (34) and (74). This minimum can be shifted by small amount due to
+            <italic toggle="yes">K</italic>
+            -violating terms. Terms in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M523.jpg" xlink:type="simple" />
+            </inline-formula>
+            are presented in Sec. III. Below we give the form for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M524.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            <disp-formula>
+               <label>76</label>
+               <tex-math id="cpc_46_10_103101_E76">
+                  <?CDATA $ \begin{aligned}[b] V_{\not{K}}^{\prime}= & \delta\lambda_{\phi_2 X}(\phi_2^{\dagger}\phi_2)(X^*X)+\delta\lambda_{\phi_2 X}^{\prime}(\phi_3^{\dagger}\phi_3)(X^*X)+\delta\lambda_{\phi X}(\phi_2^{\dagger}\phi_2)(X^2+{X^*}^2) +\delta\lambda_{\phi X}^{\prime}(\phi_3^{\dagger}\phi_3)(X^2+{X^*}^2)\\ & +\delta \lambda_{\phi_2 F_1}(\phi_2^{\dagger}\phi_2)(F_1^{*}F_1)+\delta \lambda_{\phi_2 F_1}^{\prime}(\phi_3^{\dagger}\phi_3)(F_1^{*}F_1) +\delta \lambda_{\phi_2 F_2}(\phi_2^{\dagger}\phi_2)(F_2^{*}F_2)+\delta \lambda_{\phi_2 F_2}^{\prime}(\phi_3^{\dagger}\phi_3)(F_2^{*}F_2)\\ & +{\rm i}\delta\lambda_{21}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(X^*X) +{\rm i}\delta\lambda_{22}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(X^2+{X^*}^2)+{\rm i}\delta\lambda_{23}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(F_1^*F_1) +{\rm i}\delta\lambda_{24}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(F_2^*F_2). \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E76.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            All parameters in the above equation are real due to either
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M525.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry or hermiticity of the potential. These parameters should be small compared to those in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv}+V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M526.jpg" xlink:type="simple" />
+            </inline-formula>
+            , since the above potential violates
+            <italic toggle="yes">K</italic>
+            symmetry by a small amount. We can see that the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M527.jpg" xlink:type="simple" />
+            </inline-formula>
+            in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M528.jpg" xlink:type="simple" />
+            </inline-formula>
+            can give additional contribution to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M529.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_\zeta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M530.jpg" xlink:type="simple" />
+            </inline-formula>
+            in Eq. (36). Since the parameters of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M531.jpg" xlink:type="simple" />
+            </inline-formula>
+            are small, we can notice that the contribution due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M532.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be of the same order as the terms already obtained for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M533.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_\zeta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M534.jpg" xlink:type="simple" />
+            </inline-formula>
+            in Eq. (36). As a result, the hierarchy in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M535.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M536.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be explained in our framework.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s07">
+         <label>VII.</label>
+         <title>PHENOMENOLOGY OF OUR MODEL</title>
+         <p>
+            In Secs. III and VI we have analyzed the minimum of the scalar potential of our model. One needs to study whether this minimum corresponds to a global or local minimum. Following the studies made in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib39">39</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib40">40</xref>
+            ], we expect some additional conditions to be imposed on the parameters of our model in order for the minimum of the potential in this work to be global. Nonetheless, we shall work on the vacuum stability of our scalar potential in future studies.
+         </p>
+         <p>
+            The scalar fields, which are proposed in our model, are: three Higgs doublets, one Higgs triplet and three singlet scalar fields. We can choose the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{\rm F} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M537.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry of our model to be gauged. As a result, after electroweak symmetry breaking, the following fields remain in the theory: one doubly charged scalar, three singly charged scalars, seven neutral scalars, and five pseudo scalars. In case I, which is described in Sec. III, the scalar fields belonging to the triplet Higgs can have masses around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 10^{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M538.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV. Otherwise, we can choose the parameters in the scalar potential of our model in such a way that all the scalar fields can have masses less than or about 1 TeV. In the case where the masses for the scalar fields are less than 1 TeV, one can study the collider phenomenology. For this study, one needs to know the interaction of the scalar fields with the standard model particles. We can see that the scalar components of Higgs doublets and Higgs triplet have gauge interactions. For the field
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M539.jpg" xlink:type="simple" />
+            </inline-formula>
+            , it has Yukawa interactions with quark fields. Hence, the scalars belonging to doublet and triplet Higgses can be produced at the LHC experiment via gauge or strong interactions. After production, they will decay into standard model fields. In the case of singlet scalars
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M540.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the flavons have Yukawa interactions with VLQs. Moreover, these flavons interact with doublet and triplet Higgses in the scalar potential. As for the
+            <italic toggle="yes">X</italic>
+            field, it has Yukawa interactions containing a VLQ and a right-handed quark field. Moreover,
+            <italic toggle="yes">X</italic>
+            has interactions with Higgs fields in the scalar potential. Since VLQs are color triplets, they can be produced at the LHC experiment via strong interactions. From the decay of these VLQs, one can produce the abovementioned singlet scalars in the LHC experiment. Studying the collider phenomenology of this model is beyond the scope of this work.
+         </p>
+         <p>
+            In the lepton sector of our model, the Yukawa couplings for charged leptons are diagonal. Hence, these Yukawa interactions are flavor conserving. In contrast, the Yukawa couplings for neutrinos are flavor violating. As a result, the singly and doubly charged triplet Higgs fields can drive flavor violating decays of the form
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \ell\to3\ell^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M541.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \ell\to\ell^\prime\gamma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M542.jpg" xlink:type="simple" />
+            </inline-formula>
+            . However, it is stated in Sec. II that the Yukawa couplings for neutrinos are suppressed by about
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 10^{-3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M543.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, the branching ratios for the above mentioned decays are suppressed even if the components of the triplet Higgs can have masses around few hundred GeV. As a result, constraints due to non-observation of charged lepton flavor violating decays [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ] are satisfied in our model.
+         </p>
+         <p>
+            The phenomenology of our model in the quark sector is similar to that discussed in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ]. In this regard, the
+            <italic toggle="yes">X</italic>
+            field can cause flavor changing neutral currents at tree level in our model. Consequently, there can be mass splitting in the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ K^0-\bar{K}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M544.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D^0-\bar{D}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M545.jpg" xlink:type="simple" />
+            </inline-formula>
+            due to the mediation of
+            <italic toggle="yes">X</italic>
+            . We have estimated the above mentioned mass splittings, using the procedures described in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ]. For this purpose, we define
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \beta={v_1}/{M} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M546.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In our calculations, we have taken
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \epsilon\sim\beta={1}/{5.5} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M547.jpg" xlink:type="simple" />
+            </inline-formula>
+            and the mass of
+            <italic toggle="yes">X</italic>
+            as 1 TeV. The Yukawa couplings for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ h^{d,u}_{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M548.jpg" xlink:type="simple" />
+            </inline-formula>
+            are given in Eq. (48). We have chosen
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ h_{21}^d\sim1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M549.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ h_{21}^u=-0.7 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M550.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Using the above set of parameters, we have found
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_{K}\approx 10^{-16} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M551.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_D\approx 10^{-15} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M552.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV. These numerical values are smaller than the corresponding current experimental values, which are as follows:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_{K}=3.5 \times 10^{-15} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M553.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_D=2.35 \times 10^{-14} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M554.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ]. Hence, our model satisfies the constraints due to the mass splitting in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ K^0-\bar{K}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M555.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D^0-\bar{D}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M556.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            By choosing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{\rm F} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M557.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be gauged, the gauge boson corresponding to this symmetry,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M558.jpg" xlink:type="simple" />
+            </inline-formula>
+            , can be massive. The mixing between
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z-Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M559.jpg" xlink:type="simple" />
+            </inline-formula>
+            is constrained to be very small. In this regard, phenomenology due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M560.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be studied in our model. For more details about the phenomenology on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M561.jpg" xlink:type="simple" />
+            </inline-formula>
+            , see Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib41">41</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib42">42</xref>
+            ].
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s08">
+         <label>VIII.</label>
+         <title>CONCLUSIONS</title>
+         <p>
+            In this work, we have proposed a model, which explains the maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M562.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M563.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the lepton sector. To achieve this purpose, we have introduced three Higgs doublets and one Higgs triplet. This model is based on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M564.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry and type II seesaw mechanism. To explain the above observables, the VEV of triplet Higgs should be real. Moreover, due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M565.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, the masses for muon and tau can be of the same order. After introducing the
+            <italic toggle="yes">K</italic>
+            symmetry and explicit violation of it by a small amount, we have studied the minimization of the scalar potential of our model. Thereafter, we have shown that the VEV of triplet Higgs can be real, apart from explaining the hierarchy in the muon and tau masses. In addition to predicting the above observables, the mass matrix for neutrinos in our model can make predictions about the neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M566.jpg" xlink:type="simple" />
+            </inline-formula>
+            , if the elements of this matrix satisfy certain conditions, which are given in Sec. IV. To explain these conditions, one has to propose a new mechanism in addition to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M567.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. Although we do not have a mechanism to explain all the conditions given in Sec. IV, we have attempted to give one mechanism to explain condition (i) for the case of NO. This mechanism is presented in the Appendix.
+         </p>
+         <p>
+            Since in our model three Higgs doublets exist, we have studied the Yukawa couplings between quarks and these doublets by proposing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M568.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations for quark fields. After employing a certain texture for these Yukawa couplings, we have consistently explained the quark masses and mixing pattern. To employ this texture in the quark sector of our model, we have introduced additional fields like VLQs and singlet scalars. One of these singlet scalars should acquire a complex VEV in order to generate the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M569.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating phase in quark sector. Finally, we have analyzed the scalar potential containing the singlet scalars and the above mentioned Higgs fields. After this analysis, we have demonstrated that the masses and mixing pattern in lepton and quark sectors can be consistently explained.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s08_1">
+         <title>ACKNOWLEDGEMENT</title>
+         <p>
+            <italic toggle="yes">JG acknowledges Dr. Anirban Karan for some useful discussion.</italic>
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s09">
+         <title>APPENDIX: A MODEL FOR ACHIEVING CONDITION (I) IN THE CASE OF NO</title>
+         <p>
+            In Sec. IV, we have described some conditions on the elements of the neutrino mass matrix, which can make predictions regarding the case of NO or IO and about the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M570.jpg" xlink:type="simple" />
+            </inline-formula>
+            . These conditions are purely phenomenological and cannot be achieved with just the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M571.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. An additional mechanism should be proposed in order to satisfy these conditions. For the case of NO, condition (i) can be achieved if we propose an extra
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M572.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry and the singlet scalar fields
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1,S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M573.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M574.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, we consider the following charge assignments, where
+            <italic toggle="yes">l</italic>
+            is some non-zero rational number:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{e{\rm L}}\to l $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M575.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1\to-2l $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M576.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_2\to-l $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M577.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M578.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ e_{\rm R} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M579.jpg" xlink:type="simple" />
+            </inline-formula>
+            should transform like
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{e{\rm L}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M580.jpg" xlink:type="simple" />
+            </inline-formula>
+            , whereas the rest of the fields in our model are singlets.
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1,S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M581.jpg" xlink:type="simple" />
+            </inline-formula>
+            transform under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M582.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry as
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2}\to S_{1,2}^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M583.jpg" xlink:type="simple" />
+            </inline-formula>
+            . With the above charge assignments, the Yukawa terms for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{e{\rm L}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M584.jpg" xlink:type="simple" />
+            </inline-formula>
+            in Eq. (8) are forbidden. Now, these terms can be effectively generated by the following invariant terms.
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E77">
+                  <?CDATA $ \begin{aligned}[b] & Y_e\frac{S_1}{M}\bar{D}^c_{e{\rm L}}{\rm i}\sigma_2\Delta D_{e{\rm L}} +Y_\mu\frac{S_2}{M}\bar{D}^c_{e{\rm L}}{\rm i}\sigma_2\Delta D_{\mu {\rm L}} \\ & +Y_\tau\frac{S_2}{M}\bar{D}^c_{e{\rm L}}{\rm i}\sigma_2\Delta D_{\tau L}+{\rm h.c}.. \end{aligned}\tag{A1} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E77.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <italic toggle="yes">M</italic>
+            is a mass scale that is analogous to that in the quark sector Lagrangian of Eq. (44). The above non-renormalizable terms can be generated by studying the UV completion for these terms, where one can propose heavy vector-like leptons whose masses are around
+            <italic toggle="yes">M</italic>
+            . The process of this UV completion is analogous to the description in Sec. V.B. In order for Eq. (77) to be invariant under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M585.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y_e $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M586.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y_\mu=Y_\tau^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M587.jpg" xlink:type="simple" />
+            </inline-formula>
+            . After
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M588.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry is spontaneously broken, terms in Eq. (77) effectively generate the Yukawa couplings
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee}, Y^\nu_{e\mu},Y^\nu_{e\tau} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M589.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Moreover, by taking
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {\langle S_{1,2}\rangle}/{M}\sim0.1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M590.jpg" xlink:type="simple" />
+            </inline-formula>
+            , condition (i) for the case of NO is satisfied. Since
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M591.jpg" xlink:type="simple" />
+            </inline-formula>
+            is real and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{e\mu}=(Y^\nu_{e\tau})^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M592.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_{1}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M593.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_{2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M594.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real. We justify this statement by studying the scalar potential for these fields.
+         </p>
+         <p>
+            The scalar potential, which is invariant under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P\times Z_2\times Z_3\times K \times U(1)_{\rm F}\times U(1)_S$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M595.jpg" xlink:type="simple" />
+            </inline-formula>
+            and contains
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $S_{ 1,2}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M596.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E78">
+                  <?CDATA $ \begin{aligned}[b] V_{S_1,S_2}= & -m_{S_1}^2 (S_1^* S_1)- m_{S_2}^2 (S_2^* S_2)+\lambda_{S_1} (S_1^* S_1)^2\\ & +\lambda_{S_2} (S_2^* S_2)^2 + \lambda_{S_1 S_2} (S_1^* S_1)(S_2^* S_2) \\ & +\lambda_{\phi_1 S_1}(\phi_1^* \phi_1)(S_1^*S_1) + \lambda_{\phi_2 S_1}(\phi_2^* \phi_2\\ & +\phi_3^* \phi_3)(S_1^*S_1)+\lambda_{\phi_1 S_2}(\phi_1^* \phi_1)(S_2^*S_2) \\ & +\lambda_{\phi_2 S_2}(\phi_2^* \phi_2+\phi_3^* \phi_3)(S_2^*S_2)+\lambda_{\Delta S_1}{\rm Tr}(\Delta^{\dagger}\Delta)(S_1^* S_1)\\ & +\lambda_{\Delta S_2}{\rm Tr}(\Delta^{\dagger}\Delta)(S_2^* S_2) +\lambda_{S_1 X}(S_1^*S_1)(X^*X)\\ & + \lambda_{S_2 X}(S_2^*S_2)(X^*X)+\lambda_{S_1 X}^{\prime}(S_1^*S_1)(X^2+{X^*}^2) \\ & +\lambda_{S_2 X}^{\prime}(S_2^*S_2)(X^2+{X^*}^2)+\lambda_{F_1S_1}(F_1^*F_1)(S_1^*S_1)\\ & +\lambda_{F_1S_2}(F_1^*F_1)(S_2^*S_2) +\lambda_{F_2S_1}(F_2^*F_2)(S_1^*S_1)\\ & +\lambda_{F_2S_2}(F_2^*F_2)(S_2^*S_2) + a (S_1^*S_2^2+S_1 {S_2^*}^2). \end{aligned}\tag{A2} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E78.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Now, the
+            <italic toggle="yes">K</italic>
+            -violating terms containing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $S_{ 1,2}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M597.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E79">
+                  <?CDATA $ \begin{aligned}[b] V_{\not{K}}^{\prime\prime}= & \delta \lambda_{\phi_2 S_1}(\phi_2^{\dagger}\phi_2)(S_1^{*}S_1)+\delta\lambda_{\phi_2 S_1}^{\prime}(\phi_3^{\dagger}\phi_3)(S_1^{*}S_1)\\ & +\delta\lambda_{\phi_2 S_2}(\phi_2^{\dagger}\phi_2)(S_2^*S_2) +\lambda_{\phi_2 S_2}^{\prime}(\phi_3^{\dagger}\phi_3)(S_2^*S_2)\\ & +{\rm i}\delta\lambda_{25}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(S_1^*S_1)+{\rm i}\delta\lambda_{26}(\phi_2^{\dagger}\phi_3 \\ & -\phi_3^{\dagger}\phi_2)(S_2^*S_2). \end{aligned}\tag{A3} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E79.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above two potentials, all parameters are real due to hermiticity or
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M598.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. Similar to the desciption in Sec. VI, we can see that the potential terms in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{S_1,S_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M599.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^{\prime\prime} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M600.jpg" xlink:type="simple" />
+            </inline-formula>
+            do not alter the main conclusions of Sec. III.C. This means, even with the fields
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M601.jpg" xlink:type="simple" />
+            </inline-formula>
+            , Δ acquires real VEV, whereas the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M602.jpg" xlink:type="simple" />
+            </inline-formula>
+            explain the hierarchy in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M603.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M604.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            Here, we demonstrate that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M605.jpg" xlink:type="simple" />
+            </inline-formula>
+            can acquire real VEVs. In this regard, we can see that the last term of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{S_1,S_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M606.jpg" xlink:type="simple" />
+            </inline-formula>
+            can only contain the phases in the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M607.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, after parameterizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_1\rangle =v_{s_1}{\rm e}^{\theta_{s_1}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M608.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_1\rangle=v_{s_2}{\rm e}^{\theta_{s_2}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M609.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we get
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E80">
+                  <?CDATA $ \langle V_{S_1,S_2}\rangle \ni + 2 a v_{s_1}v_{s_2}^2\cos(2\theta_{s_2}-\theta_{s_1}). \tag{A4} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E80.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            The above term has a minimum at
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 2\theta_{s_2}-\theta_{s_1}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M610.jpg" xlink:type="simple" />
+            </inline-formula>
+            when
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ av_{s_1} \lt 0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M611.jpg" xlink:type="simple" />
+            </inline-formula>
+            . To satisfy this minimum, we can choose
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{s_1}=\theta_{s_2}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M612.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, the minimum at
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{s_1}=\theta_{s_2}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M613.jpg" xlink:type="simple" />
+            </inline-formula>
+            cannot be shifted by the terms of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^{\prime\prime} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M614.jpg" xlink:type="simple" />
+            </inline-formula>
+            , since
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M615.jpg" xlink:type="simple" />
+            </inline-formula>
+            appear in the form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1^*S_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M616.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_2^*S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M617.jpg" xlink:type="simple" />
+            </inline-formula>
+            in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^{\prime\prime} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M618.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, there exist a parameter region where the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M619.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M620.jpg" xlink:type="simple" />
+            </inline-formula>
+            are real in this model.
+         </p>
+      </sec>
+   </body>
+   <back>
+      <ref-list>
+         <title>References</title>
+         <ref id="cpc_46_10_103101_bib1">
+            <label>[1]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. de Salas</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>V. Forero</surname>
+                     <given-names>D.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Gariazzo</surname>
+                     <given-names>S.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>JHEP</source>
+               <year>2021</year>
+               <volume>02</volume>
+               <fpage>071</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP02(2021)071</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2006.11237" xlink:type="simple">2006.11237</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib2">
+            <label>[2]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. Harrison</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>H. Perkins</surname>
+                     <given-names>D.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>G. Scott</surname>
+                     <given-names>W.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>530</volume>
+               <fpage>167</fpage>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0202074 " xlink:type="simple">hep-ph/0202074 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib3">
+            <label>[3]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. Harrison</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>G. Scott</surname>
+                     <given-names>W.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>535</volume>
+               <fpage>163</fpage>
+               <lpage>169</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)01753-7</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0203209 " xlink:type="simple">hep-ph/0203209 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib4">
+            <label>[4]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>z. Xing</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>533</volume>
+               <fpage>85</fpage>
+               <lpage>93</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)01649-0</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0204049 " xlink:type="simple">hep-ph/0204049 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib5">
+            <label>[5]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. Harrison</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>G. Scott</surname>
+                     <given-names>W.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>547</volume>
+               <fpage>219</fpage>
+               <lpage>228</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)02772-7</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0210197" xlink:type="simple">hep-ph/0210197</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib6">
+            <label>[6]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>z. Xing</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>h. Zhao</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+               </person-group>
+               <source>Rept. Prog. Phys.</source>
+               <year>2016</year>
+               <volume>79</volume>
+               <issue>7</issue>
+               <fpage>076201</fpage>
+               <pub-id pub-id-type="doi">10.1088/0034-4885/79/7/076201</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1512.04207" xlink:type="simple">1512.04207</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib7">
+            <label>[7]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Holthausen</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lindner</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>A. Schmidt</surname>
+                     <given-names>M.</given-names>
+                  </name>
+               </person-group>
+               <source>JHEP</source>
+               <year>2013</year>
+               <volume>04</volume>
+               <fpage>122</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP04(2013)122</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1211.6953 " xlink:type="simple">1211.6953 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib8">
+            <label>[8]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Feruglio</surname>
+                     <given-names>F.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Hagedorn</surname>
+                     <given-names>C.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Ziegler</surname>
+                     <given-names>R.</given-names>
+                  </name>
+               </person-group>
+               <source>Eur. Phys. J. C</source>
+               <year>2014</year>
+               <volume>74</volume>
+               <fpage>2753</fpage>
+               <pub-id pub-id-type="doi">10.1140/epjc/s10052-014-2753-2</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1303.7178 " xlink:type="simple">1303.7178 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib9">
+            <label>[9]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>J. He</surname>
+                     <given-names>H.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Rodejohann</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>J. Xu</surname>
+                     <given-names>X.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2015</year>
+               <volume>751</volume>
+               <fpage>586</fpage>
+               <lpage>594</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2015.10.066</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1507.03541 " xlink:type="simple">1507.03541 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib10">
+            <label>[10]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Joshipura</surname>
+                     <given-names>A.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>M. Patel</surname>
+                     <given-names>K.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2015</year>
+               <volume>749</volume>
+               <fpage>159</fpage>
+               <lpage>166</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2015.07.062</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1507.01235 " xlink:type="simple">1507.01235 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib11">
+            <label>[11]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>C. Nishi</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>JHEP</source>
+               <year>2015</year>
+               <volume>08</volume>
+               <fpage>092</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP08(2015)092</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1506.06788 " xlink:type="simple">1506.06788 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib12">
+            <label>[12]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. King</surname>
+                     <given-names>S.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>C. Nishi</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2018</year>
+               <volume>785</volume>
+               <fpage>391</fpage>
+               <lpage>398</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2018.08.056</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1807.00023 " xlink:type="simple">1807.00023 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib13">
+            <label>[13]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Grimus</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lavoura</surname>
+                     <given-names>L.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2004</year>
+               <volume>579</volume>
+               <fpage>113</fpage>
+               <lpage>122</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2003.10.075</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0305309" xlink:type="simple">hep-ph/0305309</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib14">
+            <label>[14]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Babu</surname>
+                     <given-names>K.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Ma</surname>
+                     <given-names>E.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>W. F. Valle</surname>
+                     <given-names>J.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2003</year>
+               <volume>552</volume>
+               <fpage>207</fpage>
+               <lpage>213</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)03153-2</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0206292" xlink:type="simple">hep-ph/0206292</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib15">
+            <label>[15]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Senjanovic</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. Lett.</source>
+               <year>1980</year>
+               <volume>44</volume>
+               <fpage>912</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevLett.44.912</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib16">
+            <label>[16]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Schechter</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>W. F. Valle</surname>
+                     <given-names>J.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>1980</year>
+               <volume>22</volume>
+               <fpage>2227</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.22.2227</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib17">
+            <label>[17]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Grimus</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lavoura</surname>
+                     <given-names>L.</given-names>
+                  </name>
+               </person-group>
+               <source>J. Phys. G</source>
+               <year>2004</year>
+               <volume>30</volume>
+               <fpage>73</fpage>
+               <lpage>82</lpage>
+               <pub-id pub-id-type="doi">10.1088/0954-3899/30/2/007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0309050" xlink:type="simple">hep-ph/0309050</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib18">
+            <label>[18]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>
+                  P. A. Zyla
+                  <italic toggle="yes">et al.</italic>
+                  (Particle Data Group), PTEP
+                  <bold>2020</bold>
+                  (8), 083C01 (2020) doi:
+                  <ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1093/ptep/ptaa104" xlink:type="simple">10.1093/ptep/ptaa104</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib19">
+            <label>[19]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Magg</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Wetterich</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>1980</year>
+               <volume>94</volume>
+               <fpage>61</fpage>
+               <lpage>64</lpage>
+               <pub-id pub-id-type="doi">10.1016/0370-2693(80)90825-4</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib20">
+            <label>[20]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Senjanovic</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>1981</year>
+               <volume>23</volume>
+               <fpage>165</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.23.165</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib21">
+            <label>[21]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Lazarides</surname>
+                     <given-names>G.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Shafi</surname>
+                     <given-names>Q.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Wetterich</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Nucl. Phys. B</source>
+               <year>1981</year>
+               <volume>181</volume>
+               <fpage>287</fpage>
+               <lpage>300</lpage>
+               <pub-id pub-id-type="doi">10.1016/0550-3213(81)90354-0</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib22">
+            <label>[22]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>M. Ferreira</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Grimus</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lavoura</surname>
+                     <given-names>L.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>JHEP</source>
+               <year>2012</year>
+               <volume>09</volume>
+               <fpage>128</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP09(2012)128</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1206.7072" xlink:type="simple">1206.7072</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib23">
+            <label>[23]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>C. Nishi</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2012</year>
+               <volume>86</volume>
+               <fpage>073007</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.86.073007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1208.2875" xlink:type="simple">1208.2875</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib24">
+            <label>[24]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Hundi</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Sethi</surname>
+                     <given-names>I.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2020</year>
+               <volume>102</volume>
+               <fpage>055007</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.102.055007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2003.09809 " xlink:type="simple">2003.09809 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib25">
+            <label>[25]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Ganguly</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>S. Hundi</surname>
+                     <given-names>R.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2021</year>
+               <volume>103</volume>
+               <issue>3</issue>
+               <fpage>035007</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.103.035007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:2005.04023 " xlink:type="simple">arXiv:2005.04023 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib26">
+            <label>[26]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Rasin</surname>
+                     <given-names>A.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys.Rev.  D</source>
+               <year>1998</year>
+               <volume>58</volume>
+               <fpage>096012</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.58.096012</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:hep-ph/9802356" xlink:type="simple">arXiv:hep-ph/9802356</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib27">
+            <label>[27]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Babu</surname>
+                     <given-names>K.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Nandi</surname>
+                     <given-names>S.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2000</year>
+               <volume>62</volume>
+               <fpage>033002</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.62.033002</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/9907213" xlink:type="simple">hep-ph/9907213</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib28">
+            <label>[28]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>D. Lykken</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Murdock</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Nandi</surname>
+                     <given-names>S.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2009</year>
+               <volume>79</volume>
+               <fpage>075014</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.79.075014</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/0812.1826" xlink:type="simple">0812.1826</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib29">
+            <label>[29]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>C. Li</surname>
+                     <given-names>C.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>N. Lu</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>J. Ding</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>JHEP</source>
+               <year>2018</year>
+               <volume>02</volume>
+               <fpage>038</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP02(2018)038</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1706.04576 " xlink:type="simple">1706.04576 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib30">
+            <label>[30]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Lu</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>J. Ding</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2018</year>
+               <volume>98</volume>
+               <fpage>055011</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.98.055011</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1806.02301 " xlink:type="simple">1806.02301 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib31">
+            <label>[31]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>H. Rahat</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Ramond</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Xu</surname>
+                     <given-names>B.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2018</year>
+               <volume>98</volume>
+               <issue>5</issue>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.98.055030</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:1805.10684 " xlink:type="simple">arXiv:1805.10684 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib32">
+            <label>[32]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <etal>et al</etal>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2019</year>
+               <volume>100</volume>
+               <issue>7</issue>
+               <fpage>075008</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.100.075008</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:1907.10698 " xlink:type="simple">arXiv:1907.10698 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib33">
+            <label>[33]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <etal>et al</etal>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2020</year>
+               <volume>101</volume>
+               <issue>7</issue>
+               <fpage>075018</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.101.075018</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:2001.04019 " xlink:type="simple">arXiv:2001.04019 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib34">
+            <label>[34]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Ma</surname>
+                     <given-names>E.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Raidal</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Sarkar</surname>
+                     <given-names>U.</given-names>
+                  </name>
+               </person-group>
+               <source>Nucl. Phys. B</source>
+               <year>2001</year>
+               <volume>615</volume>
+               <fpage>313</fpage>
+               <lpage>330</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0550-3213(01)00416-3</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0012101" xlink:type="simple">hep-ph/0012101</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib35">
+            <label>[35]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>
+                  M. Drees, R. Godbole, and P. Roy,
+                  <italic toggle="yes">Theory and Phenomenology of Sparticles</italic>
+                  (World Scientific, Singapore, 2004); P. Bińetruy,
+                  <italic toggle="yes">Supersymmetry</italic>
+                  (Oxford University Press, Oxford, England, 2006)
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib36">
+            <label>[36]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>P. Martin</surname>
+                     <given-names>S.</given-names>
+                  </name>
+               </person-group>
+               <source>Adv. Ser. Direct. High Energy Phys.</source>
+               <year>2010</year>
+               <volume>21</volume>
+               <fpage>1</fpage>
+               <lpage>53</lpage>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:hep-ph/9709356 " xlink:type="simple">arXiv:hep-ph/9709356 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib37">
+            <label>[37]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>
+                  N. Aghanim
+                  <italic toggle="yes">et al.</italic>
+                  (Planck Collaboration), arXiv:1807.06209 [astro-ph.CO]
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib38">
+            <label>[38]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>K. Ghosh</surname>
+                     <given-names>D.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>S. Hundi</surname>
+                     <given-names>R.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2012</year>
+               <volume>85</volume>
+               <fpage>013005</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.85.013005</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1108.3428" xlink:type="simple">1108.3428</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib39">
+            <label>[39]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>J. Xu</surname>
+                     <given-names>X.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2016</year>
+               <volume>94</volume>
+               <issue>11</issue>
+               <fpage>115025</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.94.115025</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:1612.04950 " xlink:type="simple">arXiv:1612.04950 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib40">
+            <label>[40]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>J. Xu</surname>
+                     <given-names>X.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys.  Rev.  D</source>
+               <year>2017</year>
+               <volume>95</volume>
+               <issue>11</issue>
+               <fpage>115019</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.95.115019</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/ arXiv:1705.08965 " xlink:type="simple"> arXiv:1705.08965 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib41">
+            <label>[41]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>B. N. Grossmann, Z. Murdock, and S. Nandi, arXiv:1011.5256 [hep-ph]</comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib42">
+            <label>[42]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Erler</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Langacker</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Munir</surname>
+                     <given-names>S.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>JHEP</source>
+               <year>2011</year>
+               <volume>11</volume>
+               <fpage>076</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP11(2011)076</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1103.2659 " xlink:type="simple">1103.2659 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+      </ref-list>
+   </back>
+</article>

--- a/tests/units/iop/data/without_page_nr.xml
+++ b/tests/units/iop/data/without_page_nr.xml
@@ -1,0 +1,7108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" xml:lang="en">
+   <front>
+      <journal-meta>
+         <journal-id journal-id-type="publisher-id">cpc</journal-id>
+         <journal-title-group>
+            <journal-title xml:lang="en">Chinese Physics C</journal-title>
+         </journal-title-group>
+         <issn pub-type="ppub">1674-1137</issn>
+         <publisher>
+            <publisher-name>Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+                        </publisher-name>
+         </publisher>
+      </journal-meta>
+      <article-meta>
+         <article-id pub-id-type="publisher-id">cpc_46_10_103101</article-id>
+         <article-id pub-id-type="doi">10.1088/1674-1137/ac763c</article-id>
+         <article-id pub-id-type="manuscript">ac763c</article-id>
+         <article-categories>
+            <subj-group subj-group-type="display-article-type">
+               <subject>Paper</subject>
+            </subj-group>
+            <subj-group subj-group-type="section">
+               <subject>Particles and fields</subject>
+            </subj-group>
+         </article-categories>
+         <title-group>
+            <article-title>
+               Lepton and quark mixing patterns with generalized
+               <italic toggle="yes">CP</italic>
+               transformations
+            </article-title>
+         </title-group>
+         <contrib-group>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Ganguly</surname>
+                  <given-names>Joy</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <email>ph18resch11009@iith.ac.in</email>
+            </contrib>
+            <contrib contrib-type="author" xlink:type="simple">
+               <name name-style="western">
+                  <surname>Hundi</surname>
+                  <given-names>Raghavendra Srikanth</given-names>
+               </name>
+               <xref ref-type="aff" rid="affiliation01">1</xref>
+               <email>rshundi@phy.iith.ac.in</email>
+            </contrib>
+            <aff id="affiliation01">
+               <label>1</label>
+               <institution xlink:type="simple">Department of Physics, Indian Institute of Technology Hyderabad</institution>
+               , Kandi - 502 284,
+               <country>India</country>
+            </aff>
+         </contrib-group>
+         <pub-date pub-type="ppub">
+            <day>01</day>
+            <month>10</month>
+            <year>2022</year>
+         </pub-date>
+         <pub-date pub-type="open-access">
+            <day>29</day>
+            <month>7</month>
+            <year>2022</year>
+         </pub-date>
+         <volume>46</volume>
+         <issue>10</issue>
+         <elocation-id content-type="artnum">103101</elocation-id>
+         <history>
+            <date date-type="received">
+               <day>15</day>
+               <month>4</month>
+               <year>2022</year>
+            </date>
+            <date date-type="published-online">
+               <day>29</day>
+               <month>7</month>
+               <year>2022</year>
+            </date>
+            <date date-type="oa-requested">
+               <day>15</day>
+               <month>4</month>
+               <year>2022</year>
+            </date>
+         </history>
+         <permissions>
+            <copyright-statement>© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</copyright-statement>
+            <copyright-year>2022</copyright-year>
+            <license license-type="cc-by" xlink:href="http://creativecommons.org/licenses/by/3.0/" xlink:type="simple">
+               <license-p>
+                  <graphic content-type="online" orientation="portrait" position="float" xlink:href="cpc_46_10_103101_ccby.tif" xlink:type="simple" />
+                  Content from this work may be used under the terms of the
+                  <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/3.0" xlink:type="simple">Creative Commons Attribution 3.0 licence</ext-link>
+                  . Any further distribution of this work must maintain attribution to the author(s) and the title of the work, journal citation and DOI. Article funded by SCOAP
+                  <sup>3</sup>
+                  and published under licence by Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+               </license-p>
+            </license>
+         </permissions>
+         <self-uri content-type="pdf" xlink:href="cpc_46_10_103101.pdf" xlink:type="simple" />
+         <abstract>
+            <title>Abstract</title>
+            <p>
+               In this study, we modify a scenario, originally proposed by Grimus and Lavoura, in order to obtain maximal values for the atmospheric mixing angle and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M1.jpg" xlink:type="simple" />
+               </inline-formula>
+               , violating the Dirac phase of the lepton sector. To achieve this, we employ
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M2.jpg" xlink:type="simple" />
+               </inline-formula>
+               and some discrete symmetries in a type II seesaw model. To make predictions about the neutrino mass ordering and smallness of the reactor angle, we establish some conditions on the elements of the neutrino mass matrix of our model. Finally, we study the quark masses and mixing pattern within the framework of our model.
+            </p>
+         </abstract>
+         <kwd-group kwd-group-type="author">
+            <kwd>neutrino physics</kwd>
+            <kwd>nuetrino mass and mixing model</kwd>
+            <kwd>quark mass and mixing</kwd>
+            <kwd>analysis of scalar potential</kwd>
+         </kwd-group>
+         <funding-group>
+            <open-access>
+               <p content-type="scoap3">
+                  Article funded by SCOAP
+                  <sup>3</sup>
+               </p>
+            </open-access>
+         </funding-group>
+         <custom-meta-group>
+            <custom-meta xlink:type="simple">
+               <meta-name>arxivppt</meta-name>
+               <meta-value>2107.07275</meta-value>
+            </custom-meta>
+         </custom-meta-group>
+      </article-meta>
+   </front>
+   <body>
+      <sec id="cpc_46_10_103101_s01">
+         <label>I.</label>
+         <title>INTRODUCTION</title>
+         <p>
+            According to the global fits to neutrino oscillation data [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], it is well known that the three mixing angles in the lepton sector are close to the tribimaximal (TBM) mixing [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib2">2</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib4">4</xref>
+            ]. In the TBM pattern, the values of the three mixing angles are as follows:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{12}={1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M3.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{23}={1}/{2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M4.jpg" xlink:type="simple" />
+            </inline-formula>
+            , and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{13}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M5.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In contrast, the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M6.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating Dirac phase,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{ CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M7.jpg" xlink:type="simple" />
+            </inline-formula>
+            , in the lepton sector is yet to be measured precisely. However, from the global fits to neutrino oscillation data [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], the best fit value for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M8.jpg" xlink:type="simple" />
+            </inline-formula>
+            is around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $\pi({3}/{2}\pi)$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M9.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the case of normal (inverted) ordering of neutrino masses. The TBM value for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M10.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP}=({3}/{2})\pi $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M11.jpg" xlink:type="simple" />
+            </inline-formula>
+            are still allowed in the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M12.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges for these observables in the current neutrino oscillation data [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ]. The aforementioned values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M13.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M14.jpg" xlink:type="simple" />
+            </inline-formula>
+            are considered to be maximal. To explain these maximal values for
+            <italic toggle="yes">θ</italic>
+            <sub>23</sub>
+            and
+            <italic toggle="yes">
+               δ
+               <sub>CP</sub>
+            </italic>
+            , Harrison and Scott have proposed the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M17.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry in combination with
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${C P}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M18.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, together  called
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M19.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib5">5</xref>
+            ]. For further works regarding the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M20.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${ C P}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M21.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetries, see Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib6">6</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib12">12</xref>
+            ]. Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib6">6</xref>
+            ] is a review article.
+         </p>
+         <p>
+            In the work by Grimus and Lavoura [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], it is shown that a mass matrix for light left-handed neutrinos has the following form [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib14">14</xref>
+            ]:
+         </p>
+         <p>
+            <disp-formula>
+               <label>1</label>
+               <tex-math id="cpc_46_10_103101_E1">
+                  <?CDATA $ \begin{equation} {\cal M}_\nu=\left(\begin{array}{ccc} a & r & r^* \\ r & s & b \\ r^* & b & s^* \end{array}\right) \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E1.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            which can yield maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M22.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M23.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In the above equation,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ a,b $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M24.jpg" xlink:type="simple" />
+            </inline-formula>
+            are real and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ r,s $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M25.jpg" xlink:type="simple" />
+            </inline-formula>
+            are complex. Further, in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], a model is constructed, which is based on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M26.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry and softly broken lepton numbers, to obtain a mass matrix of the same form as in Eq. (1) for light neutrinos. In this model, three Higgs doublets are introduced and light neutrinos acquire masses via type I seesaw mechanism [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib15">15</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib16">16</xref>
+            ]. The lepton number is softly broken by the mass terms for right-handed neutrinos in this model. However, in the absence of parameter fine tuning in the model, muon and tau leptons can have masses of the same order. To explain the hierarchy in the masses for these leptons,
+            <italic toggle="yes">K</italic>
+            symmetry is introduced, under which the muon is massless [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. Realistic masses for muon and tau leptons are explained in the above mentioned scenario with the soft breaking of the
+            <italic toggle="yes">K</italic>
+            symmetry [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ]. The work done together in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ], which is based on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M27.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, consistently explains the mixing pattern in lepton sector and also the masses for charged leptons.
+         </p>
+         <p>
+            Although the work done in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ] gives a consistent picture about masses and mixing pattern in the lepton sector, it suffers from a few limitations, as explained below. It is argued in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ] that the mass matrix of Eq. (1), which is obtained from
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M28.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, cannot give predictions about neutrino mass ordering and the mixing angle
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M29.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Moreover, in the case of maximal
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M30.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the mass matrix of Eq. (1) can make no predictions regarding
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M31.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. From the current neutrino oscillation data, it is known that neutrinos can have either normal or inverted mass ordering, where
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{12}\sim{1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M32.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{13}\sim10^{-2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M33.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ]. Apart from the above mentioned limitations, in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], mixing pattern in the quark sector was not addressed. Nonetheless, the mixing pattern in the quark sector [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ] is known to be different from that of lepton sector. The interest would be to know whether the same framework could be used to understand the mixing patterns for both quark and lepton sectors.
+         </p>
+         <p>
+            As stated above, in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ], a model, which is based on type I seesaw mechanism and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M34.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, is presented with the aim of obtaining the neutrino mass matrix of the same form as Eq. (1). In this work, we rather aim at investigation whether the matrix in Eq. (1) can be obtained with type II seesaw mechanism [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib19">19</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib21">21</xref>
+            ] in the framework of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M35.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry. To achieve this, we construct a model, which has three Higgs doublets and one scalar Higgs triplet. In our model, right-handed neutrinos do not exist, and hence, neutrinos acquire masses when the Higgs triplet get vacuum expectation value (VEV). The purpose of Higgs doublets is to give masses to charged leptons via Yukawa couplings. With the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M36.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry in our model, if the VEV of Higgs triplet is real, we show that mass matrix for the light neutrinos will have the form of Eq. (1). To show whether the VEV of the Higgs triplet could be real, we analyze the scalar potential of our model. We demonstrate that by using an extra discrete symmetry, the VEV of Higgs triplet can be real. In parallel to that, we also address the problem of hierarchy in the masses of muon and tau leptons. In the literature, models have been constructed in order to achieve maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M37.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M38.jpg" xlink:type="simple" />
+            </inline-formula>
+            using type II seesaw mechanism [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib22">22</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib23">23</xref>
+            ]. However, in these models, multiple Higgs triplets have been introduced in addition to the three Higgs doublets. Hence, our model  proposed here is economical compared to the aforementioned models.
+         </p>
+         <p>
+            As stated previously, the mass matrix form given in Eq. (1) can predict maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M39.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M40.jpg" xlink:type="simple" />
+            </inline-formula>
+            . However, this matrix cannot make predictions about neutrino mass ordering and the mixing angles
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{12},\theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M41.jpg" xlink:type="simple" />
+            </inline-formula>
+            . As already pointed before, we have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{13}\sim10^{-2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M42.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], which means that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M43.jpg" xlink:type="simple" />
+            </inline-formula>
+            is a small angle. In this work, we perform an analysis, based on approximation procedures [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib24">24</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib25">25</xref>
+            ], and derive some conditions on the elements of neutrino mass matrix which can make predictions about the neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M44.jpg" xlink:type="simple" />
+            </inline-formula>
+            , apart from giving maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M45.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M46.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In this analysis, we assume
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sin^2\theta_{12}\sim{1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M47.jpg" xlink:type="simple" />
+            </inline-formula>
+            . To achieve the above mentioned conditions, new mechanisms should be proposed. In this work, we have attempted to provide one mechanism to achieve one of those conditions.
+         </p>
+         <p>
+            In our model three Higgs doublets give masses to charged leptons. Thus, it is worth knowing whether these scalar doublets can also generate masses and mixing pattern for quarks. Due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M48.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry in the lepton sector, it is found that these Higgs doublets should transform non-trivially under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M49.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. As a result, we propose
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M50.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations for quarks in such a way that the corresponding Yukawa couplings are invariant under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M51.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. A large hierarchy among the masses of quarks is known. Hence, to explain the mixing pattern for quarks, their Yukawa couplings should be hierarchically suppressed [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib26">26</xref>
+            ]. To explain the realistic mixing pattern for quarks through hierarchically suppressed Yukawa couplings, we followed the work done in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ]. For more information regarding other works on quark and lepton mixings with generalized
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M52.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations, see Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib29">29</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib30">30</xref>
+            ]. Additional works addressing quark and lepton mixings with other symmetries could be found in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib31">31</xref>
+            –
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib33">33</xref>
+            ].
+         </p>
+         <p>
+            The paper is organized as follows. In the next section, we propose a model for lepton mixing, where maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M53.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M54.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be predicted if the VEV of triplet Higgs is real. In Sec. III, we analyze the scalar potential of our model and show that the VEV of triplet Higgs can be real if we introduce additional discrete symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M55.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In Sec. IV, we obtain some conditions on the elements of the neutrino mass matrix of our model, which enable predictions about the neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M56.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In Sec. VI, we investigate quark masses and mixing patterns and demonstrate that they can be explained in the framework of our model. Conclusions are presented in the last section. In the Appendix, we attempt to describe a mechanism for achieving normal order of neutrino masses.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s02">
+         <label>II.</label>
+         <title>A MODEL FOR LEPTON MIXING</title>
+         <p>
+            The model we propose for lepton mixing is similar to that in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. We propose scalar Higgs doublets
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_i=(\phi_i^+,\phi_i^0)^T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M57.jpg" xlink:type="simple" />
+            </inline-formula>
+            , where
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ i=1,2,3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M58.jpg" xlink:type="simple" />
+            </inline-formula>
+            , in order to give masses to charged leptons. We denote the lepton doublets and singlets by
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{\alpha {\rm L}}=(\nu_{\alpha {\rm L}},\alpha_{\rm L})^T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M59.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \alpha_R $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M60.jpg" xlink:type="simple" />
+            </inline-formula>
+            , where
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \alpha=e,\mu,\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M61.jpg" xlink:type="simple" />
+            </inline-formula>
+            , respectively. The
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M62.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations on the lepton fields and Higgs doublets are defined as [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>2</label>
+               <tex-math id="cpc_46_10_103101_E2">
+                  <?CDATA $ \begin{aligned}[b] & D_{\alpha {\rm L}}\to {\rm i}S_{ \alpha\beta}\gamma^0C\bar{D}_{\beta {\rm L}}^T,\quad \alpha_{\rm R}\to {\rm i}S_{ \alpha\beta}\gamma^0C\bar{\beta}_{\rm R}^T, \\ & S=\left(\begin{array}{ccc} 1 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & 1 & 0 \end{array} \right), \quad \phi_{1,2}\to\phi_{1,2}^*,\quad \phi_3\to -\phi_3^*. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E2.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <italic toggle="yes">C</italic>
+            is the charge conjugation matrix. In addition to the invariance under the above mentioned
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M63.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations, one needs to impose conservation of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M64.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M65.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetries. Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M66.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the lepton number symmetry for the individual family of leptons. Under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M67.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, only the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ e_{\rm R} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M68.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M69.jpg" xlink:type="simple" />
+            </inline-formula>
+            change sign. Considering the aforementioned charge assignments, the invariant Lagrangian for charged lepton Yukawa couplings is given by [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>3</label>
+               <tex-math id="cpc_46_10_103101_E3">
+                  <?CDATA $ \begin{equation} {\cal L}_{\rm Y} = -y_e\bar{D}_{e{\rm L}}\phi_1e_{\rm R}-\sum\limits_{j=2}^3\sum\limits_{\alpha=\mu,\tau} g_{j\alpha}\bar{D}_{\alpha {\rm L}}\phi_j\alpha_{\rm R} +{\rm h.c}.. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E3.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In order for the Lagrangian in Eq. (3) to be invariant under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M70.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, we should have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ y_e $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M71.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be real,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ g_{2\mu}=g_{2\tau}^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M72.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ g_{3\mu}=-g_{3\tau}^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M73.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Since the mass of electron should be real, we take the VEV of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M74.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be real. In contrast, the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M75.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be complex, which give masses to muon and tau leptons, whose forms are given below [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ].
+         </p>
+         <p>
+            <disp-formula>
+               <label>4</label>
+               <tex-math id="cpc_46_10_103101_E4">
+                  <?CDATA $ \begin{equation} m_\mu=|g_{2\mu}v_2+g_{3\mu}v_3|,\quad m_\tau=|g^*_{2\mu}v_2-g^*_{3\mu}v_3|. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E4.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In this work, we take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle\phi_i^0\rangle=v_i $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M76.jpg" xlink:type="simple" />
+            </inline-formula>
+            for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ i=1,2,3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M77.jpg" xlink:type="simple" />
+            </inline-formula>
+            . As an a priori assumption, the VEVs of all Higgs doublets are of the same order. Hence, from the above equations, we notice that some fine tuning is necessary in order to explain the hierarchy in the muon and tau lepton masses. To reduce this fine tuning,
+            <italic toggle="yes">K</italic>
+            symmetry is introduced, under which the non-trivial transformations of the fields are given below [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>5</label>
+               <tex-math id="cpc_46_10_103101_E5">
+                  <?CDATA $ \begin{equation} \mu_R\to -\mu_R,\quad \phi_2\leftrightarrow\phi_3. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E5.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            After imposing this
+            <italic toggle="yes">K</italic>
+            symmetry in the above model, one can see that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ g_{2\mu}=-g_{3\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M78.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Using this in Eq. (4), we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>6</label>
+               <tex-math id="cpc_46_10_103101_E6">
+                  <?CDATA $ \begin{equation} \frac{m_\mu}{m_\tau}=\left|\frac{v_2-v_3}{v_2+v_3}\right|. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E6.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Since the scalar potential of this model should also respect the
+            <italic toggle="yes">K</italic>
+            symmetry, we should get
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_2=v_3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M79.jpg" xlink:type="simple" />
+            </inline-formula>
+            , and hence,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M80.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, to explain a non-zero but small
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M81.jpg" xlink:type="simple" />
+            </inline-formula>
+            , soft breaking of
+            <italic toggle="yes">K</italic>
+            symmetry can be introduced into the scalar potential of this model [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ]. The analysis related to this is presented in the next section.
+         </p>
+         <p>To explain the masses for neutrinos in the above described framework, we introduce the following Higgs triplet into the model.</p>
+         <p>
+            <disp-formula>
+               <label>7</label>
+               <tex-math id="cpc_46_10_103101_E7">
+                  <?CDATA $ \begin{equation} \Delta=\left(\begin{array}{cc} \dfrac{\Delta^+}{\sqrt{2}} & \Delta^{++} \\ -\Delta^0 & -\dfrac{\Delta^+}{\sqrt{2}} \end{array}\right). \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E7.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Δ is singlet under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M82.jpg" xlink:type="simple" />
+            </inline-formula>
+            , but otherwise transform under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M83.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry as
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta\to\Delta^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M84.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, the Yukawa couplings for neutrinos can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <label>8</label>
+               <tex-math id="cpc_46_10_103101_E8">
+                  <?CDATA $ \begin{equation} {\cal L}_Y=\frac{1}{2}\sum\limits_{\alpha,\,\beta=e,\,\mu,\,\tau}Y^\nu_{\alpha\beta} \bar{D}^c_{\alpha {\rm L}}{\rm i}\sigma_2\Delta D_{\beta {\rm L}}+{\rm h.c}.. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E8.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{\alpha {\rm L}}^c $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M85.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the charge conjugated doublet for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{\alpha {\rm L}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M86.jpg" xlink:type="simple" />
+            </inline-formula>
+            , and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \sigma_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M87.jpg" xlink:type="simple" />
+            </inline-formula>
+            is a Pauli matrix. We can notice that the terms in the above Lagrangian break the lepton number symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M88.jpg" xlink:type="simple" />
+            </inline-formula>
+            explicitly. This can be considered technically natural, since the neutrino masses become zero in this model in the limit that the symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M89.jpg" xlink:type="simple" />
+            </inline-formula>
+            is exact. Hence, to explain the smallness of neutrino masses, the symmetry of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M90.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be broken by small amounts. Therefore, here, the neutrino Yukawa couplings
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\alpha\beta} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M91.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be small. Due to the invariance under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M92.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, these Yukawa couplings should satisfy
+         </p>
+         <p>
+            <disp-formula>
+               <label>9</label>
+               <tex-math id="cpc_46_10_103101_E9">
+                  <?CDATA $ \begin{equation} SY^\nu S=(Y^\nu)^*. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E9.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            After electroweak symmetry breaking, we can have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle\Delta^0\rangle=v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M93.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, from Eq. (8), we get the mass matrix for neutrinos, which is given by
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu=Y^\nu v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M94.jpg" xlink:type="simple" />
+            </inline-formula>
+            . If
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M95.jpg" xlink:type="simple" />
+            </inline-formula>
+            is real, using Eq. (9), we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>10</label>
+               <tex-math id="cpc_46_10_103101_E10">
+                  <?CDATA $ \begin{equation} SM_\nu S=M_\nu^*. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E10.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In order to satisfy the above relation, the form for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M96.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be the same as in Eq. (1). Hence, in the above proposed model, the mixing angle
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M97.jpg" xlink:type="simple" />
+            </inline-formula>
+            and the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M98.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating phase
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M99.jpg" xlink:type="simple" />
+            </inline-formula>
+            are maximal. However, to satisfy the relation in Eq. (10),
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M100.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real. In the next section, we present an analysis of the scalar potential in our model, where we demonstrate that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M101.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be real.
+         </p>
+         <p>
+            Now, we estimate the value of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M102.jpg" xlink:type="simple" />
+            </inline-formula>
+            in our work. As stated above, the neutrino mass matrix is
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu=Y^\nu v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M103.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Since the couplings
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M104.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be small, because they break the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{L_\alpha} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M105.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry by a small amount, we take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu\sim 10^{-3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M106.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, by fitting
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M107.jpg" xlink:type="simple" />
+            </inline-formula>
+            to neutrino masses, which are obtained from the neutrino oscillation data, an estimation of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M108.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be obtained. Using the neutrino oscillation data, the following mass-square differences have been found [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ], where we have given the best fit values.
+         </p>
+         <p>
+            <disp-formula>
+               <label>11</label>
+               <tex-math id="cpc_46_10_103101_E11">
+                  <?CDATA $ \begin{aligned}[b] & m_s^2\equiv m_2^2-m_1^2=7.5\times10^{-5}\; {\rm eV}^2,\\ & m_a^2\equiv\left\{\begin{array}{c} m_3^2-m_1^2=2.55\times10^{-3}\; {\rm eV}^2\; \; {\rm (NO)}\\ m_1^2-m_3^2=2.45\times10^{-3}\; {\rm eV}^2\; \; {\rm (IO)} \end{array}\right.. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E11.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{1,2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M109.jpg" xlink:type="simple" />
+            </inline-formula>
+            are neutrino mass eigenvalues and NO(IO) represents normal (inverted) ordering. Using the above values, we get
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_s\sim0.0087 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M110.jpg" xlink:type="simple" />
+            </inline-formula>
+            eV and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_a\sim0.05 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M111.jpg" xlink:type="simple" />
+            </inline-formula>
+            eV, which correspond to solar and atmospheric neutrino mass scales, respectively. To fit these neutrino mass scales in our work, we can take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta\sim1-10 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M112.jpg" xlink:type="simple" />
+            </inline-formula>
+            eV.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s03">
+         <label>III.</label>
+         <title>ANALYSIS OF SCALAR POTENTIAL</title>
+         <p>
+            The scalar fields of the model proposed in the previous section are charged under the symmetry
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ C P\times Z_2\times K $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M113.jpg" xlink:type="simple" />
+            </inline-formula>
+            . The invariant scalar potential of this model can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <label>12</label>
+               <tex-math id="cpc_46_10_103101_E12">
+                  <?CDATA $ \begin{equation} V_{\rm inv}=V_D+V_T. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E12.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_D $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M114.jpg" xlink:type="simple" />
+            </inline-formula>
+            contains potential terms only for the Higgs doublets.
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M115.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the scalar potential for the triplet Higgs in our model. The form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_D $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M116.jpg" xlink:type="simple" />
+            </inline-formula>
+            is given by [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+            ]
+         </p>
+         <p>
+            <disp-formula>
+               <label>13</label>
+               <tex-math id="cpc_46_10_103101_E13">
+                  <?CDATA $ \begin{aligned}[b] V_D= & -M_1^2\phi_1^\dagger\phi_1 -M_2^2(\phi_2^\dagger\phi_2+\phi_3^\dagger\phi_3) +\lambda_1(\phi_1^\dagger\phi_1)^2 \\ & +\lambda_2\left[(\phi_2^\dagger\phi_2)^2+(\phi_3^\dagger\phi_3)^2\right] \\ & +\lambda_3(\phi_1^\dagger\phi_1)(\phi_2^\dagger\phi_2+\phi_3^\dagger\phi_3) +\lambda_4(\phi_2^\dagger\phi_2)(\phi_3^\dagger\phi_3) \\ & +\lambda_5\left[(\phi_1^\dagger\phi_2)(\phi_2^\dagger\phi_1) +(\phi_1^\dagger\phi_3)(\phi_3^\dagger\phi_1)\right] \\ & +\lambda_6\left[(\phi_2^\dagger\phi_3)(\phi_3^\dagger\phi_2)\right] +\lambda_7\left[(\phi_2^\dagger\phi_3)^2+(\phi_3^\dagger\phi_2)^2\right] \\ & +\lambda_8\left[(\phi_1^\dagger\phi_2)^2+(\phi_1^\dagger\phi_3)^2 +(\phi_2^\dagger\phi_1)^2+(\phi_3^\dagger\phi_1)^2\right] \\ & +{\rm i}\lambda_9\left[(\phi_1^\dagger\phi_2)(\phi_1^\dagger\phi_3) -(\phi_2^\dagger\phi_1)(\phi_3^\dagger\phi_1)\right] \\ & +{\rm i}\lambda_{10}(\phi_2^\dagger\phi_3-\phi_3^\dagger\phi_2) (\phi_2^\dagger\phi_2-\phi_3^\dagger\phi_3). \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E13.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above equation, all parameters are real due to either hermiticity or
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M117.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry of the potential. To obtain
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M118.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we have followed the work in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib34">34</xref>
+            ]. The form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M119.jpg" xlink:type="simple" />
+            </inline-formula>
+            is given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>14</label>
+               <tex-math id="cpc_46_10_103101_E14">
+                  <?CDATA $ \begin{aligned}[b] V_T= & m_\Delta^2{\rm Tr}(\Delta^\dagger\Delta) +\frac{1}{2}\lambda_\Delta[{\rm Tr}(\Delta^\dagger\Delta)]^2 \\ & +\lambda_{11}\phi_1^\dagger\phi_1{\rm Tr}(\Delta^\dagger\Delta) +\lambda_{12}(\phi_2^\dagger\phi_2+\phi_3^\dagger\phi_3) {\rm Tr}(\Delta^\dagger\Delta) \\ & +\lambda_{13}{\rm Tr}(\Delta^\dagger\Delta^\dagger){\rm Tr}(\Delta\Delta) +\lambda_{14}\phi_1^\dagger\Delta^\dagger\Delta\phi_1 \\ & +\lambda_{15}(\phi_2^\dagger\Delta^\dagger\Delta\phi_2 +\phi_3^\dagger\Delta^\dagger\Delta\phi_3) \\ & +\kappa_1(\tilde{\phi}_1^T{\rm i}\sigma_2\Delta\tilde{\phi}_1+{\rm h.c}.) \\ & +\kappa_2(\tilde{\phi}_2^T{\rm i}\sigma_2\Delta\tilde{\phi}_2 +\tilde{\phi}_3^T{\rm i}\sigma_2\Delta\tilde{\phi}_3+{\rm h.c}.) \\ & +{\rm i}\kappa_3(\tilde{\phi}_2^T{\rm i}\sigma_2\Delta\tilde{\phi}_3-{\rm h.c}.) \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E14.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \tilde{\phi}_k={\rm i}\sigma_2\phi_k^*,\;k=1,2,3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M120.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Similarly, all parameters in the above equation are real, due to either hermiticity or
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M121.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry of the potential.
+         </p>
+         <p>
+            As described in the previous section, the VEV of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M122.jpg" xlink:type="simple" />
+            </inline-formula>
+            is real, whereas the VEVs for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M123.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be complex. Although all parameters in Eq. (14) are real, due to complex VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M124.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the trilinear terms containing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M125.jpg" xlink:type="simple" />
+            </inline-formula>
+            can contribute complex VEV to Δ. However, it may happen that the phases of the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M126.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be fine tuned in such a way that the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M127.jpg" xlink:type="simple" />
+            </inline-formula>
+            -terms can give a real VEV to Δ. We study these points by minimizing the scalar potential of our model. Nonetheless, we first have to estimate the order of magnitudes for the unknown parameters in Eqs. (13) and (14). From the naturalness argument, we take all dimensionless
+            <italic toggle="yes">λ</italic>
+            parameters to be
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {\cal O}(1) $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M128.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Since the VEVs of Higgs doublets should be around the electroweak scale of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_{\rm EW}= $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M129.jpg" xlink:type="simple" />
+            </inline-formula>
+            174 GeV, we take
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_1^2,M_2^2\sim v_{\rm EW}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M130.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, we have to determine the order of magnitudes for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M131.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa_{1,2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M132.jpg" xlink:type="simple" />
+            </inline-formula>
+            . This is explained below. After minimizing the potential of Eq. (14) with respect to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M133.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>15</label>
+               <tex-math id="cpc_46_10_103101_E15">
+                  <?CDATA $ \begin{equation} v_\Delta\sim\frac{\kappa v_{\rm EW}^2}{m_\Delta^2+\lambda v_{\rm EW}^2}. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E15.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \kappa\sim\kappa_{1,2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M134.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \lambda\sim\lambda_{11,12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M135.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In the above equation, we have used
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta\ll v_{\rm EW} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M136.jpg" xlink:type="simple" />
+            </inline-formula>
+            . To get a very small
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M137.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we can consider the following two cases.
+         </p>
+         <p>
+            <disp-formula>
+               <label>16</label>
+               <tex-math id="cpc_46_10_103101_E16">
+                  <?CDATA $ \begin{aligned}[b] & {\rm case\; I}:\quad m_\Delta\gg v_{\rm EW},\quad \kappa\sim m_\Delta. \\ & {\rm case\; II}:\quad m_\Delta\sim v_{\rm EW},\quad \kappa\sim v_\Delta. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E16.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In case I, the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M138.jpg" xlink:type="simple" />
+            </inline-formula>
+            is explained by considering a large value for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M139.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 10^{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M140.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV. In case II, by suppressing the
+            <italic toggle="yes">κ</italic>
+            parameters, one can understand the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ v_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M141.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In case I, the value of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M142.jpg" xlink:type="simple" />
+            </inline-formula>
+            is close to the breaking scale of supersymmetry in supergravity models [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib35">35</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib36">36</xref>
+            ]. Hence, one can motivate case I from supersymmetry. In contrast, in case II, one has to find a mechanism for the suppression of
+            <italic toggle="yes">κ</italic>
+            parameters. From the phenomenology point of view, case II can be tested in the LHC experiment, since the masses for the components of scalar triplet Higgs can be around few 100 GeV.
+         </p>
+         <p>
+            In case I, we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_D\rangle\sim\langle V_T\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M143.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Only the terms containing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\Delta^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M144.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <italic toggle="yes">κ</italic>
+            parameters in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_T\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M145.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be of the same order as
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_D\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M146.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Other terms in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_T\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M147.jpg" xlink:type="simple" />
+            </inline-formula>
+            give negligibly small contribution in comparison to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_D\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M148.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In contrast, in case II,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_T\rangle\ll\langle V_D\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M149.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Because of this difference in the contribution of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_T $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M150.jpg" xlink:type="simple" />
+            </inline-formula>
+            in both these cases, we minimize the scalar potential of our model separately for these two cases.
+         </p>
+         <sec id="cpc_46_10_103101_s03-01">
+            <label>A.</label>
+            <title>Case I</title>
+            <p>We parametrize the VEVs of scalar fields as follows.</p>
+            <p>
+               <disp-formula>
+                  <label>17</label>
+                  <tex-math id="cpc_46_10_103101_E17">
+                     <?CDATA $ \begin{aligned}[b] & \langle\phi_1^0\rangle=v_1,\quad \langle\phi_2^0\rangle=v_2=v\cos\sigma {\rm e}^{{\rm i}\alpha},\\ & \langle\phi_3^0\rangle=v_3=v\sin\sigma {\rm e}^{{\rm i}\beta},\quad \langle\Delta^0\rangle=v_\Delta=v^\prime {\rm e}^{{\rm i}\theta}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E17.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_1,\;v,\;v^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M151.jpg" xlink:type="simple" />
+               </inline-formula>
+               are real. We plug the above parametrizations in the scalar potential of Eq. (12). Since we want
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle\Delta^0\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M152.jpg" xlink:type="simple" />
+               </inline-formula>
+               to be real, and moreover,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M153.jpg" xlink:type="simple" />
+               </inline-formula>
+               respect
+               <italic toggle="yes">K</italic>
+               symmetry, we look for a minimum at
+            </p>
+            <p>
+               <disp-formula>
+                  <label>18</label>
+                  <tex-math id="cpc_46_10_103101_E18">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4},\quad\alpha=\beta=\omega,\quad\theta=0. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E18.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Now, we take first derivatives of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M154.jpg" xlink:type="simple" />
+               </inline-formula>
+               with respect to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta,\;\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M155.jpg" xlink:type="simple" />
+               </inline-formula>
+               at the values mentioned in Eq. (18). Thereafter, we get the following two conditions.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>19</label>
+                  <tex-math id="cpc_46_10_103101_E19">
+                     <?CDATA $ \begin{array}{*{20}{l}} & & 2\lambda_8\sin2\omega+\lambda_9\cos2\omega=0, \end{array} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E19.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>20</label>
+                  <tex-math id="cpc_46_10_103101_E20">
+                     <?CDATA $ \begin{array}{*{20}{l}} & & 2\kappa_2\sin2\omega=\kappa_3\cos2\omega. \end{array} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E20.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               By satisfying the above two conditions, Eq. (18) gives a minimum to our scalar potential. We justify that this a minimum, after computing the second derivatives of the potential. This analysis is presented shortly later. However, with the minimum of Eq. (18), we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_2=v_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M156.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Hence,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M157.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which follows from Eq. (6). To get non-zero and small
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M158.jpg" xlink:type="simple" />
+               </inline-formula>
+               , one should add
+               <italic toggle="yes">K</italic>
+               -violating terms in our model, which break the
+               <italic toggle="yes">K</italic>
+               symmetry explicitly by a small amount. Here, we can see the analogy between
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U_{L_\alpha} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M159.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <italic toggle="yes">K</italic>
+               symmetries of our model. Both of these symmetries are broken explicitly by a small amount in order to generate small masses for neutrinos and muon.
+            </p>
+            <p>
+               After including the
+               <italic toggle="yes">K</italic>
+               -violating terms, the procedure we follow for minimization of the scalar potential is similar to that in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ]. However, in this work, we write a more general form for
+               <italic toggle="yes">K</italic>
+               -violating terms as compared to that in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ]. In Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], only the soft terms, which break the
+               <italic toggle="yes">K</italic>
+               symmetry, are considered. The general form for
+               <italic toggle="yes">K</italic>
+               -violating terms in our model, which respects the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ CP\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M160.jpg" xlink:type="simple" />
+               </inline-formula>
+               , is given by
+            </p>
+            <p>
+               <disp-formula>
+                  <label>21</label>
+                  <tex-math id="cpc_46_10_103101_E21">
+                     <?CDATA $ \begin{aligned}[b]V_{\not{K}}= & {\rm i}\delta M_s^2(\phi_2^\dagger\phi_3-\phi_3^\dagger\phi_2) +\delta M_2^2\phi_2^\dagger\phi_2+\delta M_3^2\phi_3^\dagger\phi_3 \\ & +\delta\kappa_2(\tilde{\phi}_2^T{\rm i}\sigma_2\Delta\tilde{\phi}_2+{\rm h.c}.) +\delta\kappa_2^\prime(\tilde{\phi}_3^T{\rm i}\sigma_2\Delta\tilde{\phi}_3+{\rm h.c}.) \\ & +\delta\lambda_2(\phi_2^\dagger\phi_2)^2 +\delta\lambda_2^\prime(\phi_3^\dagger\phi_3)^2 +\delta\lambda_3(\phi_1^\dagger\phi_1)(\phi_2^\dagger\phi_2) \\ & +\delta\lambda_3^\prime(\phi_1^\dagger\phi_1)(\phi_3^\dagger\phi_3) \\ & +\delta\lambda_5(\phi_1^\dagger\phi_2)(\phi_2^\dagger\phi_1) +\delta\lambda_5^\prime(\phi_1^\dagger\phi_3)(\phi_3^\dagger\phi_1) \\ & +\delta\lambda_8\left[(\phi_1^\dagger\phi_2)^2+(\phi_2^\dagger\phi_1)^2\right] +\delta\lambda_8^\prime\left[(\phi_1^\dagger\phi_3)^2 +(\phi_3^\dagger\phi_1)^2\right] \\ & +{\rm i}\delta\lambda_{10}(\phi_2^\dagger\phi_2)(\phi_2^\dagger\phi_3 -\phi_3^\dagger\phi_2) \\ & +{\rm i}\delta\lambda_{10}^\prime(\phi_3^\dagger\phi_3)(\phi_2^\dagger\phi_3 -\phi_3^\dagger\phi_2) \\ & +{\rm i}\delta\lambda_s(\phi_1^\dagger\phi_1)(\phi_2^\dagger\phi_3 -\phi_3^\dagger\phi_2) \\ & +{\rm i}\delta\lambda_s^\prime\left[(\phi_1^\dagger\phi_2)(\phi_3^\dagger\phi_1) -(\phi_2^\dagger\phi_1)(\phi_1^\dagger\phi_3)\right] \\ & +\delta\lambda_{12}\phi_2^\dagger\phi_2{\rm Tr}(\Delta^\dagger\Delta) +\delta\lambda_{12}^\prime\phi_3^\dagger\phi_3{\rm Tr}(\Delta^\dagger\Delta) \\ & +\delta\lambda_{15}\phi_2^\dagger\Delta^\dagger\Delta\phi_2 +\delta\lambda_{15}^\prime\phi_3^\dagger\Delta^\dagger\Delta\phi_3 \\ & +{\rm i}\delta\lambda_t(\phi_2^\dagger\phi_3-\phi_3^\dagger\phi_2) {\rm Tr}(\Delta^\dagger\Delta) \\ & +{\rm i}\delta\lambda_t^\prime(\phi_2^\dagger\Delta^\dagger\Delta\phi_3 -\phi_3^\dagger\Delta^\dagger\Delta\phi_2). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E21.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               All parameters in the above equation are real, due to either hermiticity or
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M161.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry of the potential. Terms in the first and second lines are quadratic and trilinear, respectively. Rest of the terms in the above equation are quartic.
+            </p>
+            <p>
+               In Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], only the soft terms which are quadratic are given. Moreover, the last two terms in the first line of Eq. (21) are given in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], but by taking
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta M_2^2=-\delta M_3^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M162.jpg" xlink:type="simple" />
+               </inline-formula>
+               . We notice that if
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta M_2^2 =\delta M_3^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M163.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the sum of the corresponding terms in Eq. (21) is
+               <italic toggle="yes">K</italic>
+               -symmetric. Hence, as long as
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta M_2^2\neq\delta M_3^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M164.jpg" xlink:type="simple" />
+               </inline-formula>
+               , each of these corresponding terms in Eq. (21) is
+               <italic toggle="yes">K</italic>
+               -violating but conserving
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times Z_2$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M165.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Based on this observation, we have constructed other
+               <italic toggle="yes">K</italic>
+               -violating terms in Eq. (21). Since the terms in Eq. (21) break
+               <italic toggle="yes">K</italic>
+               symmetry by a small amount, their corresponding parameters should be small compared to the corresponding parameters of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M166.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               After including the
+               <italic toggle="yes">K</italic>
+               -violating terms, the total scalar potential of our model is
+            </p>
+            <p>
+               <disp-formula>
+                  <label>22</label>
+                  <tex-math id="cpc_46_10_103101_E22">
+                     <?CDATA $ \begin{equation} V_{\rm total}=V_{\rm inv}+V_{\not{K}}. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E22.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Previously, we minimized
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M167.jpg" xlink:type="simple" />
+               </inline-formula>
+               and argued that the minimum can be at Eq. (18). Now, due to the presence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M168.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the above minimum can be shifted by a small amount. Consequently, the minimum for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M169.jpg" xlink:type="simple" />
+               </inline-formula>
+               in terms of small deviations
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\delta_+,\delta_-,\delta_\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M170.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be written as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>23</label>
+                  <tex-math id="cpc_46_10_103101_E23">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4}-\frac{\delta_0}{2},\quad \alpha=\omega+\delta_++\frac{\delta_-}{2},\quad \beta=\omega+\delta_+-\frac{\delta_-}{2},\quad \theta=0+\delta_\theta. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E23.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Now, we express
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle V_{\rm inv}\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M171.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle V_{\not{K}}\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M172.jpg" xlink:type="simple" />
+               </inline-formula>
+               as a series summation up to second and first order, respectively, in the aforementioned small deviations. After neglecting the constant terms, we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>24</label>
+                  <tex-math id="cpc_46_10_103101_E24">
+                     <?CDATA $ \begin{equation} \langle V_{\rm total}\rangle=\frac{1}{2}\sum\limits_{a,b}{\cal F}_{ab}\delta_a\delta_b +\sum\limits_{a}f_a\delta_a. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E24.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M173.jpg" xlink:type="simple" />
+               </inline-formula>
+               is symmetric in the indices
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ a,b $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M174.jpg" xlink:type="simple" />
+               </inline-formula>
+               , corresponding to  the second derivatives of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M175.jpg" xlink:type="simple" />
+               </inline-formula>
+               calculated in Eq. (18). Non-vanishing elements of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M176.jpg" xlink:type="simple" />
+               </inline-formula>
+               are given below.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>25</label>
+                  <tex-math id="cpc_46_10_103101_E25">
+                     <?CDATA $ \begin{aligned}[b]{\cal F}_{++}= & (-8\lambda_8\cos2\omega+4\lambda_9\sin2\omega)v_1^2v^2 \\ & +(8\kappa_2\cos2\omega+4\kappa_3\sin2\omega)v^2v^\prime, \\ {\cal F}_{–}= & -2\lambda_7v^4-2\lambda_8v_1^2v^2\cos2\omega +2\kappa_2v^2v^\prime\cos2\omega, \\ {\cal F}_{00}= & -\frac{1}{2}\tilde{\lambda}v^4 +(\lambda_9v_1^2+\kappa_3v^\prime)v^2\sin2\omega, \\ {\cal F}_{\theta\theta}= & 2\kappa_1v_1^2v^\prime+2\kappa_2v^2v^\prime \cos2\omega+\kappa_3v^2v^\prime\sin2\omega, \\ {\cal F}_{0-}= & -2\lambda_8v_1^2v^2\sin2\omega+\lambda_{10}v^4 +2\kappa_2v^2v^\prime\sin2\omega, \\ {\cal F}_{+\theta}= & -2(2\kappa_2\cos2\omega+\kappa_3\sin2\omega)v^2v^\prime. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E25.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \tilde{\lambda}=-2\lambda_2+\lambda_4+\lambda_6+2\lambda_7 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M177.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The expressions for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_a $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M178.jpg" xlink:type="simple" />
+               </inline-formula>
+               are given below.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>26</label>
+                  <tex-math id="cpc_46_10_103101_E26">
+                     <?CDATA $ \begin{aligned}[b] f_0= & \frac{1}{2}(\delta M_2^2-\delta M_3^2)v^2 -(\delta\kappa_2-\delta\kappa_2^\prime)v^2v^\prime\cos2\omega \\ & +\frac{1}{2}(\delta\lambda_2-\delta\lambda_2^\prime)v^4 +\frac{1}{2}[\delta\lambda_3-\delta\lambda_3^\prime +\delta\lambda_5\\ & -\delta\lambda_5^\prime +2(\delta\lambda_8-\delta\lambda_8^\prime)\cos2\omega](v_1v)^2 \\ & +\frac{1}{2}(\delta\lambda_{12}-\delta\lambda_{12}^\prime)(vv^\prime)^2, \\f_-= & \delta M_s^2v^2+(\delta\kappa_2-\delta\kappa_2^\prime) v^2v^\prime\sin2\omega \\ & -(\delta\lambda_8-\delta\lambda_8^\prime)\sin2\omega(v_1v)^2 +\frac{1}{2}(\delta\lambda_{10}+\delta\lambda_{10}^\prime)v^4 \\ & +(\delta\lambda_s-\delta\lambda_s^\prime)(v_1v)^2 +\delta\lambda_t(vv^\prime)^2, \\ f_+= & 2(\delta\kappa_2+\delta\kappa_2^\prime)v^2v^\prime\sin2\omega -2(\delta\lambda_8+\delta\lambda_8^\prime)\sin2\omega(v_1v)^2, \\ f_\theta= & -(\delta\kappa_2+\delta\kappa_2^\prime)v^2v^\prime\sin2\omega. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E26.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Using Eq. (24), the small deviations in the minimum of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M179.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be obtained as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>27</label>
+                  <tex-math id="cpc_46_10_103101_E27">
+                     <?CDATA $ \begin{equation} \delta=-{\cal F}^{-1}f. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E27.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta=(\delta_0,\delta_-,\delta_+,\delta_\theta)^T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M180.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f=(f_0,f_-,f_+,f_\theta)^T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M181.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M182.jpg" xlink:type="simple" />
+               </inline-formula>
+               is a matrix containing the elements
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M183.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               Since some elements of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{ab} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M184.jpg" xlink:type="simple" />
+               </inline-formula>
+               are zero, Eq. (27) can be decomposed into
+            </p>
+            <p>
+               <disp-formula>
+                  <label>28</label>
+                  <tex-math id="cpc_46_10_103101_E28">
+                     <?CDATA $ \begin{aligned}[b] & \left(\begin{array}{c}\delta_0 \\ \delta_-\end{array}\right) =-{\cal F}_1^{-1}\left(\begin{array}{c}f_0 \\ f_-\end{array}\right),\quad {\cal F}_1=\left(\begin{array}{cc} {\cal F}_{00} & {\cal F}_{0-} \\ {\cal F}_{0-} & {\cal F}_{–} \end{array}\right), \\ & \left(\begin{array}{c}\delta_+ \\ \delta_\theta\end{array}\right) =-{\cal F}_2^{-1}\left(\begin{array}{c}f_+ \\ f_\theta\end{array}\right),\quad {\cal F}_2=\left(\begin{array}{cc} {\cal F}_{++} & {\cal F}_{+\theta} \\ {\cal F}_{+\theta} & {\cal F}_{\theta\theta}\end{array}\right). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E28.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               We can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M185.jpg" xlink:type="simple" />
+               </inline-formula>
+               is in block diagonal form containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M186.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M187.jpg" xlink:type="simple" />
+               </inline-formula>
+               . As stated earlier, the elements of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M188.jpg" xlink:type="simple" />
+               </inline-formula>
+               correspond to second derivatives of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $V_{\rm inv}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M189.jpg" xlink:type="simple" />
+               </inline-formula>
+               calculated in Eq. (18). It follows that, if the eigenvalues of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M190.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M191.jpg" xlink:type="simple" />
+               </inline-formula>
+               are positive, then Eq. (18) gives minimum to the scalar potential in the absence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M192.jpg" xlink:type="simple" />
+               </inline-formula>
+               . One can see that the unknown
+               <italic toggle="yes">λ</italic>
+               and
+               <italic toggle="yes">κ</italic>
+               parameters of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{1,2} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M193.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be chosen in such a way that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{1,2} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M194.jpg" xlink:type="simple" />
+               </inline-formula>
+               yields positive eigenvalues. However, in the presence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M195.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the minimum of the scalar potential in our model is shifted to Eq. (23). The small deviations of Eq. (23) can be computed from Eq. (28), from which we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_-,\delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M196.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Hence,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_2\neq v_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M197.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Using the expressions for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_-,\delta_+ $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M198.jpg" xlink:type="simple" />
+               </inline-formula>
+               in Eq. (6), we can get the required hierarchy between
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M199.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\tau $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M200.jpg" xlink:type="simple" />
+               </inline-formula>
+               , provided the parameters of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M201.jpg" xlink:type="simple" />
+               </inline-formula>
+               are small. It can be noticed that the parametrizations used in Eq. (23) are similar to those in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ], in whichit has been pointed out that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_+=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M202.jpg" xlink:type="simple" />
+               </inline-formula>
+               . In our work, we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M203.jpg" xlink:type="simple" />
+               </inline-formula>
+               , since
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M204.jpg" xlink:type="simple" />
+               </inline-formula>
+               . This difference is due to the fact that in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib17">17</xref>
+               ],
+               <italic toggle="yes">K</italic>
+               -violating quartic terms are not considered.
+            </p>
+            <p>
+               We have described that using the
+               <italic toggle="yes">K</italic>
+               -violating terms of our model, we can explain the required hierarchy between muon and tau lepton masses. However, in doing so, from Eq. (28) we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_\theta\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M205.jpg" xlink:type="simple" />
+               </inline-formula>
+               , makes
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M206.jpg" xlink:type="simple" />
+               </inline-formula>
+               complex. One can fine tune the parameters in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_2,f_+, f_\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M207.jpg" xlink:type="simple" />
+               </inline-formula>
+               in such a way that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_\theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M208.jpg" xlink:type="simple" />
+               </inline-formula>
+               . In contrast, to get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_\theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M209.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we can take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{+\theta}=0=f_\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M210.jpg" xlink:type="simple" />
+               </inline-formula>
+               . After using Eq. (20),
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F}_{+\theta}=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M211.jpg" xlink:type="simple" />
+               </inline-formula>
+               implies that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \kappa_2=\kappa_3=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M212.jpg" xlink:type="simple" />
+               </inline-formula>
+               . To make
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_\theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M213.jpg" xlink:type="simple" />
+               </inline-formula>
+               , either we can take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta\kappa_2=-\delta\kappa_2^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M214.jpg" xlink:type="simple" />
+               </inline-formula>
+               or forbid the trilinear terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M215.jpg" xlink:type="simple" />
+               </inline-formula>
+               . From the above observations,  to make
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M216.jpg" xlink:type="simple" />
+               </inline-formula>
+               real in case I, without fine tuning the parameters, the trilinear terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M217.jpg" xlink:type="simple" />
+               </inline-formula>
+               containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M218.jpg" xlink:type="simple" />
+               </inline-formula>
+               should be forbidden.
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103101_s03-02">
+            <label>B.</label>
+            <title>Case II</title>
+            <p>
+               As explained before, in this case, terms involving triplet Higgs give very small contribution in comparison to that involving only doublet Higgses. As a result, the minimization of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M219.jpg" xlink:type="simple" />
+               </inline-formula>
+               in this case proceeds in two steps. First, we minimize
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M220.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which contains only doublet Higgses and thereby determine the VEVs of these fields. Later, after using the VEVs of doublet Higgses, we minimize the potential containing the triplet Higgs field. In the first step of minimization, we can neglect
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M221.jpg" xlink:type="simple" />
+               </inline-formula>
+               in comparison to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_D $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M222.jpg" xlink:type="simple" />
+               </inline-formula>
+               and the terms in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M223.jpg" xlink:type="simple" />
+               </inline-formula>
+               containing the triplet Higgs field. In this case, we parametrize the VEVs for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{1,2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M224.jpg" xlink:type="simple" />
+               </inline-formula>
+               and Δ as given in Eq. (17). After minimizing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_D $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M225.jpg" xlink:type="simple" />
+               </inline-formula>
+               with respect to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\alpha,\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M226.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the minimum is given by Eq. (18) with the condition of Eq. (19). Since this minimum gives
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M227.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we introduce
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M228.jpg" xlink:type="simple" />
+               </inline-formula>
+               and parametrize the deviations in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\alpha,\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M229.jpg" xlink:type="simple" />
+               </inline-formula>
+               , as given by Eq. (23). Consequently, one can notice that the above mentioned deviations can be found from Eq. (27), where, in this case,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M230.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <italic toggle="yes">f</italic>
+               are 3
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \times $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M231.jpg" xlink:type="simple" />
+               </inline-formula>
+               3 and 3
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \times $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M232.jpg" xlink:type="simple" />
+               </inline-formula>
+               1 matrices, respectively. The components of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M233.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <italic toggle="yes">f</italic>
+               can be found from Eqs. (25) and (26), where the terms containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M234.jpg" xlink:type="simple" />
+               </inline-formula>
+               should be omitted, leading to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_-,\delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M235.jpg" xlink:type="simple" />
+               </inline-formula>
+               . After using this in Eq. (6), we get small and non-zero
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M236.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               Since the VEVs of doublet Higgses are determined, we now minimize
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M237.jpg" xlink:type="simple" />
+               </inline-formula>
+               and try to see if
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M238.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be real. After using Eq. (17) in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M239.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>29</label>
+                  <tex-math id="cpc_46_10_103101_E29">
+                     <?CDATA $ \begin{aligned}[b] \langle V_T\rangle= & (m_\Delta^2+\lambda_{11}v_1^2+\lambda_{12}v^2)v^{\prime^2} +\frac{1}{2}\lambda_\Delta v^{\prime^4}-2\kappa_1v_1^2v^\prime\cos\theta \\ & -2\kappa_2v^2v^\prime[\cos^2\sigma\cos(\theta-2\alpha) +\sin^2\sigma\cos(\theta-2\beta)] \\ & +\kappa_3v^2v^\prime\sin2\sigma\sin(\theta-\alpha-\beta). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E29.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since we are looking for a minimum at
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M240.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we do
+            </p>
+            <p>
+               <disp-formula>
+                  <label>30</label>
+                  <tex-math id="cpc_46_10_103101_E30">
+                     <?CDATA $ \begin{aligned}[b] \left.\frac{\partial\langle V_T\rangle}{\partial\theta}\right|_{\theta=0}= & 0 \Rightarrow -2\kappa_2[\cos^2\sigma\sin2\alpha+\sin^2\sigma\sin2\beta] \\ & +\kappa_3\sin2\sigma\cos(\alpha+\beta)=0. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E30.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               As stated earlier, we have determined
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M241.jpg" xlink:type="simple" />
+               </inline-formula>
+               up to the first order in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_-,\;\delta_+ $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M242.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Plugging the parametrizations for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M243.jpg" xlink:type="simple" />
+               </inline-formula>
+               in the above equation and expanding the terms up to the first order in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\delta_-,\delta_+ $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M244.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>31</label>
+                  <tex-math id="cpc_46_10_103101_E31">
+                     <?CDATA $ \begin{equation} 2\kappa_2\sin2\omega-\kappa_3\cos2\omega +2(2\kappa_2\cos2\omega+\kappa_3\sin2\omega)\delta_+=0. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E31.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since we have
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_+\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M245.jpg" xlink:type="simple" />
+               </inline-formula>
+               , after equating the leading and subleading terms of the above equation to zero, we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \kappa_2=\kappa_3=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M246.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Hence, in case II, one has to forbid the trilinear terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_T $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M248.jpg" xlink:type="simple" />
+               </inline-formula>
+               containing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M249.jpg" xlink:type="simple" />
+               </inline-formula>
+               to make
+               <italic toggle="yes">v</italic>
+               <sub>Δ</sub>
+               real.
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103101_s03-03">
+            <label>C.</label>
+            <title>
+               Imposing an extra
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA ${\boldsymbol Z}_{\bf 3}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M250.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry
+            </title>
+            <p>
+               From the analysis of the previous two subsections, we have seen that the trilinear terms in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M251.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which contain
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M252.jpg" xlink:type="simple" />
+               </inline-formula>
+               , should be forbidden in order to make
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M253.jpg" xlink:type="simple" />
+               </inline-formula>
+               real. To achieve this, we impose the discrete symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M254.jpg" xlink:type="simple" />
+               </inline-formula>
+               in our model. Under this symmetry, the non-trivial transformations are as follows.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>32</label>
+                  <tex-math id="cpc_46_10_103101_E32">
+                     <?CDATA $ \begin{aligned}[b] & \phi_2\to\Omega\phi_2,\quad\phi_3\to\Omega\phi_3, \\ & \mu_{\rm R}\to\Omega^2\mu_{\rm R},\quad\tau_{\rm R}\to\Omega^2\tau_{\rm R}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E32.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \Omega={\rm e}^{2\pi {\rm i}/3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M255.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Under the above transformations, the Yukawa couplings for leptons are invariant, whereas the following couplings in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M256.jpg" xlink:type="simple" />
+               </inline-formula>
+               are forbidden:
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \lambda_{8,9},\;\kappa_{2,3}, \delta\kappa,\;\delta\kappa^\prime $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M257.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Now, after using the parametrizations of Eq. (17) in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm inv} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M258.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>33</label>
+                  <tex-math id="cpc_46_10_103101_E33">
+                     <?CDATA $ \begin{aligned}[b] \langle V_{\rm inv}\rangle= & \frac{1}{4}[\tilde{\lambda}-4\lambda_7\sin^2\zeta]v^4 \sin^22\sigma\\ & +\frac{1}{2}\lambda_{10}v^4\sin4\sigma\sin\zeta -2\kappa_1v_1^2v^\prime\cos\theta. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E33.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \zeta=\alpha-\beta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M259.jpg" xlink:type="simple" />
+               </inline-formula>
+               . In the above equation, we have neglected constant terms which do not depend on
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\alpha,\;\beta,\;\theta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M260.jpg" xlink:type="simple" />
+               </inline-formula>
+               . We can notice from the above equation that
+               <italic toggle="yes">θ</italic>
+               do not mix with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\zeta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M261.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Moreover, due to the absence of trilinear terms in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\not{K}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M262.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle V_{\not{K}}\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M263.jpg" xlink:type="simple" />
+               </inline-formula>
+               do not depend on
+               <italic toggle="yes">θ</italic>
+               . As a result, we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \theta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M264.jpg" xlink:type="simple" />
+               </inline-formula>
+               is a minimum to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M265.jpg" xlink:type="simple" />
+               </inline-formula>
+               if
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \kappa_1v^\prime \gt 0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M266.jpg" xlink:type="simple" />
+               </inline-formula>
+               . This statement is true for both cases I and II. Hence, after imposing the above mentioned
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M267.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_\Delta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M268.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be real in our model.
+            </p>
+            <p>
+               For Eq. (33), the minimum in terms of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \sigma,\;\zeta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M269.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be at
+            </p>
+            <p>
+               <disp-formula>
+                  <label>34</label>
+                  <tex-math id="cpc_46_10_103101_E34">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4},\quad\zeta=0. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E34.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \zeta=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M270.jpg" xlink:type="simple" />
+               </inline-formula>
+               corresponds to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ m_\mu=0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M271.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we introduce
+               <italic toggle="yes">K</italic>
+               -violating terms into the model. Consequently, the above mentioned minimum can be shifted by small deviations
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_\zeta $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M272.jpg" xlink:type="simple" />
+               </inline-formula>
+               as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>35</label>
+                  <tex-math id="cpc_46_10_103101_E35">
+                     <?CDATA $ \begin{equation} \sigma=\frac{\pi}{4}-\frac{\delta_0}{2},\quad\zeta=0+\delta_\zeta. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E35.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Now, after imposing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M273.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry in Eq. (21) and after following the procedure for minimizing
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ V_{\rm total} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M274.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which is described in Sec. III.A, we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>36</label>
+                  <tex-math id="cpc_46_10_103101_E36">
+                     <?CDATA $ \begin{aligned}[b] \left(\begin{array}{c} \delta_0\\\delta_\zeta \end{array}\right) = & {\cal F}^{-1}\left(\begin{array}{c} f_0\\f_\zeta \end{array}\right),\quad {\cal F}=\left(\begin{array}{cc} -\frac{1}{2}\tilde{\lambda} & \lambda_{10}\\\lambda_{10} & -2\lambda_7 \end{array}\right)v^4, \\ f_0= & \frac{1}{2}(\delta M_2^2-\delta M_3^2)v^2 +\frac{1}{2}(\delta\lambda_2-\delta\lambda_2^\prime)v^4 \\ & +\frac{1}{2}(\delta\lambda_3 -\delta\lambda_3^\prime+\delta\lambda_5-\delta\lambda_5^\prime)(v_1v)^2 \\ & +\frac{1}{2}(\delta\lambda_{12}-\delta\lambda_{12}^\prime)(vv^\prime)^2, \\ f_\zeta= & \delta M_s^2v^2 +\frac{1}{2}(\delta\lambda_{10}+\delta\lambda_{10}^\prime)v^4 \\ & +(\delta\lambda_s-\delta\lambda_s^\prime)(v_1v)^2 +\delta_t(vv^\prime)^2. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E36.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               We can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_\zeta\neq0 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M275.jpg" xlink:type="simple" />
+               </inline-formula>
+               . After using these in the parametrizations for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M276.jpg" xlink:type="simple" />
+               </inline-formula>
+               , from Eq. (6), we get
+            </p>
+            <p>
+               <disp-formula>
+                  <label>37</label>
+                  <tex-math id="cpc_46_10_103101_E37">
+                     <?CDATA $ \begin{equation} \frac{m_\mu}{m_\tau}=\frac{1}{2}\big|\delta_0+{\rm i}\delta_\zeta\big|. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E37.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Using the above equation, the required hierarchy between muon and tau leptons can be explained if we take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \delta_0,\;\delta_\zeta\sim0.1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M277.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               In Sec. II, we have described our model for lepton sector by introducing additional fields and symmetries. In the current section, we have introduced one more symmetry,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M278.jpg" xlink:type="simple" />
+               </inline-formula>
+               , in order to make the triplet Higgs VEV real. In
+               <xref ref-type="table" rid="cpc_46_10_103101_t1">Table 1</xref>
+               we summarize the additional fields and symmetries, which are needed for our model, in the lepton sector.
+            </p>
+            <table-wrap id="cpc_46_10_103101_t1" orientation="portrait" position="float">
+               <label>Table 1</label>
+               <caption id="cpc_46_10_103101_tc1">
+                  <p>Additional fields and symmetries, which are introduced in the lepton sector of our model. The roles of these fields and symmetries are also described here.</p>
+               </caption>
+               <table>
+                  <thead>
+                     <tr>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Additional field</th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Role</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \phi_1 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M279.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate the mass of electron</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \phi_2 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M280.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           ,
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ \phi_3 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M281.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           to generate masses for
+                           <italic toggle="yes">μ</italic>
+                           and
+                           <italic toggle="yes">τ</italic>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Δ</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate masses for neutrinos</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Additional symmetry</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Role</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $CP$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M282.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           symmetry
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           to get
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $\mu-\tau$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M283.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           form for neutrino mass matrix
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $Z_2$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M284.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           forbids unwanted Yukawa couplings among
+                           <break />
+                           charged leptons
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $U(1)_{L_\alpha}$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M285.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to get diagonal masses for charged leptons</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <italic toggle="yes">K</italic>
+                           symmetry
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to reduce the fine-tuning in muon and tau masses</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $Z_3$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M286.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to make the VEV of Δ to be real</td>
+                     </tr>
+                  </tbody>
+               </table>
+            </table-wrap>
+         </sec>
+      </sec>
+      <sec id="cpc_46_10_103101_s04">
+         <label>IV.</label>
+         <title>
+            NEUTRINO MASS ORDERING AND THE SMALLNESS OF
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {\boldsymbol \theta}_{\bf 13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M287.jpg" xlink:type="simple" />
+            </inline-formula>
+         </title>
+         <p>
+            After showing that the triplet Higgs can acquire real VEV, the neutrino mass matrix of the model proposed in Sec. II satisfy Eq. (10). As a result, after diagonalizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M288.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M289.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M290.jpg" xlink:type="simple" />
+            </inline-formula>
+            would be maximal [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib13">13</xref>
+            ]. However, the form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M291.jpg" xlink:type="simple" />
+            </inline-formula>
+            does not give predictions about
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{12},\theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M292.jpg" xlink:type="simple" />
+            </inline-formula>
+            or neutrino mass ordering. In this section, we carry out an analysis and provide a procedure, which can give predictions about neutrino mass ordering and the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M293.jpg" xlink:type="simple" />
+            </inline-formula>
+            in our model.
+         </p>
+         <p>
+            In the model proposed in Sec. II, the charged lepton masses are in diagonal form. Hence, the unitary matrix which diagonalizes
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M294.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <label>38</label>
+               <tex-math id="cpc_46_10_103101_E38">
+                  <?CDATA $ \begin{array}{*{20}{l}}\\ & & U=\tilde{U}U_{\rm PMNS},\quad \tilde{U}={\rm diag}(1,1,-1), \\ & & U_{\rm PMNS} = \left(\begin{array}{ccc} c_{12}c_{13} & s_{12}c_{13} & s_{13}{\rm e}^{-{\rm i}\delta_{CP}} \\ -s_{12}c_{23}-c_{12}s_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & c_{12}c_{23}-s_{12}s_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & s_{23}c_{13} \\ s_{12}s_{23}-c_{12}c_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & -c_{12}s_{23}-s_{12}c_{23}s_{13}{\rm e}^{{\rm i}\delta_{CP}} & c_{23}c_{13} \end{array}\right). \\ \end{array} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E38.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ c_{ij}=\cos\theta_{ij} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M295.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{ij}=\sin\theta_{ij} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M296.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M297.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the Pontecorvo-Maki-Nakagawa-Sakata (PMNS) matrix, which is parameterized in terms of the three lepton mixing angles and the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M298.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating Dirac phase, according to the convention of PDG [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ]. Diagonal elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \tilde{U} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M299.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be absorbed into the charged lepton fields. Now, the relation for diagonalizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M300.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be expressed as
+         </p>
+         <p>
+            <disp-formula>
+               <label>39</label>
+               <tex-math id="cpc_46_10_103101_E39">
+                  <?CDATA $ \begin{equation} M_\nu=U^*{\rm diag}(m_1,m_2,m_3)U^\dagger. \end{equation} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E39.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            While solving the above equation, we can use an approximation procedure [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib24">24</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib25">25</xref>
+            ] related to neutrino masses and mixing angle
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M301.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is explained below.
+         </p>
+         <p>
+            In the expression for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M302.jpg" xlink:type="simple" />
+            </inline-formula>
+            one can have Majorana phases, which cannot be determined from neutrino oscillation data. However, they can affect the life-time of neutrinoless double beta decay, since neutrinos in our model are Majorana particles. Nonetheless, there is no concrete evidence for this decay so far [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ], and as a result, the Majorana phases can take any value between 0 and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 2\pi $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M303.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, in our analysis, for the sake of simplicity, we have chosen these phases to be zero. In contrast, by taking some specific values for Majorana phases in the below described procedure, one can study the conditions, which can give rise for neutrino Yukawa couplings of our model. Nevertheless, we shall reserve this study for a future work.
+         </p>
+         <p>
+            In
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M304.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we put
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23}={\pi}/{4} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M305.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP}={(3\pi)}/{2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M306.jpg" xlink:type="simple" />
+            </inline-formula>
+            . From the neutrino oscillation data, we have
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2\sim{1}/{3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M307.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2\sim2\cdot10^{-2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M308.jpg" xlink:type="simple" />
+            </inline-formula>
+            [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+            ]. Here, we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M309.jpg" xlink:type="simple" />
+            </inline-formula>
+            is negligibly small in comparison to unity, and hence
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}\sim0.15 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M310.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be treated as a small variable. In contrast,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M311.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{23}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M312.jpg" xlink:type="simple" />
+            </inline-formula>
+            are of order one. Since
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M313.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the only small variable in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M314.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we expand
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U_{\rm PMNS} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M315.jpg" xlink:type="simple" />
+            </inline-formula>
+            up to the first order in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M316.jpg" xlink:type="simple" />
+            </inline-formula>
+            . The corresponding expression is given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>40</label>
+               <tex-math id="cpc_46_10_103101_E40">
+                  <?CDATA $ \begin{aligned}[b] U_{\rm PMNS}= & U_0+\delta U, \\ U_0= & \left(\begin{array}{ccc} c_{12} & s_{12} & 0 \\ -\dfrac{s_{12}}{\sqrt{2}} & \dfrac{c_{12}}{\sqrt{2}} & \dfrac{1}{\sqrt{2}} \\ \dfrac{s_{12}}{\sqrt{2}} & -\dfrac{c_{12}}{\sqrt{2}} & \dfrac{1}{\sqrt{2}} \end{array}\right),\\\delta U= & \left(\begin{array}{ccc} 0 & 0 & 1 \\ \dfrac{c_{12}}{\sqrt{2}} & \dfrac{s_{12}}{\sqrt{2}} & 0 \\ \dfrac{c_{12}}{\sqrt{2}} & \dfrac{s_{12}}{\sqrt{2}} & 0 \end{array}\right){\rm i}s_{13}. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E40.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            From the neutrino oscillation data, two mass-squared differences for neutrinos are found, which are given in Eq. (11). From this equation we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {m_s^2}/{m_a^2}\sim s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M317.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is negligibly small compared to unity. This indicates that an approximation with respect to neutrino masses can also be applied while solving the Eq. (39). In order to fit the mass-square differences of Eq. (11), we can take the neutrino masses as follows.
+         </p>
+         <p>
+            <disp-formula>
+               <label>41</label>
+               <tex-math id="cpc_46_10_103101_E41">
+                  <?CDATA $ \begin{aligned}[b] & {\rm NO}:\quad m_1 \lesssim m_s,\quad m_2=\sqrt{m_s^2+m_1^2},\quad m_3=\sqrt{m_a^2+m_1^2}. \\ & {\rm IO}:\quad m_3 \lesssim m_s,\quad m_1=\sqrt{m_a^2+m_3^2},\quad m_2=\sqrt{m_s^2+m_1^2}. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E41.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Now we can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {m_1}/{m_a} \lesssim s_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M318.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the case of NO, whereas,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {m_1}/{m_a}\sim1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M319.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the case of IO. Similar conclusions can be made about
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${m_2}/{m_a}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M320.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${m_3}/{m_a} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M321.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            Using the approximation scheme described in the previous paragraph, we can expand
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${({1}/{m_a})}M_\nu$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M322.jpg" xlink:type="simple" />
+            </inline-formula>
+            in powers of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13},\;{m_s}/{m_a} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M323.jpg" xlink:type="simple" />
+            </inline-formula>
+            . After neglecting the second and higher order corrections in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13},\;{m_s}/{m_a} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M324.jpg" xlink:type="simple" />
+            </inline-formula>
+            , for both  NO and IO cases, the elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA ${({1}/{m_a})}M_\nu$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M325.jpg" xlink:type="simple" />
+            </inline-formula>
+            are given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>42</label>
+               <tex-math id="cpc_46_10_103101_E42">
+                  <?CDATA $ \begin{aligned}[b] & \frac{1}{m_a}M_\nu=\frac{1}{2m_a}\left(\begin{array}{ccc} x & z & z^*\\ z & w & y\\ z^* & y & w^* \end{array}\right), \\ {\rm NO}:\;\; & x=2c_{12}^2m_1+2 s_{12}^2 m_2,\\ & z=\sqrt{2} c_{12}s_{12}(m_2-m_1)-{\rm i}\sqrt{2}m_3s_{13}, \\ & w=m_3+c_{12}^2m_2+s_{12}^2m_1,\\ & y=-m_3+c_{12}^2m_2+s_{12}^2m_1. \\ {\rm IO}:\;\; & x=2m_1,\quad z=-\sqrt{2} {\rm i} s_{13}m_1,\\ & w=m_1+m_3,\quad y=m_1-m_3. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E42.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Using the above relations, in order for the matrix
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M326.jpg" xlink:type="simple" />
+            </inline-formula>
+            to make predictions about neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M327.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the Yukawa couplings in Eq. (8) should satisfy the following conditions.
+         </p>
+         <p>
+            ● To predict NO and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M328.jpg" xlink:type="simple" />
+            </inline-formula>
+            :
+         </p>
+         <p>
+            (i)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee},Y^\nu_{e\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M329.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be suppressed by approximately 0.1 compared to that of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\mu\mu},Y^\nu_{\mu\tau} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M330.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            (ii)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\mu\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M331.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real.
+         </p>
+         <p>
+            ● To predict IO and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M332.jpg" xlink:type="simple" />
+            </inline-formula>
+            :
+         </p>
+         <p>
+            (i)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{e\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M333.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be purely imaginary and its magnitude is suppressed by approximately 0.1 compared to other elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M334.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            (ii)
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{\mu\mu} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M335.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real.
+         </p>
+         <p>
+            We recall that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M336.jpg" xlink:type="simple" />
+            </inline-formula>
+            is a symmetric matrix satisfying Eq. (9). Hence, not all elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M337.jpg" xlink:type="simple" />
+            </inline-formula>
+            are independent. As a result, while describing the above conditions, we have considered
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee},Y^\nu_{e\mu},Y^\nu_{\mu\mu},Y^\nu_{\mu\tau} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M338.jpg" xlink:type="simple" />
+            </inline-formula>
+            as independent elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M339.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Another point worth mentioning here is that the aforementioned conditions are true after neglecting second and higher order corrections in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {({1}/{m_a})}M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M340.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            The condition (ii) described for the cases of NO and IO is trivially satisfied if one uses the relations in Eq. (42). The non-trivial condition to check is the condition (i) in the NO and IO cases. The suppression factor mentioned in this condition is arising due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}\sim {({m_s}/{m_a})}\sim 0.15 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M341.jpg" xlink:type="simple" />
+            </inline-formula>
+            . We have checked this suppression factor for the case of NO by computing the following ratios:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{ee}|}/{|Y^\nu_{\mu\mu}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M342.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{ee}|}/{|Y^\nu_{\mu\tau}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M343.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\mu}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M344.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\tau}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M345.jpg" xlink:type="simple" />
+            </inline-formula>
+            . While for the case of IO, the following ratios are computed in order to check condition (i):
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{ee}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M346.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\mu}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M347.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {|Y^\nu_{e\mu}|}/{|Y^\nu_{\mu\tau}|} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M348.jpg" xlink:type="simple" />
+            </inline-formula>
+            . One can notice that the neutrino Yukawa couplings are proportional to the elements of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ M_\nu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M349.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which are given in Eq. (42). The neutrino masses in Eq. (42) are computed using Eq. (41) and by varying
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m^2_s,\;m^2_a $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M350.jpg" xlink:type="simple" />
+            </inline-formula>
+            over their allowed
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M351.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges. The mass of the lightest neutrino is varied from 0 to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_s $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M352.jpg" xlink:type="simple" />
+            </inline-formula>
+            in  the NO and IO cases. While computing the above mentioned ratios, we have also varied
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M353.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M354.jpg" xlink:type="simple" />
+            </inline-formula>
+            over their allowed
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M355.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges. We have listed the allowed
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M356.jpg" xlink:type="simple" />
+            </inline-formula>
+            ranges for the abovementioned variables in
+            <xref ref-type="table" rid="cpc_46_10_103101_t2">Table 2</xref>
+            .
+         </p>
+         <table-wrap id="cpc_46_10_103101_t2" orientation="portrait" position="float">
+            <label>Table 2</label>
+            <caption id="cpc_46_10_103101_tc2">
+               <p>
+                  Allowed
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 3\sigma $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103101_M357.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  ranges of the neutrino oscillation observables [
+                  <xref ref-type="bibr" rid="cpc_46_10_103101_bib1">1</xref>
+                  ], which are used in our analysis.
+               </p>
+            </caption>
+            <table>
+               <thead>
+                  <tr>
+                     <th align="center" colspan="1" rowspan="1" valign="middle">Parameters</th>
+                     <th align="center" colspan="1" rowspan="1" valign="middle">Allowed range</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ m_s^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M358.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        (6.94
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M359.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        8.14)
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \times 10^{-5} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M360.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        eV
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ ^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M361.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ m_a^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M362.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (NO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        (2.47
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M363.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        2.63)
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \times 10^{-3} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M364.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        eV
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ ^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M365.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ m_a^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M366.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (IO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        (2.37
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M367.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        2.53)
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ \times 10^{-3} $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M368.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        eV
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ ^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M369.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ s_{12}^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M370.jpg" xlink:type="simple" />
+                        </inline-formula>
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        0.271
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M371.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        0.369
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ s_{13}^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M372.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (NO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        0.0200
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M373.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        0.02405
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ s_{13}^2 $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M374.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        (IO)
+                     </td>
+                     <td align="center" colspan="1" rowspan="1" valign="middle">
+                        0.02018
+                        <inline-formula>
+                           <tex-math>
+                              <?CDATA $ - $?>
+                           </tex-math>
+                           <inline-graphic xlink:href="cpc_46_10_103101_M375.jpg" xlink:type="simple" />
+                        </inline-formula>
+                        0.02424
+                     </td>
+                  </tr>
+               </tbody>
+            </table>
+         </table-wrap>
+         <p>
+            As we proceeded with above analysis, we checked if the sum of the three neutrinos is less than 0.12 eV, which is a constraint obtained from the cosmological observations [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib37">37</xref>
+            ]. As already described in the previous paragraph, the suppression in the ratios of various Yukawa couplings should be around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}\sim{({m_s}/{m_a})}\sim 0.15 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M376.jpg" xlink:type="simple" />
+            </inline-formula>
+            . However, in our analysis we have found that some of these ratios can become as large as 0.5, and thus, invalidate the approximation procedure, which we are using here. Hence, in the analysis we have restricted all these ratios to be less than or of the order of 0.2. Selected plots from this analysis are presented in
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            . From this figure we can see that the mass of lightest neutrino,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{\rm lightest} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M377.jpg" xlink:type="simple" />
+            </inline-formula>
+            , is constrained due to aforementioned restriction on the ratios of Yukawa couplings. We can notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{\rm lightest} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M378.jpg" xlink:type="simple" />
+            </inline-formula>
+            has a narrow allowed region in the case of NO compared to that of IO. Apart from the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_{\rm lightest} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M379.jpg" xlink:type="simple" />
+            </inline-formula>
+            in
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{13}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M380.jpg" xlink:type="simple" />
+            </inline-formula>
+            is also constrained to be in the range of 0.02 to 0.023, in the case of NO. In contrast, this variable is not constrained in the case of IO. As for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ s_{12}^2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M381.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we have found that it can take the full
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 3\sigma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M382.jpg" xlink:type="simple" />
+            </inline-formula>
+            range in both the NO and IO cases of
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            . Although we have presented selected plots in
+            <xref ref-type="fig" rid="cpc_46_10_103101_f1">Fig. 1</xref>
+            , we have obtained similar plots for other ratios of Yukawa couplings, which are mentioned in the previous paragraph. These plots justify the approximation procedure, which we are using here, and verify the condition (i) for the cases of NO and IO, which are mentioned below Eq. (42).
+         </p>
+         <fig id="cpc_46_10_103101_f1" orientation="portrait" position="float">
+            <label>Fig. 1</label>
+            <caption id="cpc_46_10_103101_fc1">
+               <p>
+                  (color online) Ratios of the magnitude of Yukawa couplings versus the mass of lightest neutrino. The left- and right-hand side plots are for NO and IO, respectively. In both plots, we vary the neutrino oscillation observables over their allowed
+                  <inline-formula>
+                     <tex-math>
+                        <?CDATA $ 3\sigma $?>
+                     </tex-math>
+                     <inline-graphic xlink:href="cpc_46_10_103101_M383.jpg" xlink:type="simple" />
+                  </inline-formula>
+                  ranges, which are given in
+                  <xref ref-type="table" rid="cpc_46_10_103101_t2">Table 2</xref>
+                  . For other details, see the text.
+               </p>
+            </caption>
+            <graphic content-type="print" id="cpc_46_10_103101_f1_eps" orientation="portrait" position="float" xlink:href="cpc_46_10_103101_f1.pdf" xlink:type="simple" />
+            <graphic content-type="online" id="cpc_46_10_103101_f1_online" orientation="portrait" position="float" xlink:href="cpc_46_10_103101_f1.pdf" xlink:type="simple" />
+         </fig>
+         <p>
+            The conditions mentioned below Eq. (42), for both the NO and IO cases, cannot be achieved just with the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M384.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. An additional mechanism should be proposed to satisfy these conditions. In an attempt towards this, we have proposed one mechanism to achieve condition (i) for the case of NO, where the necessary suppression in the Yukawa couplings is explained through non-renormalizable terms within the framework of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M385.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. This mechanism is presented in the Appendix. In this work, we do not have a mechanism to achieve condition (i) for the case of IO and to achieve condition (ii) for both NO and IO. These problems would be investigated in future works. As already described, with the generalized
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M386.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M387.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M388.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M389.jpg" xlink:type="simple" />
+            </inline-formula>
+            will be maximal. However, in future neutrino oscillation experiments,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M390.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M391.jpg" xlink:type="simple" />
+            </inline-formula>
+            may be found to be away from their maximal values. In such a case, one needs to device a mechanism for the breaking of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M392.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry in order to explain the non-maximal values for the above mentioned observables. However, these topics are outside the scope of the present study.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s05">
+         <label>V.</label>
+         <title>QUARK MIXING</title>
+         <p>
+            In our proposed model for lepton mixing, three Higgs doublets exist. Since they can also give masses to quarks, it is interesting to check whether quark mixing can also be explained with
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M393.jpg" xlink:type="simple" />
+            </inline-formula>
+            and other symmetries of our model. As already described in Sec. I, since there is a hierarchy among quark masses, the mixing pattern for quarks can be explained if their Yukawa couplings are hierarchically suppressed. Babu and Nandi have proposed one model [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ] for explaining quark mixing through hierarchically suppressed Yukawa couplings. Later, this model has been modified in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ], where the suppression in Yukawa couplings is explained with a singlet scalar field. We follow the work of Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ] to explain quark mixing in our framework.
+         </p>
+         <sec id="cpc_46_10_103101_s05-01">
+            <label>A.</label>
+            <title>Model for quark masses and mixing</title>
+            <p>
+               We denote the three families of quark doublets, up- and down-type singlets as
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Q_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M394.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ u_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M395.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ d_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M396.jpg" xlink:type="simple" />
+               </inline-formula>
+               , respectively. We propose a scalar field
+               <italic toggle="yes">X,</italic>
+               which is singlet under standard model gauge group. We assume all the quark fields to be singlets under the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_2\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M397.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The
+               <italic toggle="yes">X</italic>
+               field is singlet under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M398.jpg" xlink:type="simple" />
+               </inline-formula>
+               but is odd under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M399.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Both the quark and
+               <italic toggle="yes">X</italic>
+               fields transform under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M400.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>43</label>
+                  <tex-math id="cpc_46_10_103101_E43">
+                     <?CDATA $ \begin{aligned}[b] & Q_{j{\rm L}}\to {\rm i}\gamma^0C\bar{Q}_{j{\rm L}}^T,\quad u_{j{\rm R}}\to {\rm i}\gamma^0C\bar{u}_{j{\rm R}}^T, \\ & d_{j{\rm R}}\to {\rm i}\gamma^0C\bar{d}_{j{\rm R}}^T, \quad X\to X^*. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E43.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>Now, with the above mentioned transformations and fields, we consider the following effective Lagrangian for quark masses.</p>
+            <p>
+               <disp-formula>
+                  <label>44</label>
+                  <tex-math id="cpc_46_10_103101_E44">
+                     <?CDATA $ \begin{aligned}[b] {\cal L}_Y= & h^u_{33}\bar{Q}_{3{\rm L}}\tilde{\phi}_1u_{3{\rm R}} +\left(\frac{X}{M}\right)^2[h^d_{33}\bar{Q}_{3{\rm L}}\phi_1 d_{3{\rm R}} \\ & +h^u_{22}\bar{Q}_{2{\rm L}}\tilde{\phi}_1u_{2{\rm R}} +h^u_{23}\bar{Q}_{2{\rm L}}\tilde{\phi}_1u_{3{\rm R}} \\ & +h^u_{32}\bar{Q}_{3{\rm L}}\tilde{\phi}_1 u_{2{\rm R}}]+\left(\frac{X}{M}\right)^4[h^d_{22}\bar{Q}_{2{\rm L}}\phi_1 d_{2{\rm R}} \\ & +h^d_{23}\bar{Q}_{2{\rm L}}\phi_1 d_{3{\rm R}}+h^d_{32}\bar{Q}_{3{\rm L}}\phi_1 d_{2{\rm R}} \\ & +h^u_{12}\bar{Q}_{1{\rm L}}\tilde{\phi}_1u_{2{\rm R}}+h^u_{21}\bar{Q}_{2{\rm L}}\tilde{\phi}_1u_{1{\rm R}}\\ & +h^u_{13}\bar{Q}_{1{\rm L}}\tilde{\phi}_1u_{3{\rm R}}+ h^u_{31}\bar{Q}_{3{\rm L}}\tilde{\phi}_1u_{1{\rm R}}] \\ & +\left(\frac{X}{M}\right)^6[h^u_{11}\bar{Q}_{1{\rm L}}\tilde{\phi}_1u_{1{\rm R}} +h^d_{11}\bar{Q}_{1{\rm L}}\phi_1 d_{1{\rm R}}\\ & +h^d_{12}\bar{Q}_{1{\rm L}}\phi_1 d_{2{\rm R}} +h^d_{13}\bar{Q}_{1{\rm L}}\phi_1 d_{3{\rm R}}] \\ & +\left(\frac{X}{M}\right)^9[h^d_{21}\bar{Q}_{2{\rm L}}\phi_1 u_{1{\rm R}}] +\left(\frac{X}{M}\right)^{10}[h^d_{31}\bar{Q}_{3{\rm L}}\phi_1 u_{1{\rm R}}]+{\rm h.c}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E44.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               The above Lagrangian is valid below a mass scale of
+               <italic toggle="yes">M</italic>
+               . The non-renormalizable terms of this Lagrangian can be motivated by the UV completion of this model, which is presented in the next subsection. According to this UV completion, we propose a flavor symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M401.jpg" xlink:type="simple" />
+               </inline-formula>
+               and heavy vector-like quark (VLQ) fields above the scale
+               <italic toggle="yes">M</italic>
+               . After integrating the heavy fields in our model, below the scale
+               <italic toggle="yes">M</italic>
+               , the non-renormalizable terms of Eq. (44) can appear. Here we can see that
+               <italic toggle="yes">M</italic>
+               represents the mass scale of heavy VLQs. Since new particles can be probed at the LHC experiment if their masses are around 1 TeV, we take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M\sim $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M402.jpg" xlink:type="simple" />
+               </inline-formula>
+               1 TeV.
+            </p>
+            <p>
+               Due to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M403.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, the Yukawa couplings
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^{u,d}_{jk} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M404.jpg" xlink:type="simple" />
+               </inline-formula>
+               should be real in Eq. (44). After
+               <italic toggle="yes">X</italic>
+               acquires VEV, for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle X\rangle \lt M $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M405.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we can see that
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {X}/{M} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M406.jpg" xlink:type="simple" />
+               </inline-formula>
+               gives suppression to the effective quark Yukawa couplings. Since the Yukawa couplings of Eq. (44) are real, we assume
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \langle X\rangle $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M407.jpg" xlink:type="simple" />
+               </inline-formula>
+               is complex, and this can be the source for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M408.jpg" xlink:type="simple" />
+               </inline-formula>
+               violation in the quark sector. In the Lagrangian of Eq. (44), only the doublet
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M409.jpg" xlink:type="simple" />
+               </inline-formula>
+               generates Yukawa couplings for quark fields. The other doublets
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \phi_{2,3} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M410.jpg" xlink:type="simple" />
+               </inline-formula>
+               do not generate these Yukawa couplings due to the presence of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times K$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M411.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry.
+            </p>
+            <p>After electroweak symmetry breaking, using Eq. (44), the matrices for up- and down-type quarks can be written, respectively, as</p>
+            <p>
+               <disp-formula>
+                  <label>45</label>
+                  <tex-math id="cpc_46_10_103101_E45">
+                     <?CDATA $ \begin{aligned}[b] & M_u=\left(\begin{array}{ccc} h^u_{11}\epsilon^6 & h^u_{12}\epsilon^4 & h^u_{13}\epsilon^4 \\ h^u_{21}\epsilon^4 & h^u_{22}\epsilon^2 & h^u_{23}\epsilon^2 \\ h^u_{31}\epsilon^4 & h^u_{32}\epsilon^2 & h^u_{33} \end{array}\right)v_1,\\ & M_d=\left(\begin{array}{ccc} h^d_{11}\epsilon^6 & h^d_{12}\epsilon^6 & h^d_{13}\epsilon^6 \\ h^d_{21}\epsilon^9 & h^d_{22}\epsilon^4 & h^d_{23}\epsilon^4 \\ h^d_{31}\epsilon^{10} & h^d_{32}\epsilon^4 & h^d_{33}\epsilon^2 \end{array}\right)v_1. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E45.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Here,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ \epsilon=\dfrac{\langle X\rangle}{M} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M412.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The form of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M_{u,d} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M413.jpg" xlink:type="simple" />
+               </inline-formula>
+               is similar to the corresponding matrices in Refs. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+               ,
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ]. However, the only difference is that the elements 21 and 31 of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M_d $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M414.jpg" xlink:type="simple" />
+               </inline-formula>
+               are generated at a higher order compared to those in Refs. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+               ,
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ]. It is argued in Ref. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ] that the above mentioned elements do not affect quark masses and mixing if they are generated at higher order. Hence, after diagonalizing the above matrices, the masses and mixing angles for quarks, up to leading order in
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon| $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M415.jpg" xlink:type="simple" />
+               </inline-formula>
+               , are given by
+            </p>
+            <p>
+               <disp-formula>
+                  <label>46</label>
+                  <tex-math id="cpc_46_10_103101_E46">
+                     <?CDATA $ \begin{aligned}[b] & (m_t,m_c,m_u)\approx(|h^u_{33}|,|h^u_{22}||\epsilon|^2, |h^u_{11}-h^u_{12}h^u_{21}/h^u_{22}||\epsilon|^6)v_1, \\ & (m_b,m_s,m_d)\approx(|h^d_{33}||\epsilon|^2, |h^d_{22}||\epsilon|^4,|h^d_{11}||\epsilon|^6)v_1, \\ & |V_{us}|\approx\left|\frac{h^d_{12}}{h^d_{22}}- \frac{h^u_{12}}{h^u_{22}}\right||\epsilon|^2, \\ & |V_{cb}|\approx\left|\frac{h^d_{23}}{h^d_{33}}- \frac{h^u_{23}}{h^u_{33}}\right||\epsilon|^2, \\ & |V_{ub}|\approx\left|\frac{h^d_{13}}{h^d_{33}}- \frac{h^u_{12}h^d_{23}}{h^u_{22}h^d_{33}}- \frac{h^u_{13}}{h^u_{33}}\right||\epsilon|^4, \\ & {\rm arg}(V_{ub})\approx4{\rm arg}(\epsilon). \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E46.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Due to three Higgs doublets in our model, we have
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |v_1|^2+|v_2|^2+|v_3|^2 \approx(174\; {\rm GeV})^2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M416.jpg" xlink:type="simple" />
+               </inline-formula>
+               . To satisfy this, we take
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_1,v\sim174/\sqrt{2} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M417.jpg" xlink:type="simple" />
+               </inline-formula>
+               GeV. With this value for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ v_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M418.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we fit the expressions of Eq. (46) to the following best fit values [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+               ].
+            </p>
+            <p>
+               <disp-formula>
+                  <tex-math id="cpc_46_10_103101_E47-1">
+                     <?CDATA $ \begin{aligned}[b] & (m_t,m_c,m_u)=(172.76,1.27,2.16\times10^{-3})\; {\rm GeV}, \\ & (m_b,m_s,m_d)=(4.18\times10^3,93,4.67)\; {\rm MeV}, \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E47-1.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>47</label>
+                  <tex-math id="cpc_46_10_103101_E47">
+                     <?CDATA $ \begin{aligned}[b] & (|V_{us}|,|V_{cb}|,|V_{ub}|)=(0.2245,0.041,0.00382), \\ & {\rm arg}(V_{ub})=-1.196 \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E47.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               After the abovementioned fitting, we give a sample set of numerical values with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/5.5 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M419.jpg" xlink:type="simple" />
+               </inline-formula>
+               as follows.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>48</label>
+                  <tex-math id="cpc_46_10_103101_E48">
+                     <?CDATA $ \begin{aligned}[b] & (|h^u_{33}|,|h^u_{22}|, |h^u_{11}-h^u_{12}h^u_{21}/h^u_{22}|) \approx(1.4,0.31,0.49), \\ & (|h^d_{33}|,|h^d_{22}|,|h^d_{11}|)\approx (1.03,0.69,1.05), \\ & (h^d_{12},h^u_{12},h^d_{23},h^u_{23}, h^d_{13},h^u_{13})\\\approx & (1.49,-1.45,0.69,-0.8,1.12,1.0), \\ & {\rm arg}(\epsilon)\approx-0.3. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E48.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               From the numerical values given above, we can see that the magnitudes of all Yukawa couplings are less than about 1.5. We have considered numerical values with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/6 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M420.jpg" xlink:type="simple" />
+               </inline-formula>
+               . However, in this case, some of the Yukawa couplings can become larger than 2.0. Hence, with
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/5.5 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M421.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal O}(1) $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M422.jpg" xlink:type="simple" />
+               </inline-formula>
+               Yukawa couplings, we can explain the quark masses and mixing pattern in our model. Since we expect new physics to appear around 1 TeV, we can take the cut-off scale of Eq. (44) to be
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ M\sim $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M423.jpg" xlink:type="simple" />
+               </inline-formula>
+               1 TeV. Now, for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\epsilon|=1/5.5 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M424.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ |\langle X\rangle|\sim $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M425.jpg" xlink:type="simple" />
+               </inline-formula>
+               181 GeV.
+            </p>
+         </sec>
+         <sec id="cpc_46_10_103101_s05-02">
+            <label>B.</label>
+            <title>UV completion</title>
+            <p>
+               Here, we present the UV completion for our model in order to explain the origin of non-renormalizable terms of Eq. (44). To achieve this UV completion, we follow the works of Refs. [
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+               ,
+               <xref ref-type="bibr" rid="cpc_46_10_103101_bib38">38</xref>
+               ]. The idea of this UV completion is to explain non-renormalizable terms following from a theory which is renormalizable at a high scale. Hence, we assume our model is renormalizable at and above the scale
+               <italic toggle="yes">M</italic>
+               and propose a flavor symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M426.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which is exactly above
+               <italic toggle="yes">M</italic>
+               . To generate non-renormalizable terms below
+               <italic toggle="yes">M</italic>
+               , we propose additional fields like flavons and VLQs, which transform under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M427.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The standard model quarks are charged under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M428.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry. However, the Higgs doublets and
+               <italic toggle="yes">X</italic>
+               field are singlets under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M429.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M430.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry is spontaneously broken when the flavons acquire VEVs around
+               <italic toggle="yes">M</italic>
+               , which is also the mass scale of VLQs. Here, we can see that our model should respect the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times K\times Z_2\times Z_3\times U(1)_{\rm F}$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M431.jpg" xlink:type="simple" />
+               </inline-formula>
+               above the scale
+               <italic toggle="yes">M</italic>
+               . However, below
+               <italic toggle="yes">M</italic>
+               , after integrating the heavy VLQs and flavon fields, our model should generate non-renormalizable terms of Eq. (44), which respect the symmetry
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P\times K\times Z_2\times Z_3$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M432.jpg" xlink:type="simple" />
+               </inline-formula>
+               .
+            </p>
+            <p>
+               Under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M433.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we denote the charges for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Q_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M434.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ u_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M435.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ d_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M436.jpg" xlink:type="simple" />
+               </inline-formula>
+               as
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ q_{jf} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M437.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ u_{jf} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M438.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ d_{jf} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M439.jpg" xlink:type="simple" />
+               </inline-formula>
+               , respectively. We propose only two flavon fields,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ F_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M440.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ F_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M441.jpg" xlink:type="simple" />
+               </inline-formula>
+               , whose charges under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M442.jpg" xlink:type="simple" />
+               </inline-formula>
+               are
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M443.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M444.jpg" xlink:type="simple" />
+               </inline-formula>
+               , respectively. Flavons are charged under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M445.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry but are otherwise singlets under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_2\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M446.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M447.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, flavons transform like the
+               <italic toggle="yes">X</italic>
+               field of our model. Now, to generate non-renormalizable terms for up-type quarks in Eq. (44), we introduce VLQs
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M448.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M449.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which are color triplets and their hypercharges are same as those of right-handed singlet up-quarks. Analogous to
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M450.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M451.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we introduce
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ G_{j{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M452.jpg" xlink:type="simple" />
+               </inline-formula>
+               and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ G_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M453.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which generate non-renormalizable terms for down-type quarks. The above VLQs are singlets under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $S U(2)$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M454.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry of the standard model and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K\times Z_3 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M455.jpg" xlink:type="simple" />
+               </inline-formula>
+               . These fields are charged under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M456.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry. Under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M457.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, they transform like the quark fields.
+            </p>
+            <p>
+               After describing the field content and their charge assignments in the UV completion of our model, we further explain the generation of non-renormalizable terms of Eq. (44). The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{33} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M458.jpg" xlink:type="simple" />
+               </inline-formula>
+               term in Eq. (44) is renormalizable, which can be generated in our model by taking
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ q_{3f}=u_{3f} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M459.jpg" xlink:type="simple" />
+               </inline-formula>
+               . To generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{32} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M460.jpg" xlink:type="simple" />
+               </inline-formula>
+               term in Eq. (44), we consider the below invariant terms in the UV completion.
+            </p>
+            <p>
+               <disp-formula>
+                  <label>49</label>
+                  <tex-math id="cpc_46_10_103101_E49">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{32}= & \bar{Q}_{3{\rm L}}\tilde{\phi}_1 K_{1{\rm R}}+ F_1^*\bar{K}_{1{\rm R}}K_{1{\rm L}}+ X \bar{K}_{1{\rm L}}K_{2{\rm R}}\\ & + F_2 \bar{K}_{2{\rm R}}K_{2{\rm L}}+ X \bar{K}_{2{\rm L}}u_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E49.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since the terms in the above equation are invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $C P$?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M461.jpg" xlink:type="simple" />
+               </inline-formula>
+               symmetry, the dimensionless Yukawa couplings should be real; these are
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal O}(1) $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M462.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which we have not written explicitly here. The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M463.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ K_{j{\rm L}},K_{j{\rm R}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M464.jpg" xlink:type="simple" />
+               </inline-formula>
+               can be fixed in terms of corresponding charges of quarks and flavons in such a way that the above equation is invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M465.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Similarly, the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M466.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for these VLQs can be assigned such that the above equation is invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M467.jpg" xlink:type="simple" />
+               </inline-formula>
+               . The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F}\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M468.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for VLQs of
+               <italic toggle="yes">K</italic>
+               -type are given in Eq. (57). When the flavons acquire VEVs, the VLQs in Eq. (49) acquire masses of the order of
+               <italic toggle="yes">M</italic>
+               . After integrating these heavy VLQs, terms in Eq. (49) generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{32} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M469.jpg" xlink:type="simple" />
+               </inline-formula>
+               term of Eq. (44).
+            </p>
+            <p>
+               By introducing more VLQs of
+               <italic toggle="yes">K</italic>
+               -type, the process described in the previous paragraph can be applied to generate other non-renormalizable terms of Eq. (44). Below we show the invariant Lagrangians of the form
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal L}^u_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M470.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^u_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M471.jpg" xlink:type="simple" />
+               </inline-formula>
+               term of Eq. (44), after integrating the heavy VLQs and flavons. The
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F}\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M472.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges for the VLQs in these Lagrangians can be seen in Eq. (57).
+            </p>
+            <p>
+               <disp-formula>
+                  <label>50</label>
+                  <tex-math id="cpc_46_10_103101_E50">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{31}= & \bar{Q}_{3{\rm L}}\tilde{\phi}_1 K_{1{\rm R}}+ F_1^*\bar{K}_{1{\rm R}}K_{1{\rm L}}+ X \bar{K}_{1{\rm L}}K_{2{\rm R}}+ F_2 \bar{K}_{2{\rm R}}K_{2{\rm L}}+ X \bar{K}_{2{\rm L}}K_{3{\rm R}}+ F_2 \bar{K}_{3{\rm R}}K_{3{\rm L}} + X \bar{K}_{3{\rm L}}K_{4{\rm R}}+ M \bar{K}_{4{\rm R}}K_{4{\rm L}}\\ & +X\bar{K}_{4{\rm L}}u_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E50.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>51</label>
+                  <tex-math id="cpc_46_10_103101_E51">
+                     <?CDATA $ \mathcal{L}^u_{23}= \bar{Q}_{2{\rm L}}\tilde{\phi}_1K_{5{\rm R}}+M\bar{K}_{5{\rm R}}K_{5{\rm L}}+X \bar{K}_{5{\rm L}}K_{6{\rm R}}+ F_1 \bar{K}_{6{\rm R}}K_{6{\rm L}}+X \bar{K}_{6{\rm L}}u_{3{\rm R}}+{\rm h.c}. $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E51.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>52</label>
+                  <tex-math id="cpc_46_10_103101_E52">
+                     <?CDATA $ \mathcal{L}^u_{22}= \bar{Q}_{2{\rm L}}\tilde{\phi}_1K_{5{\rm R}}+M\bar{K}_{5{\rm R}}K_{5{\rm L}}+ X\bar{K}_{5{\rm L}}K_{7{\rm R}}+F_2 \bar{K}_{7{\rm R}}K_{7{\rm L}}+X\bar{K}_{7{\rm L}}u_{2{\rm R}}+{\rm h.c}. $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E52.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>53</label>
+                  <tex-math id="cpc_46_10_103101_E53">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{21}= & \bar{Q}_{2L}\tilde{\phi}_1K_{5{\rm R}}+M\bar{K}_{5{\rm R}}K_{5{\rm L}}+X\bar{K}_{5{\rm L}}K_{7{\rm R}}+F_2 \bar{K}_{7{\rm R}}K_{7{\rm L}}+X \bar{K}_{7{\rm L}}K_{8{\rm R}}+M\bar{K}_{8{\rm R}}K_{8{\rm L}}+ +X\bar{K}_{8{\rm L}}K_{9{\rm R}}+F_2\bar{K}_{9{\rm R}}K_{9{\rm L}}\\ & +X\bar{K}_{9{\rm L}}u_{1{\rm R}}+{\rm h.c}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E53.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>54</label>
+                  <tex-math id="cpc_46_10_103101_E54">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{11}= & \bar{Q}_{1{\rm L}}\tilde{\phi}_1K_{10{\rm R}}+F_2 \bar{K}_{10{\rm R}}K_{10{\rm L}}+X\bar{K}_{10{\rm L}}K_{11{\rm R}}+F_2 \bar{K}_{11{\rm R}}K_{11{\rm L}} +X\bar{K}_{11{\rm L}}K_{12{\rm R}} F_2\bar{K}_{12{\rm R}}K_{12{\rm L}}+X\bar{K}_{12{\rm L}}K_{13{\rm R}}\\ & +F_2 \bar{K}_{13{\rm R}}K_{13{\rm L}}+X\bar{K}_{13{\rm L}}K_{14{\rm R}}+F_2 \bar{K}_{14{\rm R}}K_{14{\rm L}} + X\bar{K}_{14{\rm L}}K_{15{\rm R}}+M\bar{K}_{15{\rm R}}K_{15{\rm L}}+X\bar{K}_{15{\rm L}}u_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E54.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>55</label>
+                  <tex-math id="cpc_46_10_103101_E55">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{12}= & \bar{Q}_{1{\rm L}}\tilde{\phi}_1K_{10{\rm R}}+F_2 \bar{K}_{10{\rm R}}K_{10{\rm L}}+X\bar{K}_{10{\rm L}}K_{11{\rm R}}+F_2 \bar{K}_{11{\rm R}}K_{11{\rm L}}+X\bar{K}_{11{\rm L}}K_{12{\rm R}} +F_2\bar{K}_{12{\rm R}}K_{12{\rm L}}+X\bar{K}_{12{\rm L}}K_{13{\rm R}}\\ & +F_2 \bar{K}_{13{\rm R}}K_{13{\rm L}}+X\bar{K}_{13{\rm L}}u_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E55.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>56</label>
+                  <tex-math id="cpc_46_10_103101_E56">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^u_{13}= & \bar{Q}_{1{\rm L}}\tilde{\phi}_1K_{10{\rm R}}+F_2 \bar{K}_{10{\rm R}}K_{10{\rm L}}+X\bar{K}_{10{\rm L}}K_{11{\rm R}}+F_2 \bar{K}_{11{\rm R}}K_{11{\rm L}}+X\bar{K}_{11{\rm L}}K_{12{\rm R}} +F_2\bar{K}_{12{\rm R}}K_{12{\rm L}}\\ & +X\bar{K}_{12{\rm L}}K_{16{\rm R}}+F_1 \bar{K}_{16{\rm R}}K_{16{\rm L}}+X\bar{K}_{16{\rm L}}u_{3{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E56.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>57</label>
+                  <tex-math id="cpc_46_10_103101_E57">
+                     <?CDATA $ \begin{aligned}[b] U(1)_{\rm F}\;:\; & K_{1{\rm R}}\rightarrow q_{3f},\quad K_{1{\rm L}}, K_{2{\rm R}}\rightarrow q_{3f}+f_1,\quad K_{2{\rm L}}, K_{3{\rm R}}\rightarrow q_{3f}+f_1-f_2, \quad K_{3{\rm L}},K_{4{\rm L}}, K_{4{\rm R}}\rightarrow q_{3f}+f_1-2f_2,\\ & K_{5{\rm R}}, K_{5{\rm L}},K_{6{\rm R}},K_{7{\rm R}}\rightarrow q_{2f} \quad K_{7{\rm L}},K_{8{\rm R}},K_{8{\rm L}},K_{9{\rm R}}\rightarrow q_{2f}-f_2,\quad K_{6{\rm L}}\rightarrow q_{2f}-f_1,\quad K_{9{\rm L}}\rightarrow q_{2f}-2 f_2, \\ & K_{10{\rm R}}\rightarrow q_{1f},\quad K_{10{\rm L}},K_{11{\rm R}}\rightarrow q_{1f}-f_2,\quad K_{11{\rm L}},K_{12{\rm R}}\rightarrow q_{1f}-2 f_2, \quad K_{12{\rm L}},K_{13{\rm R}},K_{16{\rm R}}\rightarrow q_{1f}-3 f_2, \\ & K_{13{\rm L}},K_{14{\rm R}}\rightarrow q_{1f}-4 f_2, \quad K_{14{\rm L}},K_{15{\rm R}},K_{15{\rm L}}\rightarrow q_{1f}-5 f_2,\quad K_{16{\rm L}},u_{3{\rm R}}\rightarrow q_{1f}-3 f_2-f_1. \\ Z_2 \;:\; & K_{1{\rm L}}, K_{1{\rm R}}, K_{3{\rm L}}, K_{3{\rm R}},K_{5{\rm L}}, K_{5{\rm R}},K_{8{\rm L}},K_{8{\rm R}}, K_{10{\rm L}},K_{10{\rm R}},K_{12{\rm L}},K_{12{\rm R}},K_{14{\rm L}},K_{14{\rm R}}, \rightarrow \rm{even},\\ & K_{2{\rm L}}, K_{2{\rm R}}, K_{4{\rm L}}, K_{4{\rm R}},K_{6{\rm L}},K_{6{\rm R}},K_{7{\rm L}}, K_{7{\rm R}},K_{9{\rm L}},K_{9{\rm R}},K_{11{\rm L}},K_{11{\rm R}}, K_{13{\rm L}},K_{13{\rm R}},K_{15{\rm R}},K_{15{\rm L}},K_{16{\rm L}},K_{16{\rm R}}\rightarrow \rm{odd}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E57.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since the Lagragians of Eqs. (49) –(56) are invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M473.jpg" xlink:type="simple" />
+               </inline-formula>
+               , we get relations among the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M474.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges of quarks and flavons. These relations can be consistently solved. Taking
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ q_{3f} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M475.jpg" xlink:type="simple" />
+               </inline-formula>
+               ,
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_1 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M476.jpg" xlink:type="simple" />
+               </inline-formula>
+               , and
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ f_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M477.jpg" xlink:type="simple" />
+               </inline-formula>
+               as independent variables, the above mentioned relations can be expressed as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>58</label>
+                  <tex-math id="cpc_46_10_103101_E58">
+                     <?CDATA $ \begin{aligned}[b] & q_{2f}=q_{3f}+f_1,\quad q_{1f}=q_{3f}+f_1+3f_2,\quad u_{3f}=q_{3f},\quad \\ & u_{2f}=q_{3f}+f_1-f_2,\quad u_{1f}=q_{3f}+f_1-2f_2. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E58.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               The procedure described above has been applied in order to generate non-renormalizable terms for down-type quarks of Eq. (44). In this case, we introduce VLQs
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ G_{i{\rm R}},G_{i{\rm L}} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M478.jpg" xlink:type="simple" />
+               </inline-formula>
+               , where
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ i=1,\cdots,30 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M479.jpg" xlink:type="simple" />
+               </inline-formula>
+               . Below, we give invariant Lagrangians in the form of
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ {\cal L}^d_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M480.jpg" xlink:type="simple" />
+               </inline-formula>
+               , which generate the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ h^d_{ij} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M481.jpg" xlink:type="simple" />
+               </inline-formula>
+               term in Eq. (44), after integrating the heavy VLQs and flavons. Since these Lagrangians are invariant under the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F}\times Z_2 $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M482.jpg" xlink:type="simple" />
+               </inline-formula>
+               , the charges of VLQs under this symmetry are fixed in terms of corresponding charges of quarks and flavons. These charges are given in Eq. (68).
+            </p>
+            <p>
+               <disp-formula>
+                  <label>59</label>
+                  <tex-math id="cpc_46_10_103101_E59">
+                     <?CDATA $ \mathcal{L}^d_{33}= \bar{Q}_{3{\rm L}}\phi_1 G_{1{\rm R}}+ F_1 \bar{G}_{1{\rm R}}G_{1{\rm L}}+X \bar{G}_{1{\rm L}}G_{2{\rm R}}+ F_1 \bar{G}_{2{\rm R}}G_{2{\rm L}}+ X \bar{G}_{2{\rm L}}d_{3{\rm R}}+{\rm h.c}.. $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E59.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>60</label>
+                  <tex-math id="cpc_46_10_103101_E60">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{32}= & \bar{Q}_{3{\rm L}}\phi_1 G_{1{\rm R}}+ F_1 \bar{G}_{1{\rm R}}G_{1{\rm L}}+ X \bar{G}_{1{\rm L}}G_{2{\rm R}}+ F_1 \bar{G}_{2{\rm R}}G_{2{\rm L}}+ X \bar{G}_{2{\rm L}}G_{3{\rm R}} + M \bar{G}_{3{\rm R}}G_{3{\rm L}} + X \bar{G}_{3{\rm L}}G_{4{\rm R}}\\ & + F_2^*\bar{G}_{4{\rm R}}G_{4{\rm L}}+ X \bar{G}_{4{\rm L}}d_{2{\rm R}}+ {\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E60.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>61</label>
+                  <tex-math id="cpc_46_10_103101_E61">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{23} = & \bar{Q}_{2{\rm L}}\phi_1 G_{5{\rm R}}+ F_1 \bar{G}_{5{\rm R}}G_{5{\rm L}}+X\bar{G}_{5{\rm L}}G_{6{\rm R}}+F_1 \bar{G}_{6{\rm R}}G_{6{\rm L}}+X \bar{G}_{6{\rm L}}G_{7{\rm R}} +F_1 \bar{G}_{7{\rm R}}G_{7{\rm L}}+ X \bar{G}_{7{\rm L}}G_{8{\rm R}}\\ & +M \bar{G}_{8{\rm R}}G_{8{\rm L}}+\bar{G}_{8{\rm L}}d_{3{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E61.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>62</label>
+                  <tex-math id="cpc_46_10_103101_E62">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{22}= & \bar{Q}_{2{\rm L}}\phi_1 G_{5{\rm R}}+ F_1 \bar{G}_{5{\rm R}}G_{5{\rm L}}+X\bar{G}_{5{\rm L}}G_{6{\rm R}}+F_1 \bar{G}_{6{\rm R}}G_{6{\rm L}}+X \bar{G}_{6{\rm L}}G_{7{\rm R}} +F_1 \bar{G}_{7{\rm R}}G_{7{\rm L}}+X\bar{G}_{7{\rm L}}G_{9{\rm R}}\\ & +F_2^* \bar{G}_{9{\rm R}}G_{9{\rm L}}+X\bar{G}_{9{\rm L}}d_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E62.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>63</label>
+                  <tex-math id="cpc_46_10_103101_E63">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{13}= & \bar{Q}_{1{\rm L}}\phi_1 G_{10{\rm R}}+F_1 \bar{G}_{10{\rm R}}G_{10{\rm L}}+X\bar{G}_{10{\rm L}}G_{11{\rm R}}+ +F_1 \bar{G}_{11{\rm R}}G_{11{\rm L}}+X\bar{G}_{11{\rm L}}G_{12{\rm R}} +F_1 \bar{G}_{12{\rm R}}G_{12{\rm L}}+X \bar{G}_{12{\rm L}}G_{13{\rm R}}\\ & +F_2 \bar{G}_{13{\rm R}}G_{13{\rm L}}+X \bar{G}_{13{\rm L}}G_{14{\rm R}}+F_2 \bar{G}_{14{\rm R}}G_{14{\rm L}}+X \bar{G}_{14{\rm L}}G_{15{\rm R}}+F_2 \bar{G}_{15{\rm R}}G_{15{\rm L}}+X\bar{G}_{15{\rm L}}d_{3{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E63.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>64</label>
+                  <tex-math id="cpc_46_10_103101_E64">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{12}= & \bar{Q}_{1{\rm L}}\phi_1 G_{10{\rm R}}+F_1 \bar{G}_{10{\rm R}}G_{10{\rm L}}+X\bar{G}_{10{\rm L}}G_{11{\rm R}}+F_1 \bar{G}_{11{\rm R}}G_{11{\rm L}}+X\bar{G}_{11{\rm L}}G_{12{\rm R}} +F_1 \bar{G}_{12{\rm R}}G_{12{\rm L}}+X \bar{G}_{12{\rm L}}G_{13{\rm R}}\\ & +F_2 \bar{G}_{13{\rm R}}G_{13{\rm L}}+X \bar{G}_{13{\rm L}}G_{14{\rm R}}+F_2 \bar{G}_{14{\rm R}}G_{14{\rm L}} X \bar{G}_{14{\rm L}}G_{16{\rm R}}+M \bar{G}_{16{\rm R}}G_{16{\rm L}}+X\bar{G}_{16{\rm L}}d_{2{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E64.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>65</label>
+                  <tex-math id="cpc_46_10_103101_E65">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{11}= & \bar{Q}_{1{\rm L}}\phi_1 G_{10{\rm R}}+F_1 \bar{G}_{10{\rm R}}G_{10{\rm L}}+X\bar{G}_{10{\rm L}}G_{11{\rm R}} +F_1 \bar{G}_{11{\rm R}}G_{11{\rm L}}+X\bar{G}_{11{\rm L}}G_{12{\rm R}} +F_1 \bar{G}_{12{\rm R}}G_{12{\rm L}}+X\bar{G}_{12{\rm L}}G_{17{\rm R}}\\ & +F_1 \bar{G}_{17{\rm R}}G_{17{\rm L}}+X\bar{G}_{17{\rm L}}G_{18{\rm R}} +F_1\bar{G}_{18{\rm R}}G_{18{\rm L}} +X\bar{G}_{18{\rm L}}G_{19{\rm R}}+F_2^* \bar{G}_{19{\rm R}}G_{19{\rm L}}+X\bar{G}_{19{\rm L}}d_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E65.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>66</label>
+                  <tex-math id="cpc_46_10_103101_E66">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{21}= & \bar{Q}_{2L}\phi_1 M_{5R}+ F_1 \bar{G}_{5R}G_{5L}+X\bar{G}_{5L}G_{6R}+F_1 \bar{G}_{6R}G_{6L}+X \bar{G}_{6L}G_{7R}+F_1 \bar{G}_{7R}G_{7L} +X\bar{G}_{7L}G_{9R}+F_2^* \bar{G}_{9R}G_{9L} \\ & + X\bar{G}_{9L}G_{20R} + F_2^*\bar{G}_{20R}G_{20L} +X\bar{G}_{20L}G_{21R}+F_2^* \bar{G}_{21R}G_{21L} + X\bar{G}_{21L}G_{22R}+ F_2^* \bar{G}_{22R}G_{22L}\\ & + X\bar{G}_{22L}G_{23R} +F_1 \bar{G}_{23R}G_{23L} + X \bar{G}_{23L}G_{24R} + F_1\bar{G}_{24R}G_{24L} + X \bar{G}_{24L}d_{1R}+h.c.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E66.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>67</label>
+                  <tex-math id="cpc_46_10_103101_E67">
+                     <?CDATA $ \begin{aligned}[b] \mathcal{L}^d_{31}= & \bar{Q}_{3{\rm L}}\phi_1 G_{1{\rm R}}+ F_1 \bar{G}_{1{\rm R}}G_{1{\rm L}}+ X \bar{G}_{1{\rm L}}G_{2{\rm R}}+ F_1 \bar{G}_{2{\rm R}}G_{2{\rm L}}+ X\bar{G}_{2{\rm L}}G_{25{\rm R}} +F_1\bar{G}_{25{\rm R}}G_{25{\rm L}} + X\bar{G}_{25{\rm L}}G_{26{\rm R}} + F_1 \bar{G}_{26{\rm R}}G_{26{\rm L}} \\ & + X\bar{G}_{26{\rm L}}G_{27{\rm R}} + F_2^*\bar{G}_{27{\rm R}}G_{27{\rm L}}+X\bar{G}_{27{\rm L}}G_{28{\rm R}}+F_2^* \bar{G}_{28{\rm R}}G_{28{\rm L}} + X\bar{G}_{28{\rm L}}G_{29{\rm R}} \\ & + F_2^*\bar{G}_{29{\rm R}}G_{29{\rm L}} +X\bar{G}_{29{\rm L}}G_{30{\rm R}} +F_2^*\bar{G}_{30{\rm R}}G_{30{\rm L}} + X \bar{G}_{30L}d_{1{\rm R}}+{\rm h.c}.. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E67.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <tex-math id="cpc_46_10_103101_E68-1">
+                     <?CDATA $ \begin{aligned}[b] U(1)_F \;\;:\;\; & G_{1{\rm R}}\rightarrow q_{3f},\quad G_{1{\rm L}},G_{2{\rm R}}\rightarrow q_{3f}-f_1\quad G_{2{\rm L}},G_{3{\rm R}},G_{3{\rm L}},G_{4{\rm R}},G_{25{\rm R}}\rightarrow q_{3f}-2f_1, \\ & G_{4{\rm L}}\rightarrow q_{3f}-2f_1+f_2,\quad G_{5{\rm R}}\rightarrow q_{2f},\quad G_{5{\rm L}},G_{6{\rm R}}\rightarrow q_{2f}-f_1, \\ & G_{6{\rm L}},G_{7{\rm R}}\rightarrow q_{2f}-2f_1,\quad G_{7{\rm L}},G_{8{\rm R}},G_{8{\rm L}},G_{9{\rm R}}\rightarrow q_{2f}-3 f_1 \\ & G_{9{\rm L}},G_{20{\rm R}}\rightarrow q_{2f}-3 f_1+f_2,\quad G_{10{\rm R}}\rightarrow q_{1f},\quad G_{10{\rm L}},G_{11{\rm R}}\rightarrow q_{1f}-f_1, \\ & G_{11{\rm L}},G_{12{\rm R}}\rightarrow q_{1f}-2 f_1,\quad G_{12{\rm L}},G_{13{\rm R}},G_{17{\rm R}}\rightarrow q_{1f}-3 f_1, \\ & G_{13{\rm L}},G_{14{\rm R}}\rightarrow q_{1f}-3 f_1-f_3,\quad G_{14{\rm L}},G_{15{\rm R}},G_{16{\rm L}},G_{16{\rm R}}\rightarrow q_{1f}-3 f_1-2 f_2 \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E68-1.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               <disp-formula>
+                  <label>68</label>
+                  <tex-math id="cpc_46_10_103101_E68">
+                     <?CDATA $ \begin{aligned}[b] & G_{15{\rm L}}\rightarrow q_{1f}-3 f_1-3f_3,\quad G_{17{\rm L}},G_{18{\rm R}}\rightarrow q_{1f}-4 f_1,\quad G_{18{\rm L}},G_{19{\rm R}}\rightarrow q_{1f}-5 f_1, \\ & G_{19{\rm L}}\rightarrow q_{1f}-5 f_1-f_2,\quad G_{20{\rm L}},G_{21{\rm R}}\rightarrow q_{2f}-3 f_1+2 f_2, \\ & G_{21{\rm L}},G_{22{\rm R}}\rightarrow q_{2f}-3f_1+3 f_2,\quad G_{22{\rm L}},G_{23{\rm R}}\rightarrow q_{2f}-3 f_1+4 f_2, \\ & G_{23{\rm L}},G_{24{\rm R}}\rightarrow q_{2f}–4 f_1+4 f_2,\quad G_{24{\rm L}}\rightarrow q_{2f}-5 f_1+4 f_2, \\ & G_{25{\rm L}},G_{26{\rm R}}\rightarrow q_{3f}-3 f_1,\quad G_{26{\rm L}},G_{27{\rm R}{\rm R}}\rightarrow q_{3f}-4 f_1,\quad G_{27{\rm L}}, G_{28{\rm R}}\rightarrow q_{3f}-4 f_1+f_2, \\ & G_{28{\rm L}},G_{29{\rm R}}\rightarrow q_{3f}-4 f_1+2 f_2,\quad G_{29{\rm L}},G_{30{\rm R}}\rightarrow q_{3f}-4 f_1+3 f_2, \\ & g_{30{\rm L}}\rightarrow q_{3f}-4 f_1+4 f_2. \\ Z_2 \;\;:\;\; & G_{1{\rm L}},G_{1{\rm R}}, G_{3{\rm L}}, G_{3{\rm R}}, G_{5{\rm L}}, G_{5{\rm R}}, G_{7{\rm L}}, G_{7{\rm R}}, G_{10{\rm L}}, G_{10{\rm R}},G_{12{\rm L}}, G_{12{\rm R}}, G_{14{\rm L}}, G_{14{\rm R}}, G_{18{\rm L}}, \\ & G_{18{\rm R}}, G_{20{\rm L}}, G_{20{\rm R}}, G_{22{\rm L}}, G_{22{\rm R}}, G_{24{\rm L}}, G_{24{\rm R}}, G_{25{\rm L}}, G_{25{\rm R}}, G_{27{\rm L}}, G_{27{\rm R}}, G_{29{\rm L}}, G_{29{\rm R}} \rightarrow \rm{even}. \\ & G_{2{\rm L}},G_{2{\rm R}}, G_{4{\rm L}}, G_{4{\rm R}}, G_{6{\rm L}}, G_{6{\rm R}}, G_{8{\rm L}}, G_{8{\rm R}}, G_{9{\rm L}}, G_{9{\rm R}}, G_{11{\rm L}}, G_{11R}, G_{13{\rm L}}, G_{13{\rm R}},G_{15{\rm L}}, \\ & G_{15{\rm R}}, G_{16{\rm L}}, G_{16{\rm R}}, G_{17{\rm L}}, G_{17{\rm R}}, G_{19{\rm L}}, G_{19{\rm R}}, G_{21{\rm L}}, G_{21{\rm R}}, G_{23{\rm L}}, G_{23{\rm R}}, G_{26{\rm L}}, G_{26{\rm R}}, \\ & G_{28{\rm L}}, G_{28{\rm R}}, G_{30{\rm L}}, G_{30{\rm R}} \rightarrow \rm{odd}. \end{aligned} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E68.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               Since the Lagrangians in Eqs. (59)–(67) are invariant under
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M483.jpg" xlink:type="simple" />
+               </inline-formula>
+               , nine relations emerge among the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M484.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges of quarks and flavons. These relations can be solved consistently along with Eq. (58). After doing this, the
+               <inline-formula>
+                  <tex-math>
+                     <?CDATA $ U(1)_{\rm F} $?>
+                  </tex-math>
+                  <inline-graphic xlink:href="cpc_46_10_103101_M485.jpg" xlink:type="simple" />
+               </inline-formula>
+               charges of singlet down-type quarks can be expressed as
+            </p>
+            <p>
+               <disp-formula>
+                  <label>69</label>
+                  <tex-math id="cpc_46_10_103101_E69">
+                     <?CDATA $ \begin{equation} d_{3f}=q_{3f}-2f_1,\quad d_{2f}=q_{3f}-2f_1+f_2,\quad d_{1f}=q_{3f}-4f_1+4f_2. \end{equation} $?>
+                  </tex-math>
+                  <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E69.jpg" xlink:type="simple" />
+               </disp-formula>
+            </p>
+            <p>
+               In this section, we have described our model for the quark sector as well as the UV completion to it. As part of this whole construction, we introduce extra fields and symmetries into our model, which are summarized in
+               <xref ref-type="table" rid="cpc_46_10_103101_t3">Table 3</xref>
+               .
+            </p>
+            <table-wrap id="cpc_46_10_103101_t3" orientation="portrait" position="float">
+               <label>Table 3</label>
+               <caption id="cpc_46_10_103101_tc3">
+                  <p>Additional fields and symmetry, along with their roles, in the quark sector of our model.</p>
+               </caption>
+               <table>
+                  <thead>
+                     <tr>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Additional field</th>
+                        <th align="center" colspan="1" rowspan="1" valign="middle">Role</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <italic toggle="yes">X</italic>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           to generate hierarchy in quark masses and also
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $C P$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M486.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           violation in quark sector
+                        </td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ F_1,F_2 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M487.jpg" xlink:type="simple" />
+                           </inline-formula>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate masses for VLQs in the UV completion of our model</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $K_{i{\rm L}},K_{i{\rm R}}$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M488.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           (
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ i=1,\cdots,16 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M489.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           )
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate effective Yukawa couplings for up-type quarks from UV completion our model</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $G_{i{\rm L} },G_{i{\rm R} }$?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M490.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           (
+                           <inline-formula>
+                              <tex-math>
+                                 <?CDATA $ i=1,\cdots,30 $?>
+                              </tex-math>
+                              <inline-graphic xlink:href="cpc_46_10_103101_M491.jpg" xlink:type="simple" />
+                           </inline-formula>
+                           )
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate effective Yukawa couplings for down-type quarks from UV completion our model</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Additional symmetry</td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">Role</td>
+                     </tr>
+                     <tr>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">
+                           <italic toggle="yes">U</italic>
+                           (1)
+                           <sub>
+                              <italic toggle="yes">F</italic>
+                           </sub>
+                        </td>
+                        <td align="center" colspan="1" rowspan="1" valign="middle">to generate invariant terms in the UV completion of our model</td>
+                     </tr>
+                  </tbody>
+               </table>
+            </table-wrap>
+         </sec>
+      </sec>
+      <sec id="cpc_46_10_103101_s06">
+         <label>VI.</label>
+         <title>FULL SCALAR POTENTIAL</title>
+         <p>
+            In Sec. III, we have detailed the analysis of scalar potential for the model described in Sec. II. However, the model in Sec. II addresses problems related to the masses of leptons. Later, within the framework of that model, we have addressed the hierarchy in the masses of quark fields in Sec. V. Concurrently, we have introduced additional singlet scalar fields:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,\;F_1,\;F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M492.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which can give extra terms with the doublet and triplet Higgses in the scalar potential. These extra terms may change the results derived in Sec. III. For this purpose, in this section, we give the full scalar potential of our model. After minimizing the full scalar potential, we demonstrate that the above mentioned singlet scalar fields do not change the main conclusions of the analysis made in Sec. III. We recall the following main conclusions of Sec. III: (i) triplet Higgs acquire real VEV, (ii) VEVs of doublet Higgses
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M493.jpg" xlink:type="simple" />
+            </inline-formula>
+            explain the hierarchy between
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M494.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M495.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>The full scalar potential of our model is</p>
+         <p>
+            <disp-formula>
+               <label>70</label>
+               <tex-math id="cpc_46_10_103101_E70">
+                  <?CDATA $ \begin{array}{*{20}{l}} V_{{\rm full}}=V_{\rm inv}+ V_{X,F_1,F_2}+V_{\not{K}}+V^\prime_{\not{K}}. \end{array} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E70.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M496.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the invariant scalar potential of our model, arising due to the singlet fields
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,\;F_1,\;F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M497.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V^\prime_{\not{K}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M498.jpg" xlink:type="simple" />
+            </inline-formula>
+            contains potential terms due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,\;F_1,\;F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M499.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which violate
+            <italic toggle="yes">K</italic>
+            -symmetry explicitly. Recall that the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv}+V_{\not{K}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M500.jpg" xlink:type="simple" />
+            </inline-formula>
+            has been discussed in Sec. III. First we find a minimum for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv}+V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M501.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Further, we study the shift in this minimum due to the presence of
+            <italic toggle="yes">K</italic>
+            -violating terms. In this regard, the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M502.jpg" xlink:type="simple" />
+            </inline-formula>
+            , after applying the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z_3 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M503.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, has been studied in Sec. III.C. Here, we verify whether this minimization can be affected by
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M504.jpg" xlink:type="simple" />
+            </inline-formula>
+            . The form for this potential is given below.
+         </p>
+         <p>
+            <disp-formula>
+               <label>71</label>
+               <tex-math id="cpc_46_10_103101_E71">
+                  <?CDATA $ \begin{aligned}[b]\\ V_{X,F_1,F_2}= & -m_X^2 (X^*X)-m_{F_1}^2(F_1^* F_1)-m_{F_2}^2(F_2^* F_2)+\lambda_X (X^*X)^2 +\lambda_{F_1}(F_1^* F_1)^2 +\lambda_{F_2}(F_2^* F_2)^2+ A(X^2+{X^*}^2)\\ & +B(X^4+{X^*}^4)+ \lambda_X^{\prime}(X^3X^{*}+{X^*}^3X) +\lambda_{F_1F_2}(F_1^* F_1)(F_2^* F_2) +\lambda_{F_1 X}(F_1^*F_1)(X^*X) +\lambda_{F_1 X}^{\prime}(F_1^*F_1)(X^2+{X^*}^2) \\ & +\lambda_{F_2 X}(F_2^*F_2)(X^*X)+\lambda_{F_2 X}^{\prime}(F_2^*F_2)(X^2+{X^*}^2) +\lambda_{\phi_1 X}(\phi_1^{\dagger}\phi_1)(X^*X) +\lambda_{\phi_1 X}^{\prime}(\phi_1^{\dagger}\phi_1)(X^2+{X^*}^2)\\ & +\lambda_{\phi_2 X}(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3)(X^*X)+\lambda_{\phi_2 X}^{\prime}(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3)(X^2+{X^*}^2)+\lambda_{\Delta X}\rm Tr(\Delta^{\dagger}\Delta)(X^*X) +\lambda_{\Delta X}^{\prime}{\rm Tr}(\Delta^{\dagger}\Delta)(X^2+{X^*}^2)\\ & +\lambda_{F_1\phi_1}(F_1^*F_1)(\phi_1^{\dagger}\phi_1)+\lambda_{F_2\phi_1}(F_2^*F_2)(\phi_1^{\dagger}\phi_1) +\lambda_{F_1\phi_2}(F_1^*F_1)(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3)+\lambda_{F_2\phi_2}(F_2^*F_2)(\phi_2^{\dagger}\phi_2+\phi_3^{\dagger}\phi_3) \\ & +\lambda_{F_1\Delta}{\rm Tr}(\Delta^{\dagger}\Delta)(F_1^*F_1)+\lambda_{F_2\Delta}{\rm Tr}(\Delta^{\dagger}\Delta)(F_2^*F_2). \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E71.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above equation, all parameters are real due to hermiticity and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M505.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry.
+         </p>
+         <p>
+            In Eq. (71),
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M506.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M507.jpg" xlink:type="simple" />
+            </inline-formula>
+            appear in the form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_1^*F_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M508.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_2^*F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M509.jpg" xlink:type="simple" />
+            </inline-formula>
+            , respectively. As a result, we can consider the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M510.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M511.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be real. Hence, we can parameterize the VEVs for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M512.jpg" xlink:type="simple" />
+            </inline-formula>
+            as
+         </p>
+         <p>
+            <disp-formula>
+               <label>72</label>
+               <tex-math id="cpc_46_10_103101_E72">
+                  <?CDATA $ \begin{array}{*{20}{l}} \langle X \rangle =v_{X}{\rm e}^{{\rm i}\theta_{X}},\quad \langle F_1 \rangle =v_{f_1},\quad \langle F_2 \rangle =v_{f_2}. \end{array} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E72.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M513.jpg" xlink:type="simple" />
+            </inline-formula>
+            is the phase in the VEV of
+            <italic toggle="yes">X</italic>
+            . After using the above VEVs and Eq. (17) in Eq. (71), we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>73</label>
+               <tex-math id="cpc_46_10_103101_E73">
+                  <?CDATA $ \begin{aligned}[b] \langle V_{X,F_1,F_2}\rangle \ni & 2 v_X^2\Big[ A +\lambda_X^{\prime} v_X^2 +\lambda_{\phi_1 X}^{\prime}v_1^2+\lambda_{\phi_2 X}^{\prime}v^2+\lambda_{\Delta X}{v^{\prime}}^2\\ & +\lambda_{F_1 X}^{\prime}v_{f_1}^2+ +\lambda_{F_2 X}^{\prime}v_{f_2}^2\Big]\cos2\theta_X +2 B v_X^4 \cos4\theta_{X}. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E73.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above equation, we have not written constant terms which do not contain phases of the VEVs of the fields. It is possible to notice that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M514.jpg" xlink:type="simple" />
+            </inline-formula>
+            do not mix with the phases in the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M515.jpg" xlink:type="simple" />
+            </inline-formula>
+            and Δ. Hence, the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{\rm inv}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M516.jpg" xlink:type="simple" />
+            </inline-formula>
+            , which is presented in Sec. III.C, is not affected due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{X,F_1,F_2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M517.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Consequently, Δ can acquire a real VEV, while Eq. (34) remains valid. From the minimization of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{X,F_1,F_2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M518.jpg" xlink:type="simple" />
+            </inline-formula>
+            with respect to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M519.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we get
+         </p>
+         <p>
+            <disp-formula>
+               <label>74</label>
+               <tex-math id="cpc_46_10_103101_E74">
+                  <?CDATA $ \begin{aligned}[b] \cos2\theta_{X}= & -\frac{1}{4 B v_X^2}\Big[A+\lambda_X^{\prime}v_X^2+\lambda_{\phi_1 X}^{\prime}v_1^2+\lambda_{\phi_2 X}^{\prime}v^2\\ & +\lambda_{\Delta X}^{\prime}{v^{\prime}}^2+\lambda_{F_1 X}^{\prime}v_{f_1}^2+\lambda_{F_2 X}^{\prime}v_{f_2}^2\Big]. \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E74.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            The above relation corresponds to the minimum for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_X $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M520.jpg" xlink:type="simple" />
+            </inline-formula>
+            , provided the below condition is satisfied.
+         </p>
+         <p>
+            <disp-formula>
+               <label>75</label>
+               <tex-math id="cpc_46_10_103101_E75">
+                  <?CDATA $ \begin{aligned}[b] 16 B^2 v_X^4 \gt & \Big[A+\lambda_X^{\prime}v_X^2+\lambda_{\phi_1 X}^{\prime}v_1^2+\lambda_{\phi_2 X}^{\prime}v^2+\lambda_{\Delta X}^{\prime}{v^{\prime}}^2\\ & +\lambda_{F_1 X}^{\prime}v_{f_1}^2+\lambda_{F_2 X}^{\prime}v_{f_2}^2\Big]^2 . \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E75.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here we have shown that
+            <italic toggle="yes">X</italic>
+            can acquire complex VEV. This must be achieved to generate the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ CP $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M521.jpg" xlink:type="simple" />
+            </inline-formula>
+            violation in the quark sector, which is discussed in Sec. V.
+         </p>
+         <p>
+            After minimizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle V_{\rm inv}\rangle+\langle V_{X,F_1,F_2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M522.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we have shown that the minimum can be given by Eqs. (34) and (74). This minimum can be shifted by small amount due to
+            <italic toggle="yes">K</italic>
+            -violating terms. Terms in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M523.jpg" xlink:type="simple" />
+            </inline-formula>
+            are presented in Sec. III. Below we give the form for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M524.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            <disp-formula>
+               <label>76</label>
+               <tex-math id="cpc_46_10_103101_E76">
+                  <?CDATA $ \begin{aligned}[b] V_{\not{K}}^{\prime}= & \delta\lambda_{\phi_2 X}(\phi_2^{\dagger}\phi_2)(X^*X)+\delta\lambda_{\phi_2 X}^{\prime}(\phi_3^{\dagger}\phi_3)(X^*X)+\delta\lambda_{\phi X}(\phi_2^{\dagger}\phi_2)(X^2+{X^*}^2) +\delta\lambda_{\phi X}^{\prime}(\phi_3^{\dagger}\phi_3)(X^2+{X^*}^2)\\ & +\delta \lambda_{\phi_2 F_1}(\phi_2^{\dagger}\phi_2)(F_1^{*}F_1)+\delta \lambda_{\phi_2 F_1}^{\prime}(\phi_3^{\dagger}\phi_3)(F_1^{*}F_1) +\delta \lambda_{\phi_2 F_2}(\phi_2^{\dagger}\phi_2)(F_2^{*}F_2)+\delta \lambda_{\phi_2 F_2}^{\prime}(\phi_3^{\dagger}\phi_3)(F_2^{*}F_2)\\ & +{\rm i}\delta\lambda_{21}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(X^*X) +{\rm i}\delta\lambda_{22}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(X^2+{X^*}^2)+{\rm i}\delta\lambda_{23}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(F_1^*F_1) +{\rm i}\delta\lambda_{24}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(F_2^*F_2). \end{aligned} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E76.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            All parameters in the above equation are real due to either
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M525.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry or hermiticity of the potential. These parameters should be small compared to those in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\rm inv}+V_{X,F_1,F_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M526.jpg" xlink:type="simple" />
+            </inline-formula>
+            , since the above potential violates
+            <italic toggle="yes">K</italic>
+            symmetry by a small amount. We can see that the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M527.jpg" xlink:type="simple" />
+            </inline-formula>
+            in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M528.jpg" xlink:type="simple" />
+            </inline-formula>
+            can give additional contribution to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M529.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_\zeta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M530.jpg" xlink:type="simple" />
+            </inline-formula>
+            in Eq. (36). Since the parameters of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M531.jpg" xlink:type="simple" />
+            </inline-formula>
+            are small, we can notice that the contribution due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M532.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be of the same order as the terms already obtained for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M533.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ f_\zeta $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M534.jpg" xlink:type="simple" />
+            </inline-formula>
+            in Eq. (36). As a result, the hierarchy in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M535.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M536.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be explained in our framework.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s07">
+         <label>VII.</label>
+         <title>PHENOMENOLOGY OF OUR MODEL</title>
+         <p>
+            In Secs. III and VI we have analyzed the minimum of the scalar potential of our model. One needs to study whether this minimum corresponds to a global or local minimum. Following the studies made in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib39">39</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib40">40</xref>
+            ], we expect some additional conditions to be imposed on the parameters of our model in order for the minimum of the potential in this work to be global. Nonetheless, we shall work on the vacuum stability of our scalar potential in future studies.
+         </p>
+         <p>
+            The scalar fields, which are proposed in our model, are: three Higgs doublets, one Higgs triplet and three singlet scalar fields. We can choose the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{\rm F} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M537.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry of our model to be gauged. As a result, after electroweak symmetry breaking, the following fields remain in the theory: one doubly charged scalar, three singly charged scalars, seven neutral scalars, and five pseudo scalars. In case I, which is described in Sec. III, the scalar fields belonging to the triplet Higgs can have masses around
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 10^{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M538.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV. Otherwise, we can choose the parameters in the scalar potential of our model in such a way that all the scalar fields can have masses less than or about 1 TeV. In the case where the masses for the scalar fields are less than 1 TeV, one can study the collider phenomenology. For this study, one needs to know the interaction of the scalar fields with the standard model particles. We can see that the scalar components of Higgs doublets and Higgs triplet have gauge interactions. For the field
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M539.jpg" xlink:type="simple" />
+            </inline-formula>
+            , it has Yukawa interactions with quark fields. Hence, the scalars belonging to doublet and triplet Higgses can be produced at the LHC experiment via gauge or strong interactions. After production, they will decay into standard model fields. In the case of singlet scalars
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ X,F_1,F_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M540.jpg" xlink:type="simple" />
+            </inline-formula>
+            , the flavons have Yukawa interactions with VLQs. Moreover, these flavons interact with doublet and triplet Higgses in the scalar potential. As for the
+            <italic toggle="yes">X</italic>
+            field, it has Yukawa interactions containing a VLQ and a right-handed quark field. Moreover,
+            <italic toggle="yes">X</italic>
+            has interactions with Higgs fields in the scalar potential. Since VLQs are color triplets, they can be produced at the LHC experiment via strong interactions. From the decay of these VLQs, one can produce the abovementioned singlet scalars in the LHC experiment. Studying the collider phenomenology of this model is beyond the scope of this work.
+         </p>
+         <p>
+            In the lepton sector of our model, the Yukawa couplings for charged leptons are diagonal. Hence, these Yukawa interactions are flavor conserving. In contrast, the Yukawa couplings for neutrinos are flavor violating. As a result, the singly and doubly charged triplet Higgs fields can drive flavor violating decays of the form
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \ell\to3\ell^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M541.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \ell\to\ell^\prime\gamma $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M542.jpg" xlink:type="simple" />
+            </inline-formula>
+            . However, it is stated in Sec. II that the Yukawa couplings for neutrinos are suppressed by about
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 10^{-3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M543.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, the branching ratios for the above mentioned decays are suppressed even if the components of the triplet Higgs can have masses around few hundred GeV. As a result, constraints due to non-observation of charged lepton flavor violating decays [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ] are satisfied in our model.
+         </p>
+         <p>
+            The phenomenology of our model in the quark sector is similar to that discussed in Ref. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ]. In this regard, the
+            <italic toggle="yes">X</italic>
+            field can cause flavor changing neutral currents at tree level in our model. Consequently, there can be mass splitting in the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ K^0-\bar{K}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M544.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D^0-\bar{D}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M545.jpg" xlink:type="simple" />
+            </inline-formula>
+            due to the mediation of
+            <italic toggle="yes">X</italic>
+            . We have estimated the above mentioned mass splittings, using the procedures described in Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib27">27</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib28">28</xref>
+            ]. For this purpose, we define
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \beta={v_1}/{M} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M546.jpg" xlink:type="simple" />
+            </inline-formula>
+            . In our calculations, we have taken
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \epsilon\sim\beta={1}/{5.5} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M547.jpg" xlink:type="simple" />
+            </inline-formula>
+            and the mass of
+            <italic toggle="yes">X</italic>
+            as 1 TeV. The Yukawa couplings for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ h^{d,u}_{12} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M548.jpg" xlink:type="simple" />
+            </inline-formula>
+            are given in Eq. (48). We have chosen
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ h_{21}^d\sim1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M549.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ h_{21}^u=-0.7 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M550.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Using the above set of parameters, we have found
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_{K}\approx 10^{-16} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M551.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_D\approx 10^{-15} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M552.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV. These numerical values are smaller than the corresponding current experimental values, which are as follows:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_{K}=3.5 \times 10^{-15} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M553.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \Delta m_D=2.35 \times 10^{-14} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M554.jpg" xlink:type="simple" />
+            </inline-formula>
+            GeV [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib18">18</xref>
+            ]. Hence, our model satisfies the constraints due to the mass splitting in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ K^0-\bar{K}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M555.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D^0-\bar{D}^0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M556.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            By choosing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_{\rm F} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M557.jpg" xlink:type="simple" />
+            </inline-formula>
+            to be gauged, the gauge boson corresponding to this symmetry,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M558.jpg" xlink:type="simple" />
+            </inline-formula>
+            , can be massive. The mixing between
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z-Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M559.jpg" xlink:type="simple" />
+            </inline-formula>
+            is constrained to be very small. In this regard, phenomenology due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M560.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be studied in our model. For more details about the phenomenology on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Z^\prime $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M561.jpg" xlink:type="simple" />
+            </inline-formula>
+            , see Refs. [
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib41">41</xref>
+            ,
+            <xref ref-type="bibr" rid="cpc_46_10_103101_bib42">42</xref>
+            ].
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s08">
+         <label>VIII.</label>
+         <title>CONCLUSIONS</title>
+         <p>
+            In this work, we have proposed a model, which explains the maximal values for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{23} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M562.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \delta_{CP} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M563.jpg" xlink:type="simple" />
+            </inline-formula>
+            in the lepton sector. To achieve this purpose, we have introduced three Higgs doublets and one Higgs triplet. This model is based on
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M564.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry and type II seesaw mechanism. To explain the above observables, the VEV of triplet Higgs should be real. Moreover, due to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \mu-\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M565.jpg" xlink:type="simple" />
+            </inline-formula>
+            reflection symmetry, the masses for muon and tau can be of the same order. After introducing the
+            <italic toggle="yes">K</italic>
+            symmetry and explicit violation of it by a small amount, we have studied the minimization of the scalar potential of our model. Thereafter, we have shown that the VEV of triplet Higgs can be real, apart from explaining the hierarchy in the muon and tau masses. In addition to predicting the above observables, the mass matrix for neutrinos in our model can make predictions about the neutrino mass ordering and smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M566.jpg" xlink:type="simple" />
+            </inline-formula>
+            , if the elements of this matrix satisfy certain conditions, which are given in Sec. IV. To explain these conditions, one has to propose a new mechanism in addition to
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M567.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. Although we do not have a mechanism to explain all the conditions given in Sec. IV, we have attempted to give one mechanism to explain condition (i) for the case of NO. This mechanism is presented in the Appendix.
+         </p>
+         <p>
+            Since in our model three Higgs doublets exist, we have studied the Yukawa couplings between quarks and these doublets by proposing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M568.jpg" xlink:type="simple" />
+            </inline-formula>
+            transformations for quark fields. After employing a certain texture for these Yukawa couplings, we have consistently explained the quark masses and mixing pattern. To employ this texture in the quark sector of our model, we have introduced additional fields like VLQs and singlet scalars. One of these singlet scalars should acquire a complex VEV in order to generate the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M569.jpg" xlink:type="simple" />
+            </inline-formula>
+            violating phase in quark sector. Finally, we have analyzed the scalar potential containing the singlet scalars and the above mentioned Higgs fields. After this analysis, we have demonstrated that the masses and mixing pattern in lepton and quark sectors can be consistently explained.
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s08_1">
+         <title>ACKNOWLEDGEMENT</title>
+         <p>
+            <italic toggle="yes">JG acknowledges Dr. Anirban Karan for some useful discussion.</italic>
+         </p>
+      </sec>
+      <sec id="cpc_46_10_103101_s09">
+         <title>APPENDIX: A MODEL FOR ACHIEVING CONDITION (I) IN THE CASE OF NO</title>
+         <p>
+            In Sec. IV, we have described some conditions on the elements of the neutrino mass matrix, which can make predictions regarding the case of NO or IO and about the smallness of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{13} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M570.jpg" xlink:type="simple" />
+            </inline-formula>
+            . These conditions are purely phenomenological and cannot be achieved with just the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M571.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. An additional mechanism should be proposed in order to satisfy these conditions. For the case of NO, condition (i) can be achieved if we propose an extra
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M572.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry and the singlet scalar fields
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1,S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M573.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M574.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry, we consider the following charge assignments, where
+            <italic toggle="yes">l</italic>
+            is some non-zero rational number:
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{e{\rm L}}\to l $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M575.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1\to-2l $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M576.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_2\to-l $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M577.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M578.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ e_{\rm R} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M579.jpg" xlink:type="simple" />
+            </inline-formula>
+            should transform like
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{e{\rm L}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M580.jpg" xlink:type="simple" />
+            </inline-formula>
+            , whereas the rest of the fields in our model are singlets.
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1,S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M581.jpg" xlink:type="simple" />
+            </inline-formula>
+            transform under the
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M582.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry as
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2}\to S_{1,2}^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M583.jpg" xlink:type="simple" />
+            </inline-formula>
+            . With the above charge assignments, the Yukawa terms for
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ D_{e{\rm L}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M584.jpg" xlink:type="simple" />
+            </inline-formula>
+            in Eq. (8) are forbidden. Now, these terms can be effectively generated by the following invariant terms.
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E77">
+                  <?CDATA $ \begin{aligned}[b] & Y_e\frac{S_1}{M}\bar{D}^c_{e{\rm L}}{\rm i}\sigma_2\Delta D_{e{\rm L}} +Y_\mu\frac{S_2}{M}\bar{D}^c_{e{\rm L}}{\rm i}\sigma_2\Delta D_{\mu {\rm L}} \\ & +Y_\tau\frac{S_2}{M}\bar{D}^c_{e{\rm L}}{\rm i}\sigma_2\Delta D_{\tau L}+{\rm h.c}.. \end{aligned}\tag{A1} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E77.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Here,
+            <italic toggle="yes">M</italic>
+            is a mass scale that is analogous to that in the quark sector Lagrangian of Eq. (44). The above non-renormalizable terms can be generated by studying the UV completion for these terms, where one can propose heavy vector-like leptons whose masses are around
+            <italic toggle="yes">M</italic>
+            . The process of this UV completion is analogous to the description in Sec. V.B. In order for Eq. (77) to be invariant under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M585.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y_e $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M586.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y_\mu=Y_\tau^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M587.jpg" xlink:type="simple" />
+            </inline-formula>
+            . After
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ U(1)_S $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M588.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry is spontaneously broken, terms in Eq. (77) effectively generate the Yukawa couplings
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee}, Y^\nu_{e\mu},Y^\nu_{e\tau} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M589.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Moreover, by taking
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ {\langle S_{1,2}\rangle}/{M}\sim0.1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M590.jpg" xlink:type="simple" />
+            </inline-formula>
+            , condition (i) for the case of NO is satisfied. Since
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{ee} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M591.jpg" xlink:type="simple" />
+            </inline-formula>
+            is real and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ Y^\nu_{e\mu}=(Y^\nu_{e\tau})^* $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M592.jpg" xlink:type="simple" />
+            </inline-formula>
+            ,
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_{1}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M593.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_{2}\rangle $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M594.jpg" xlink:type="simple" />
+            </inline-formula>
+            should be real. We justify this statement by studying the scalar potential for these fields.
+         </p>
+         <p>
+            The scalar potential, which is invariant under
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P\times Z_2\times Z_3\times K \times U(1)_{\rm F}\times U(1)_S$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M595.jpg" xlink:type="simple" />
+            </inline-formula>
+            and contains
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $S_{ 1,2}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M596.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E78">
+                  <?CDATA $ \begin{aligned}[b] V_{S_1,S_2}= & -m_{S_1}^2 (S_1^* S_1)- m_{S_2}^2 (S_2^* S_2)+\lambda_{S_1} (S_1^* S_1)^2\\ & +\lambda_{S_2} (S_2^* S_2)^2 + \lambda_{S_1 S_2} (S_1^* S_1)(S_2^* S_2) \\ & +\lambda_{\phi_1 S_1}(\phi_1^* \phi_1)(S_1^*S_1) + \lambda_{\phi_2 S_1}(\phi_2^* \phi_2\\ & +\phi_3^* \phi_3)(S_1^*S_1)+\lambda_{\phi_1 S_2}(\phi_1^* \phi_1)(S_2^*S_2) \\ & +\lambda_{\phi_2 S_2}(\phi_2^* \phi_2+\phi_3^* \phi_3)(S_2^*S_2)+\lambda_{\Delta S_1}{\rm Tr}(\Delta^{\dagger}\Delta)(S_1^* S_1)\\ & +\lambda_{\Delta S_2}{\rm Tr}(\Delta^{\dagger}\Delta)(S_2^* S_2) +\lambda_{S_1 X}(S_1^*S_1)(X^*X)\\ & + \lambda_{S_2 X}(S_2^*S_2)(X^*X)+\lambda_{S_1 X}^{\prime}(S_1^*S_1)(X^2+{X^*}^2) \\ & +\lambda_{S_2 X}^{\prime}(S_2^*S_2)(X^2+{X^*}^2)+\lambda_{F_1S_1}(F_1^*F_1)(S_1^*S_1)\\ & +\lambda_{F_1S_2}(F_1^*F_1)(S_2^*S_2) +\lambda_{F_2S_1}(F_2^*F_2)(S_1^*S_1)\\ & +\lambda_{F_2S_2}(F_2^*F_2)(S_2^*S_2) + a (S_1^*S_2^2+S_1 {S_2^*}^2). \end{aligned}\tag{A2} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E78.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            Now, the
+            <italic toggle="yes">K</italic>
+            -violating terms containing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $S_{ 1,2}$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M597.jpg" xlink:type="simple" />
+            </inline-formula>
+            can be written as
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E79">
+                  <?CDATA $ \begin{aligned}[b] V_{\not{K}}^{\prime\prime}= & \delta \lambda_{\phi_2 S_1}(\phi_2^{\dagger}\phi_2)(S_1^{*}S_1)+\delta\lambda_{\phi_2 S_1}^{\prime}(\phi_3^{\dagger}\phi_3)(S_1^{*}S_1)\\ & +\delta\lambda_{\phi_2 S_2}(\phi_2^{\dagger}\phi_2)(S_2^*S_2) +\lambda_{\phi_2 S_2}^{\prime}(\phi_3^{\dagger}\phi_3)(S_2^*S_2)\\ & +{\rm i}\delta\lambda_{25}(\phi_2^{\dagger}\phi_3-\phi_3^{\dagger}\phi_2)(S_1^*S_1)+{\rm i}\delta\lambda_{26}(\phi_2^{\dagger}\phi_3 \\ & -\phi_3^{\dagger}\phi_2)(S_2^*S_2). \end{aligned}\tag{A3} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E79.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            In the above two potentials, all parameters are real due to hermiticity or
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $C P$?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M598.jpg" xlink:type="simple" />
+            </inline-formula>
+            symmetry. Similar to the desciption in Sec. VI, we can see that the potential terms in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{S_1,S_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M599.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^{\prime\prime} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M600.jpg" xlink:type="simple" />
+            </inline-formula>
+            do not alter the main conclusions of Sec. III.C. This means, even with the fields
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M601.jpg" xlink:type="simple" />
+            </inline-formula>
+            , Δ acquires real VEV, whereas the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \phi_{2,3} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M602.jpg" xlink:type="simple" />
+            </inline-formula>
+            explain the hierarchy in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\mu $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M603.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ m_\tau $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M604.jpg" xlink:type="simple" />
+            </inline-formula>
+            .
+         </p>
+         <p>
+            Here, we demonstrate that
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M605.jpg" xlink:type="simple" />
+            </inline-formula>
+            can acquire real VEVs. In this regard, we can see that the last term of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{S_1,S_2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M606.jpg" xlink:type="simple" />
+            </inline-formula>
+            can only contain the phases in the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M607.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, after parameterizing
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_1\rangle =v_{s_1}{\rm e}^{\theta_{s_1}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M608.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \langle S_1\rangle=v_{s_2}{\rm e}^{\theta_{s_2}} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M609.jpg" xlink:type="simple" />
+            </inline-formula>
+            , we get
+         </p>
+         <p>
+            <disp-formula>
+               <tex-math id="cpc_46_10_103101_E80">
+                  <?CDATA $ \langle V_{S_1,S_2}\rangle \ni + 2 a v_{s_1}v_{s_2}^2\cos(2\theta_{s_2}-\theta_{s_1}). \tag{A4} $?>
+               </tex-math>
+               <graphic orientation="portrait" position="float" xlink:href="cpc_46_10_103101_E80.jpg" xlink:type="simple" />
+            </disp-formula>
+         </p>
+         <p>
+            The above term has a minimum at
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ 2\theta_{s_2}-\theta_{s_1}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M610.jpg" xlink:type="simple" />
+            </inline-formula>
+            when
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ av_{s_1} \lt 0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M611.jpg" xlink:type="simple" />
+            </inline-formula>
+            . To satisfy this minimum, we can choose
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{s_1}=\theta_{s_2}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M612.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Now, the minimum at
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ \theta_{s_1}=\theta_{s_2}=0 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M613.jpg" xlink:type="simple" />
+            </inline-formula>
+            cannot be shifted by the terms of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^{\prime\prime} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M614.jpg" xlink:type="simple" />
+            </inline-formula>
+            , since
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_{1,2} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M615.jpg" xlink:type="simple" />
+            </inline-formula>
+            appear in the form of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1^*S_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M616.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_2^*S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M617.jpg" xlink:type="simple" />
+            </inline-formula>
+            in
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ V_{\not{K}}^{\prime\prime} $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M618.jpg" xlink:type="simple" />
+            </inline-formula>
+            . Hence, there exist a parameter region where the VEVs of
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_1 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M619.jpg" xlink:type="simple" />
+            </inline-formula>
+            and
+            <inline-formula>
+               <tex-math>
+                  <?CDATA $ S_2 $?>
+               </tex-math>
+               <inline-graphic xlink:href="cpc_46_10_103101_M620.jpg" xlink:type="simple" />
+            </inline-formula>
+            are real in this model.
+         </p>
+      </sec>
+   </body>
+   <back>
+      <ref-list>
+         <title>References</title>
+         <ref id="cpc_46_10_103101_bib1">
+            <label>[1]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. de Salas</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>V. Forero</surname>
+                     <given-names>D.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Gariazzo</surname>
+                     <given-names>S.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>JHEP</source>
+               <year>2021</year>
+               <volume>02</volume>
+               <fpage>071</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP02(2021)071</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2006.11237" xlink:type="simple">2006.11237</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib2">
+            <label>[2]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. Harrison</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>H. Perkins</surname>
+                     <given-names>D.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>G. Scott</surname>
+                     <given-names>W.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>530</volume>
+               <fpage>167</fpage>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0202074 " xlink:type="simple">hep-ph/0202074 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib3">
+            <label>[3]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. Harrison</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>G. Scott</surname>
+                     <given-names>W.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>535</volume>
+               <fpage>163</fpage>
+               <lpage>169</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)01753-7</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0203209 " xlink:type="simple">hep-ph/0203209 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib4">
+            <label>[4]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>z. Xing</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>533</volume>
+               <fpage>85</fpage>
+               <lpage>93</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)01649-0</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0204049 " xlink:type="simple">hep-ph/0204049 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib5">
+            <label>[5]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. Harrison</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>G. Scott</surname>
+                     <given-names>W.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2002</year>
+               <volume>547</volume>
+               <fpage>219</fpage>
+               <lpage>228</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)02772-7</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0210197" xlink:type="simple">hep-ph/0210197</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib6">
+            <label>[6]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>z. Xing</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>h. Zhao</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+               </person-group>
+               <source>Rept. Prog. Phys.</source>
+               <year>2016</year>
+               <volume>79</volume>
+               <issue>7</issue>
+               <fpage>076201</fpage>
+               <pub-id pub-id-type="doi">10.1088/0034-4885/79/7/076201</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1512.04207" xlink:type="simple">1512.04207</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib7">
+            <label>[7]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Holthausen</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lindner</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>A. Schmidt</surname>
+                     <given-names>M.</given-names>
+                  </name>
+               </person-group>
+               <source>JHEP</source>
+               <year>2013</year>
+               <volume>04</volume>
+               <fpage>122</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP04(2013)122</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1211.6953 " xlink:type="simple">1211.6953 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib8">
+            <label>[8]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Feruglio</surname>
+                     <given-names>F.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Hagedorn</surname>
+                     <given-names>C.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Ziegler</surname>
+                     <given-names>R.</given-names>
+                  </name>
+               </person-group>
+               <source>Eur. Phys. J. C</source>
+               <year>2014</year>
+               <volume>74</volume>
+               <fpage>2753</fpage>
+               <pub-id pub-id-type="doi">10.1140/epjc/s10052-014-2753-2</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1303.7178 " xlink:type="simple">1303.7178 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib9">
+            <label>[9]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>J. He</surname>
+                     <given-names>H.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Rodejohann</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>J. Xu</surname>
+                     <given-names>X.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2015</year>
+               <volume>751</volume>
+               <fpage>586</fpage>
+               <lpage>594</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2015.10.066</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1507.03541 " xlink:type="simple">1507.03541 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib10">
+            <label>[10]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Joshipura</surname>
+                     <given-names>A.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>M. Patel</surname>
+                     <given-names>K.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2015</year>
+               <volume>749</volume>
+               <fpage>159</fpage>
+               <lpage>166</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2015.07.062</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1507.01235 " xlink:type="simple">1507.01235 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib11">
+            <label>[11]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>C. Nishi</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>JHEP</source>
+               <year>2015</year>
+               <volume>08</volume>
+               <fpage>092</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP08(2015)092</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1506.06788 " xlink:type="simple">1506.06788 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib12">
+            <label>[12]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>F. King</surname>
+                     <given-names>S.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>C. Nishi</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2018</year>
+               <volume>785</volume>
+               <fpage>391</fpage>
+               <lpage>398</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2018.08.056</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1807.00023 " xlink:type="simple">1807.00023 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib13">
+            <label>[13]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Grimus</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lavoura</surname>
+                     <given-names>L.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2004</year>
+               <volume>579</volume>
+               <fpage>113</fpage>
+               <lpage>122</lpage>
+               <pub-id pub-id-type="doi">10.1016/j.physletb.2003.10.075</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0305309" xlink:type="simple">hep-ph/0305309</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib14">
+            <label>[14]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Babu</surname>
+                     <given-names>K.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Ma</surname>
+                     <given-names>E.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>W. F. Valle</surname>
+                     <given-names>J.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>2003</year>
+               <volume>552</volume>
+               <fpage>207</fpage>
+               <lpage>213</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0370-2693(02)03153-2</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0206292" xlink:type="simple">hep-ph/0206292</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib15">
+            <label>[15]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Senjanovic</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. Lett.</source>
+               <year>1980</year>
+               <volume>44</volume>
+               <fpage>912</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevLett.44.912</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib16">
+            <label>[16]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Schechter</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>W. F. Valle</surname>
+                     <given-names>J.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>1980</year>
+               <volume>22</volume>
+               <fpage>2227</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.22.2227</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib17">
+            <label>[17]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Grimus</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lavoura</surname>
+                     <given-names>L.</given-names>
+                  </name>
+               </person-group>
+               <source>J. Phys. G</source>
+               <year>2004</year>
+               <volume>30</volume>
+               <fpage>73</fpage>
+               <lpage>82</lpage>
+               <pub-id pub-id-type="doi">10.1088/0954-3899/30/2/007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0309050" xlink:type="simple">hep-ph/0309050</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib18">
+            <label>[18]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>
+                  P. A. Zyla
+                  <italic toggle="yes">et al.</italic>
+                  (Particle Data Group), PTEP
+                  <bold>2020</bold>
+                  (8), 083C01 (2020) doi:
+                  <ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1093/ptep/ptaa104" xlink:type="simple">10.1093/ptep/ptaa104</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib19">
+            <label>[19]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Magg</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Wetterich</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Lett. B</source>
+               <year>1980</year>
+               <volume>94</volume>
+               <fpage>61</fpage>
+               <lpage>64</lpage>
+               <pub-id pub-id-type="doi">10.1016/0370-2693(80)90825-4</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib20">
+            <label>[20]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Senjanovic</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>1981</year>
+               <volume>23</volume>
+               <fpage>165</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.23.165</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib21">
+            <label>[21]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Lazarides</surname>
+                     <given-names>G.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Shafi</surname>
+                     <given-names>Q.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Wetterich</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Nucl. Phys. B</source>
+               <year>1981</year>
+               <volume>181</volume>
+               <fpage>287</fpage>
+               <lpage>300</lpage>
+               <pub-id pub-id-type="doi">10.1016/0550-3213(81)90354-0</pub-id>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib22">
+            <label>[22]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>M. Ferreira</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Grimus</surname>
+                     <given-names>W.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Lavoura</surname>
+                     <given-names>L.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>JHEP</source>
+               <year>2012</year>
+               <volume>09</volume>
+               <fpage>128</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP09(2012)128</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1206.7072" xlink:type="simple">1206.7072</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib23">
+            <label>[23]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Mohapatra</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>C. Nishi</surname>
+                     <given-names>C.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2012</year>
+               <volume>86</volume>
+               <fpage>073007</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.86.073007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1208.2875" xlink:type="simple">1208.2875</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib24">
+            <label>[24]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Hundi</surname>
+                     <given-names>R.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Sethi</surname>
+                     <given-names>I.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2020</year>
+               <volume>102</volume>
+               <fpage>055007</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.102.055007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/2003.09809 " xlink:type="simple">2003.09809 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib25">
+            <label>[25]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Ganguly</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>S. Hundi</surname>
+                     <given-names>R.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2021</year>
+               <volume>103</volume>
+               <issue>3</issue>
+               <fpage>035007</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.103.035007</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:2005.04023 " xlink:type="simple">arXiv:2005.04023 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib26">
+            <label>[26]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Rasin</surname>
+                     <given-names>A.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys.Rev.  D</source>
+               <year>1998</year>
+               <volume>58</volume>
+               <fpage>096012</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.58.096012</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:hep-ph/9802356" xlink:type="simple">arXiv:hep-ph/9802356</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib27">
+            <label>[27]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>S. Babu</surname>
+                     <given-names>K.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Nandi</surname>
+                     <given-names>S.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2000</year>
+               <volume>62</volume>
+               <fpage>033002</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.62.033002</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/9907213" xlink:type="simple">hep-ph/9907213</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib28">
+            <label>[28]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>D. Lykken</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Murdock</surname>
+                     <given-names>Z.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Nandi</surname>
+                     <given-names>S.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2009</year>
+               <volume>79</volume>
+               <fpage>075014</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.79.075014</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/0812.1826" xlink:type="simple">0812.1826</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib29">
+            <label>[29]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>C. Li</surname>
+                     <given-names>C.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>N. Lu</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>J. Ding</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>JHEP</source>
+               <year>2018</year>
+               <volume>02</volume>
+               <fpage>038</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP02(2018)038</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1706.04576 " xlink:type="simple">1706.04576 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib30">
+            <label>[30]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>N. Lu</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>J. Ding</surname>
+                     <given-names>G.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2018</year>
+               <volume>98</volume>
+               <fpage>055011</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.98.055011</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1806.02301 " xlink:type="simple">1806.02301 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib31">
+            <label>[31]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>H. Rahat</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Ramond</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Xu</surname>
+                     <given-names>B.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2018</year>
+               <volume>98</volume>
+               <issue>5</issue>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.98.055030</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:1805.10684 " xlink:type="simple">arXiv:1805.10684 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib32">
+            <label>[32]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <etal>et al</etal>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2019</year>
+               <volume>100</volume>
+               <issue>7</issue>
+               <fpage>075008</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.100.075008</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:1907.10698 " xlink:type="simple">arXiv:1907.10698 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib33">
+            <label>[33]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <etal>et al</etal>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2020</year>
+               <volume>101</volume>
+               <issue>7</issue>
+               <fpage>075018</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.101.075018</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:2001.04019 " xlink:type="simple">arXiv:2001.04019 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib34">
+            <label>[34]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Ma</surname>
+                     <given-names>E.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Raidal</surname>
+                     <given-names>M.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Sarkar</surname>
+                     <given-names>U.</given-names>
+                  </name>
+               </person-group>
+               <source>Nucl. Phys. B</source>
+               <year>2001</year>
+               <volume>615</volume>
+               <fpage>313</fpage>
+               <lpage>330</lpage>
+               <pub-id pub-id-type="doi">10.1016/S0550-3213(01)00416-3</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/hep-ph/0012101" xlink:type="simple">hep-ph/0012101</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib35">
+            <label>[35]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>
+                  M. Drees, R. Godbole, and P. Roy,
+                  <italic toggle="yes">Theory and Phenomenology of Sparticles</italic>
+                  (World Scientific, Singapore, 2004); P. Bińetruy,
+                  <italic toggle="yes">Supersymmetry</italic>
+                  (Oxford University Press, Oxford, England, 2006)
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib36">
+            <label>[36]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>P. Martin</surname>
+                     <given-names>S.</given-names>
+                  </name>
+               </person-group>
+               <source>Adv. Ser. Direct. High Energy Phys.</source>
+               <year>2010</year>
+               <volume>21</volume>
+               <fpage>1</fpage>
+               <lpage>53</lpage>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:hep-ph/9709356 " xlink:type="simple">arXiv:hep-ph/9709356 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib37">
+            <label>[37]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>
+                  N. Aghanim
+                  <italic toggle="yes">et al.</italic>
+                  (Planck Collaboration), arXiv:1807.06209 [astro-ph.CO]
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib38">
+            <label>[38]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>K. Ghosh</surname>
+                     <given-names>D.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>S. Hundi</surname>
+                     <given-names>R.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2012</year>
+               <volume>85</volume>
+               <fpage>013005</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.85.013005</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1108.3428" xlink:type="simple">1108.3428</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib39">
+            <label>[39]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>J. Xu</surname>
+                     <given-names>X.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys. Rev. D</source>
+               <year>2016</year>
+               <volume>94</volume>
+               <issue>11</issue>
+               <fpage>115025</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.94.115025</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/arXiv:1612.04950 " xlink:type="simple">arXiv:1612.04950 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib40">
+            <label>[40]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>J. Xu</surname>
+                     <given-names>X.</given-names>
+                  </name>
+               </person-group>
+               <source>Phys.  Rev.  D</source>
+               <year>2017</year>
+               <volume>95</volume>
+               <issue>11</issue>
+               <fpage>115019</fpage>
+               <pub-id pub-id-type="doi">10.1103/PhysRevD.95.115019</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/ arXiv:1705.08965 " xlink:type="simple"> arXiv:1705.08965 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib41">
+            <label>[41]</label>
+            <element-citation publication-type="other" xlink:type="simple">
+               <comment>B. N. Grossmann, Z. Murdock, and S. Nandi, arXiv:1011.5256 [hep-ph]</comment>
+            </element-citation>
+         </ref>
+         <ref id="cpc_46_10_103101_bib42">
+            <label>[42]</label>
+            <element-citation publication-type="journal" xlink:type="simple">
+               <person-group person-group-type="author">
+                  <name name-style="western">
+                     <surname>Erler</surname>
+                     <given-names>J.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Langacker</surname>
+                     <given-names>P.</given-names>
+                  </name>
+                  <name name-style="western">
+                     <surname>Munir</surname>
+                     <given-names>S.</given-names>
+                  </name>
+                  <etal>et al</etal>
+               </person-group>
+               <source>JHEP</source>
+               <year>2011</year>
+               <volume>11</volume>
+               <fpage>076</fpage>
+               <pub-id pub-id-type="doi">10.1007/JHEP11(2011)076</pub-id>
+               <comment>
+                  arXiv:
+                  <ext-link ext-link-type="arxiv" xlink:href="http://arxiv.org/abs/1103.2659 " xlink:type="simple">1103.2659 </ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+      </ref-list>
+   </back>
+</article>

--- a/tests/units/iop/test_iop_parser.py
+++ b/tests/units/iop/test_iop_parser.py
@@ -1,0 +1,499 @@
+import xml.etree.ElementTree as ET
+
+from common.parsing.xml_extractors import RequiredFieldNotFoundExtractionError
+from iop.iop_process_file import enhance_iop, enrich_iop, iop_validate_record
+from iop.parser import IOPParser
+from pytest import fixture, raises
+
+
+@fixture(scope="module")
+def iop_parser():
+    return IOPParser()
+
+
+@fixture
+def article_without_abstract(shared_datadir):
+    with open(shared_datadir / "without_abstract.xml") as f:
+        return ET.fromstring(f.read())
+
+
+def test_article_without_abstract(iop_parser, article_without_abstract):
+    with raises(RequiredFieldNotFoundExtractionError):
+        assert iop_parser._publisher_specific_parsing(article_without_abstract)
+
+
+@fixture
+def article_without_arxiv(shared_datadir):
+    with open(shared_datadir / "without_arxiv.xml") as f:
+        return ET.fromstring(f.read())
+
+
+@fixture
+def parsed_article_without_arxiv(iop_parser, article_without_arxiv):
+    return iop_parser._publisher_specific_parsing(article_without_arxiv)
+
+
+def test_without_arxiv(parsed_article_without_arxiv):
+    assert parsed_article_without_arxiv["arxiv_eprints"] == []
+
+
+@fixture
+def article_without_page_nr(shared_datadir):
+    with open(shared_datadir / "without_page_nr.xml") as f:
+        return ET.fromstring(f.read())
+
+
+@fixture
+def parsed_article_without_page_nr(iop_parser, article_without_page_nr):
+    return iop_parser._publisher_specific_parsing(article_without_page_nr)
+
+
+def test_page_nr_without_page_nr(parsed_article_without_page_nr):
+    assert parsed_article_without_page_nr["page_nr"] == [0]
+
+
+def test_iop_record_validation(iop_parser, parsed_article_without_page_nr):
+    enhanced = enhance_iop(iop_parser._generic_parsing(parsed_article_without_page_nr))
+    enriched = enrich_iop(enhanced)
+    iop_validate_record(enriched)
+
+
+@fixture
+def article_without_doi(shared_datadir):
+    with open(shared_datadir / "without_doi.xml") as f:
+        return ET.fromstring(f.read())
+
+
+def parsed_article_without_doi(iop_parser, article_without_doi):
+    with raises(RequiredFieldNotFoundExtractionError):
+        return iop_parser._publisher_specific_parsing(article_without_doi)
+
+
+@fixture
+def articles(shared_datadir):
+    files = ["example1.xml", "example2.xml"]
+    articles = []
+    for file in files:
+        with open(shared_datadir / file) as f:
+            articles.append(ET.fromstring(f.read()))
+    return articles
+
+
+@fixture
+def parsed_articles(iop_parser, articles):
+    return [iop_parser._publisher_specific_parsing(article) for article in articles]
+
+
+def test_dois(parsed_articles):
+    dois = ["10.1088/1674-1137/ac66cc", "10.1088/1674-1137/ac763c"]
+    for doi, article in zip(dois, parsed_articles):
+        assert article["dois"] == [doi]
+
+
+def test_journal_doctype(parsed_articles):
+    doctype = ["article", "article"]
+    for doctype, article in zip(doctype, parsed_articles):
+        assert article["journal_doctype"] == doctype
+
+
+def test_related_article_doi(parsed_articles):
+    for article in parsed_articles:
+        assert article["related_article_doi"] == []
+
+
+def test_arxiv_eprints(parsed_articles):
+    arxiv_eprints = [{"value": "2108.04010"}, {"value": "2107.07275"}]
+    for arxiv_eprint, article in zip(arxiv_eprints, parsed_articles):
+        assert article["arxiv_eprints"] == [arxiv_eprint]
+
+
+def test_page_nr(parsed_articles):
+    page_nrs = [9, 18]
+    for page_nr, article in zip(page_nrs, parsed_articles):
+        assert article["page_nr"] == [page_nr]
+
+
+def test_abstract(parsed_articles):
+    abstracts = [
+        'Solar, terrestrial, and supernova neutrino experiments are subject to muon-induced radioactive background. The China Jinping Underground Laboratory (CJPL), with its unique advantage of a 2400 m rock coverage and long distance from nuclear power plants, is ideal for MeV-scale neutrino experiments. Using a 1-ton prototype detector of the Jinping Neutrino Experiment (JNE), we detected 343 high-energy cosmic-ray muons and (7.86<inline-formula xmlns:ns0="http://www.w3.org/1999/xlink"><tex-math></tex-math><inline-graphic ns0:href="cpc_46_8_085001_M1.jpg" ns0:type="simple" /></inline-formula>3.97) muon-induced neutrons from an 820.28-day dataset at the first phase of CJPL (CJPL-I). Based on the muon-induced neutrons, we measured the corresponding muon-induced neutron yield in a liquid scintillator to be<inline-formula xmlns:ns0="http://www.w3.org/1999/xlink"><tex-math></tex-math><inline-graphic ns0:href="cpc_46_8_085001_M2.jpg" ns0:type="simple" /></inline-formula><inline-formula xmlns:ns0="http://www.w3.org/1999/xlink"><tex-math></tex-math><inline-graphic ns0:href="cpc_46_8_085001_M2-1.jpg" ns0:type="simple" /></inline-formula>&#956;<sup>&#8722;1</sup>g<sup>&#8722;1</sup>cm<sup>2</sup>at an average muon energy of 340 GeV. We provided the first study for such neutron background at CJPL. A global fit including this measurement shows a power-law coefficient of (0.75<inline-formula xmlns:ns0="http://www.w3.org/1999/xlink"><tex-math></tex-math><inline-graphic ns0:href="cpc_46_8_085001_M3.jpg" ns0:type="simple" /></inline-formula>0.02) for the dependence of the neutron yield at the liquid scintillator on muon energy.',
+        'In this study, we modify a scenario, originally proposed by Grimus and Lavoura, in order to obtain maximal values for the atmospheric mixing angle and<inline-formula xmlns:ns0="http://www.w3.org/1999/xlink"><tex-math></tex-math><inline-graphic ns0:href="cpc_46_10_103101_M1.jpg" ns0:type="simple" /></inline-formula>, violating the Dirac phase of the lepton sector. To achieve this, we employ<inline-formula xmlns:ns0="http://www.w3.org/1999/xlink"><tex-math></tex-math><inline-graphic ns0:href="cpc_46_10_103101_M2.jpg" ns0:type="simple" /></inline-formula>and some discrete symmetries in a type II seesaw model. To make predictions about the neutrino mass ordering and smallness of the reactor angle, we establish some conditions on the elements of the neutrino mass matrix of our model. Finally, we study the quark masses and mixing pattern within the framework of our model.',
+    ]
+    for abstract, article in zip(abstracts, parsed_articles):
+        print(article["abstract"])
+        assert article["abstract"] == abstract
+
+
+def test_title(parsed_articles):
+    titles = [
+        'Measurement of muon-induced neutron yield at the China Jinping Underground Laboratory<xref ref-type="fn" rid="cpc_46_8_085001_fn1">*</xref><fn id="cpc_46_8_085001_fn1"><label>*</label><p>Supported in part by the National Natural Science Foundation of China (11620101004, 11475093, 12127808), the Key Laboratory of Particle &amp; Radiation Imaging (TsinghuaUniversity), the CAS Center for Excellence in Particle Physics (CCEPP), and Guangdong Basic and Applied Basic Research Foundation (2019A1515012216). Portion of this work performed at Brookhaven National Laboratory is supported in part by the United States Department of Energy (DE-SC0012704)</p></fn>',
+        'Lepton and quark mixing patterns with generalized<italic toggle="yes">CP</italic>transformations',
+    ]
+    for title, article in zip(titles, parsed_articles):
+        assert article["title"] == title
+
+
+def test_subtitle(parsed_articles):
+    for article in parsed_articles:
+        assert article["subtitle"] == ""
+
+
+def test_affiliations(parsed_articles):
+    authors = [
+        [
+            {
+                "surname": "Zhao",
+                "given_names": "Lin",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Luo",
+                "given_names": "Wentai",
+                "affiliations": [
+                    {
+                        "value": "School of Physical Sciences, University of Chinese Academy of Sciences,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Bathe-Peters",
+                "given_names": "Lars",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Chen",
+                "given_names": "Shaomin",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Chouaki",
+                "given_names": "Mourad",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Dou",
+                "given_names": "Wei",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Guo",
+                "given_names": "Lei",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Guo",
+                "given_names": "Ziyi",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Hussain",
+                "given_names": "Ghulam",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Li",
+                "given_names": "Jinjing",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Liang",
+                "given_names": "Ye",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Liu",
+                "given_names": "Qian",
+                "affiliations": [
+                    {
+                        "value": "School of Physical Sciences, University of Chinese Academy of Sciences,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Luo",
+                "given_names": "Guang",
+                "affiliations": [
+                    {
+                        "value": "School of Physics, Sun Yat-Sen University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Qi",
+                "given_names": "Ming",
+                "affiliations": [
+                    {
+                        "value": "School of Physics, Nanjing University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Shao",
+                "given_names": "Wenhui",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Tang",
+                "given_names": "Jian",
+                "affiliations": [
+                    {
+                        "value": "School of Physics, Sun Yat-Sen University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Wan",
+                "given_names": "Linyan",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Wang",
+                "given_names": "Zhe",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Wu",
+                "given_names": "Yiyang",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Xu",
+                "given_names": "Benda",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Xu",
+                "given_names": "Tong",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Xu",
+                "given_names": "Weiran",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Yang",
+                "given_names": "Yuzi",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Yeh",
+                "given_names": "Minfang",
+                "affiliations": [
+                    {
+                        "value": "Brookhaven National Laboratory, Upton,USA",
+                        "country": "USA",
+                    }
+                ],
+            },
+            {
+                "surname": "Zhang",
+                "given_names": "Aiqiang",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+            {
+                "surname": "Zhang",
+                "given_names": "Bin",
+                "affiliations": [
+                    {
+                        "value": "Department of Engineering Physics, Tsinghua University,China",
+                        "country": "China",
+                    }
+                ],
+            },
+        ],
+        [
+            {
+                "surname": "Ganguly",
+                "given_names": "Joy",
+                "affiliations": [
+                    {
+                        "value": "Department of Physics, Indian Institute of Technology Hyderabad,India",
+                        "country": "India",
+                    }
+                ],
+            },
+            {
+                "surname": "Hundi",
+                "given_names": "Raghavendra Srikanth",
+                "affiliations": [
+                    {
+                        "value": "Department of Physics, Indian Institute of Technology Hyderabad,India",
+                        "country": "India",
+                    }
+                ],
+            },
+        ],
+    ]
+    for author, article in zip(authors, parsed_articles):
+        assert article["authors"] == author
+
+
+def test_get_published_date(parsed_articles):
+    doctypes = ["2022-08-01", "2022-10-01"]
+    for doctype, article in zip(doctypes, parsed_articles):
+        assert article["date_published"] == doctype
+
+
+def test_publication_info(parsed_articles):
+    publications_info = [
+        [
+            {
+                "journal_title": "Chinese Physics C",
+                "journal_volume": "46",
+                "journal_year": 2022,
+                "journal_issue": "8",
+                "journal_artid": "085001",
+            }
+        ],
+        [
+            {
+                "journal_title": "Chinese Physics C",
+                "journal_volume": "46",
+                "journal_year": 2022,
+                "journal_issue": "10",
+                "journal_artid": "103101",
+            }
+        ],
+    ]
+    for publication_info, article in zip(publications_info, parsed_articles):
+        assert article["publication_info"] == publication_info
+
+
+def test_get_date_published(parsed_articles):
+    published_dates = ["2022-08-01", "2022-10-01"]
+    for published_date, article in zip(published_dates, parsed_articles):
+        assert article["date_published"] == published_date
+
+
+def test_get_copyright_year(parsed_articles):
+    copyright_years = ["2022", "2022"]
+    for copyright_year, article in zip(copyright_years, parsed_articles):
+        assert article["copyright_year"] == copyright_year
+
+
+def test_get_copyright_statements(parsed_articles):
+    copyright_statements = [
+        "© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd",
+        "© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd",
+    ]
+    for copyright_statement, article in zip(copyright_statements, parsed_articles):
+        assert article["copyright_statement"] == copyright_statement
+
+
+def test_get_license(parsed_articles):
+    licenses = [
+        [
+            {
+                "license": "CC-BY-3.0",
+                "url": "http://creativecommons.org/licenses/by/3.0/",
+            }
+        ],
+        [
+            {
+                "license": "CC-BY-3.0",
+                "url": "http://creativecommons.org/licenses/by/3.0/",
+            }
+        ],
+    ]
+    for license, article in zip(licenses, parsed_articles):
+        assert article["license"] == license

--- a/tests/units/iop/test_iop_process_file.py
+++ b/tests/units/iop/test_iop_process_file.py
@@ -1,0 +1,40 @@
+import xml.etree.ElementTree as ET
+
+from iop.iop_process_file import enhance_iop, enrich_iop, iop_validate_record
+from iop.parser import IOPParser
+from pytest import fixture
+
+
+@fixture
+def article(shared_datadir):
+    file_content = (shared_datadir / "example1.xml").read_text()
+    yield ET.fromstring(file_content)
+
+
+@fixture
+def parser():
+    return IOPParser()
+
+
+@fixture
+def parsed_article(article, parser):
+    return parser._publisher_specific_parsing(article)
+
+
+@fixture
+def parsed_generic_article(parsed_article, parser):
+    return parser._generic_parsing(parsed_article)
+
+
+@fixture
+def enhance_article(parsed_generic_article):
+    return enhance_iop(parsed_generic_article)
+
+
+@fixture
+def enrich_article(enhance_article):
+    return enrich_iop(enhance_article)
+
+
+def test_aps_validated_record(enrich_article):
+    iop_validate_record(enrich_article)


### PR DESCRIPTION
* Added a check while extracting text from Elementree object.
* Parser won't try to extract text from Elemntree obj, which are None (for example: arxiv_id).
* FIX: before extracting text on Custom Extractor, the value of Elementree object is checked.
* ref: cern-sis/issues-scoap3#98