### PR TITLE
workflows IOP: parsed date published

### DIFF
--- a/dags/common/constants.py
+++ b/dags/common/constants.py
@@ -1,3 +1,4 @@
 import re
 
 ARXIV_EXTRACTION_PATTERN = re.compile(r"(arxiv:|v[0-9]$)", flags=re.I)
+NODE_ATTRIBUTE_NOT_FOUND_ERRORS = (AttributeError, TypeError)

--- a/tests/units/iop/data/no_date_published.xml
+++ b/tests/units/iop/data/no_date_published.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" xml:lang="en">
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="publisher-id">cpc</journal-id>
+            <journal-title-group>
+                <journal-title xml:lang="en">Chinese Physics C</journal-title>
+            </journal-title-group>
+            <issn pub-type="ppub">1674-1137</issn>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="publisher-id">cpc_46_8_085001</article-id>
+            <article-id pub-id-type="doi">10.1088/1674-1137/ac66cc</article-id>
+            <article-id pub-id-type="manuscript">ac66cc</article-id>
+            <title-group>
+                <article-title>
+                    Measurement of muon-induced neutron yield at the China Jinping Underground Laboratory
+                    <xref ref-type="fn" rid="cpc_46_8_085001_fn1">*</xref>
+                    <fn id="cpc_46_8_085001_fn1">
+                        <label>*</label>
+                        <p>Supported in part by the National Natural Science Foundation of China (11620101004, 11475093, 12127808), the Key Laboratory of Particle &amp; Radiation Imaging (TsinghuaUniversity), the CAS Center for Excellence in Particle Physics (CCEPP), and Guangdong Basic and Applied Basic Research Foundation (2019A1515012216). Portion of this work performed at Brookhaven National Laboratory is supported in part by the United States Department of Energy (DE-SC0012704)</p>
+                    </fn>
+                </article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author" xlink:type="simple">
+                    <name name-style="western">
+                        <surname>Zhao</surname>
+                        <given-names>Lin</given-names>
+                    </name>
+                    <name content-type="non-latin-no-space" name-style="eastern">
+                        <surname>赵</surname>
+                        <given-names>林</given-names>
+                    </name>
+                    <xref ref-type="aff" rid="affiliation01">1</xref>
+                    <xref ref-type="aff" rid="affiliation02">2</xref>
+                </contrib>
+            </contrib-group>
+            <pub-date pub-type="ppub">
+            </pub-date>
+            <permissions>
+                <copyright-statement>© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</copyright-statement>
+                <copyright-year>2022</copyright-year>
+                <license license-type="cc-by" xlink:href="http://creativecommons.org/licenses/by/3.0/" xlink:type="simple">
+                    <license-p>
+                        <graphic content-type="online" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_ccby.tif" xlink:type="simple" />
+                        Content from this work may be used under the terms of the
+                        <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/3.0" xlink:type="simple">Creative Commons Attribution 3.0 licence</ext-link>
+                        . Any further distribution of this work must maintain attribution to the author(s) and the title of the work, journal citation and DOI. Article funded by SCOAP
+                        <sup>3</sup>
+                        and published under licence by Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+                    </license-p>
+                </license>
+            </permissions>
+            <abstract>
+                <title>Abstract</title>
+                <p>
+                    Solar, terrestrial, and supernova neutrino experiments are subject to muon-induced radioactive background. The China Jinping Underground Laboratory (CJPL), with its unique advantage of a 2400 m rock coverage and long distance from nuclear power plants, is ideal for MeV-scale neutrino experiments. Using a 1-ton prototype detector of the Jinping Neutrino Experiment (JNE), we detected 343 high-energy cosmic-ray muons and (7.86
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ \pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M1.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    3.97) muon-induced neutrons from an 820.28-day dataset at the first phase of CJPL (CJPL-I). Based on the muon-induced neutrons, we measured the corresponding muon-induced neutron yield in a liquid scintillator to be
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $(3.44 \pm 1.86_{\rm stat.}\pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M2.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ 0.76_{\rm syst.})\times 10^{-4}$?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M2-1.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    μ
+                    <sup>−1</sup>
+                    g
+                    <sup>−1</sup>
+                    cm
+                    <sup>2</sup>
+                    at an average muon energy of 340 GeV. We provided the first study for such neutron background at CJPL. A global fit including this measurement shows a power-law coefficient of (0.75
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ \pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M3.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    0.02) for the dependence of the neutron yield at the liquid scintillator on muon energy.
+                </p>
+            </abstract>
+            <custom-meta-group>
+                <custom-meta xlink:type="simple">
+                    <meta-name>arxivppt</meta-name>
+                    <meta-value>2108.04010</meta-value>
+                </custom-meta>
+            </custom-meta-group>
+        </article-meta>
+    </front>
+</article>

--- a/tests/units/iop/data/no_day_published.xml
+++ b/tests/units/iop/data/no_day_published.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" xml:lang="en">
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="publisher-id">cpc</journal-id>
+            <journal-title-group>
+                <journal-title xml:lang="en">Chinese Physics C</journal-title>
+            </journal-title-group>
+            <issn pub-type="ppub">1674-1137</issn>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="publisher-id">cpc_46_8_085001</article-id>
+            <article-id pub-id-type="doi">10.1088/1674-1137/ac66cc</article-id>
+            <article-id pub-id-type="manuscript">ac66cc</article-id>
+            <title-group>
+                <article-title>
+                    Measurement of muon-induced neutron yield at the China Jinping Underground Laboratory
+                    <xref ref-type="fn" rid="cpc_46_8_085001_fn1">*</xref>
+                    <fn id="cpc_46_8_085001_fn1">
+                        <label>*</label>
+                        <p>Supported in part by the National Natural Science Foundation of China (11620101004, 11475093, 12127808), the Key Laboratory of Particle &amp; Radiation Imaging (TsinghuaUniversity), the CAS Center for Excellence in Particle Physics (CCEPP), and Guangdong Basic and Applied Basic Research Foundation (2019A1515012216). Portion of this work performed at Brookhaven National Laboratory is supported in part by the United States Department of Energy (DE-SC0012704)</p>
+                    </fn>
+                </article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author" xlink:type="simple">
+                    <name name-style="western">
+                        <surname>Zhao</surname>
+                        <given-names>Lin</given-names>
+                    </name>
+                    <name content-type="non-latin-no-space" name-style="eastern">
+                        <surname>赵</surname>
+                        <given-names>林</given-names>
+                    </name>
+                    <xref ref-type="aff" rid="affiliation01">1</xref>
+                    <xref ref-type="aff" rid="affiliation02">2</xref>
+                </contrib>
+            </contrib-group>
+            <pub-date pub-type="ppub">
+                <month>8</month>
+                <year>2022</year>
+            </pub-date>
+            <permissions>
+                <copyright-statement>© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</copyright-statement>
+                <copyright-year>2022</copyright-year>
+                <license license-type="cc-by" xlink:href="http://creativecommons.org/licenses/by/3.0/" xlink:type="simple">
+                    <license-p>
+                        <graphic content-type="online" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_ccby.tif" xlink:type="simple" />
+                        Content from this work may be used under the terms of the
+                        <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/3.0" xlink:type="simple">Creative Commons Attribution 3.0 licence</ext-link>
+                        . Any further distribution of this work must maintain attribution to the author(s) and the title of the work, journal citation and DOI. Article funded by SCOAP
+                        <sup>3</sup>
+                        and published under licence by Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+                    </license-p>
+                </license>
+            </permissions>
+            <abstract>
+                <title>Abstract</title>
+                <p>
+                    Solar, terrestrial, and supernova neutrino experiments are subject to muon-induced radioactive background. The China Jinping Underground Laboratory (CJPL), with its unique advantage of a 2400 m rock coverage and long distance from nuclear power plants, is ideal for MeV-scale neutrino experiments. Using a 1-ton prototype detector of the Jinping Neutrino Experiment (JNE), we detected 343 high-energy cosmic-ray muons and (7.86
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ \pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M1.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    3.97) muon-induced neutrons from an 820.28-day dataset at the first phase of CJPL (CJPL-I). Based on the muon-induced neutrons, we measured the corresponding muon-induced neutron yield in a liquid scintillator to be
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $(3.44 \pm 1.86_{\rm stat.}\pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M2.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ 0.76_{\rm syst.})\times 10^{-4}$?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M2-1.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    μ
+                    <sup>−1</sup>
+                    g
+                    <sup>−1</sup>
+                    cm
+                    <sup>2</sup>
+                    at an average muon energy of 340 GeV. We provided the first study for such neutron background at CJPL. A global fit including this measurement shows a power-law coefficient of (0.75
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ \pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M3.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    0.02) for the dependence of the neutron yield at the liquid scintillator on muon energy.
+                </p>
+            </abstract>
+            <custom-meta-group>
+                <custom-meta xlink:type="simple">
+                    <meta-name>arxivppt</meta-name>
+                    <meta-value>2108.04010</meta-value>
+                </custom-meta>
+            </custom-meta-group>
+        </article-meta>
+    </front>
+</article>

--- a/tests/units/iop/data/no_month_published.xml
+++ b/tests/units/iop/data/no_month_published.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" xml:lang="en">
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="publisher-id">cpc</journal-id>
+            <journal-title-group>
+                <journal-title xml:lang="en">Chinese Physics C</journal-title>
+            </journal-title-group>
+            <issn pub-type="ppub">1674-1137</issn>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="publisher-id">cpc_46_8_085001</article-id>
+            <article-id pub-id-type="doi">10.1088/1674-1137/ac66cc</article-id>
+            <article-id pub-id-type="manuscript">ac66cc</article-id>
+            <title-group>
+                <article-title>
+                    Measurement of muon-induced neutron yield at the China Jinping Underground Laboratory
+                    <xref ref-type="fn" rid="cpc_46_8_085001_fn1">*</xref>
+                    <fn id="cpc_46_8_085001_fn1">
+                        <label>*</label>
+                        <p>Supported in part by the National Natural Science Foundation of China (11620101004, 11475093, 12127808), the Key Laboratory of Particle &amp; Radiation Imaging (TsinghuaUniversity), the CAS Center for Excellence in Particle Physics (CCEPP), and Guangdong Basic and Applied Basic Research Foundation (2019A1515012216). Portion of this work performed at Brookhaven National Laboratory is supported in part by the United States Department of Energy (DE-SC0012704)</p>
+                    </fn>
+                </article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author" xlink:type="simple">
+                    <name name-style="western">
+                        <surname>Zhao</surname>
+                        <given-names>Lin</given-names>
+                    </name>
+                    <name content-type="non-latin-no-space" name-style="eastern">
+                        <surname>赵</surname>
+                        <given-names>林</given-names>
+                    </name>
+                    <xref ref-type="aff" rid="affiliation01">1</xref>
+                    <xref ref-type="aff" rid="affiliation02">2</xref>
+                </contrib>
+            </contrib-group>
+            <pub-date pub-type="ppub">
+                <day>03</day>
+                <year>2022</year>
+            </pub-date>
+            <permissions>
+                <copyright-statement>© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</copyright-statement>
+                <copyright-year>2022</copyright-year>
+                <license license-type="cc-by" xlink:href="http://creativecommons.org/licenses/by/3.0/" xlink:type="simple">
+                    <license-p>
+                        <graphic content-type="online" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_ccby.tif" xlink:type="simple" />
+                        Content from this work may be used under the terms of the
+                        <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/3.0" xlink:type="simple">Creative Commons Attribution 3.0 licence</ext-link>
+                        . Any further distribution of this work must maintain attribution to the author(s) and the title of the work, journal citation and DOI. Article funded by SCOAP
+                        <sup>3</sup>
+                        and published under licence by Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+                    </license-p>
+                </license>
+            </permissions>
+            <abstract>
+                <title>Abstract</title>
+                <p>
+                    Solar, terrestrial, and supernova neutrino experiments are subject to muon-induced radioactive background. The China Jinping Underground Laboratory (CJPL), with its unique advantage of a 2400 m rock coverage and long distance from nuclear power plants, is ideal for MeV-scale neutrino experiments. Using a 1-ton prototype detector of the Jinping Neutrino Experiment (JNE), we detected 343 high-energy cosmic-ray muons and (7.86
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ \pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M1.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    3.97) muon-induced neutrons from an 820.28-day dataset at the first phase of CJPL (CJPL-I). Based on the muon-induced neutrons, we measured the corresponding muon-induced neutron yield in a liquid scintillator to be
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $(3.44 \pm 1.86_{\rm stat.}\pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M2.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ 0.76_{\rm syst.})\times 10^{-4}$?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M2-1.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    μ
+                    <sup>−1</sup>
+                    g
+                    <sup>−1</sup>
+                    cm
+                    <sup>2</sup>
+                    at an average muon energy of 340 GeV. We provided the first study for such neutron background at CJPL. A global fit including this measurement shows a power-law coefficient of (0.75
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ \pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M3.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    0.02) for the dependence of the neutron yield at the liquid scintillator on muon energy.
+                </p>
+            </abstract>
+            <custom-meta-group>
+                <custom-meta xlink:type="simple">
+                    <meta-name>arxivppt</meta-name>
+                    <meta-value>2108.04010</meta-value>
+                </custom-meta>
+            </custom-meta-group>
+        </article-meta>
+    </front>
+</article>

--- a/tests/units/iop/data/no_year_published.xml
+++ b/tests/units/iop/data/no_year_published.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" xml:lang="en">
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="publisher-id">cpc</journal-id>
+            <journal-title-group>
+                <journal-title xml:lang="en">Chinese Physics C</journal-title>
+            </journal-title-group>
+            <issn pub-type="ppub">1674-1137</issn>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="publisher-id">cpc_46_8_085001</article-id>
+            <article-id pub-id-type="doi">10.1088/1674-1137/ac66cc</article-id>
+            <article-id pub-id-type="manuscript">ac66cc</article-id>
+            <title-group>
+                <article-title>
+                    Measurement of muon-induced neutron yield at the China Jinping Underground Laboratory
+                    <xref ref-type="fn" rid="cpc_46_8_085001_fn1">*</xref>
+                    <fn id="cpc_46_8_085001_fn1">
+                        <label>*</label>
+                        <p>Supported in part by the National Natural Science Foundation of China (11620101004, 11475093, 12127808), the Key Laboratory of Particle &amp; Radiation Imaging (TsinghuaUniversity), the CAS Center for Excellence in Particle Physics (CCEPP), and Guangdong Basic and Applied Basic Research Foundation (2019A1515012216). Portion of this work performed at Brookhaven National Laboratory is supported in part by the United States Department of Energy (DE-SC0012704)</p>
+                    </fn>
+                </article-title>
+            </title-group>
+            <contrib-group>
+                <contrib contrib-type="author" xlink:type="simple">
+                    <name name-style="western">
+                        <surname>Zhao</surname>
+                        <given-names>Lin</given-names>
+                    </name>
+                    <name content-type="non-latin-no-space" name-style="eastern">
+                        <surname>赵</surname>
+                        <given-names>林</given-names>
+                    </name>
+                    <xref ref-type="aff" rid="affiliation01">1</xref>
+                    <xref ref-type="aff" rid="affiliation02">2</xref>
+                </contrib>
+            </contrib-group>
+            <pub-date pub-type="ppub">
+                <day>01</day>
+                <month>8</month>
+            </pub-date>
+            <permissions>
+                <copyright-statement>© 2022 Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd</copyright-statement>
+                <copyright-year>2022</copyright-year>
+                <license license-type="cc-by" xlink:href="http://creativecommons.org/licenses/by/3.0/" xlink:type="simple">
+                    <license-p>
+                        <graphic content-type="online" orientation="portrait" position="float" xlink:href="cpc_46_8_085001_ccby.tif" xlink:type="simple" />
+                        Content from this work may be used under the terms of the
+                        <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/3.0" xlink:type="simple">Creative Commons Attribution 3.0 licence</ext-link>
+                        . Any further distribution of this work must maintain attribution to the author(s) and the title of the work, journal citation and DOI. Article funded by SCOAP
+                        <sup>3</sup>
+                        and published under licence by Chinese Physical Society and the Institute of High Energy Physics of the Chinese Academy of Sciences and the Institute of Modern Physics of the Chinese Academy of Sciences and IOP Publishing Ltd
+                    </license-p>
+                </license>
+            </permissions>
+            <abstract>
+                <title>Abstract</title>
+                <p>
+                    Solar, terrestrial, and supernova neutrino experiments are subject to muon-induced radioactive background. The China Jinping Underground Laboratory (CJPL), with its unique advantage of a 2400 m rock coverage and long distance from nuclear power plants, is ideal for MeV-scale neutrino experiments. Using a 1-ton prototype detector of the Jinping Neutrino Experiment (JNE), we detected 343 high-energy cosmic-ray muons and (7.86
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ \pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M1.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    3.97) muon-induced neutrons from an 820.28-day dataset at the first phase of CJPL (CJPL-I). Based on the muon-induced neutrons, we measured the corresponding muon-induced neutron yield in a liquid scintillator to be
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $(3.44 \pm 1.86_{\rm stat.}\pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M2.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ 0.76_{\rm syst.})\times 10^{-4}$?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M2-1.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    μ
+                    <sup>−1</sup>
+                    g
+                    <sup>−1</sup>
+                    cm
+                    <sup>2</sup>
+                    at an average muon energy of 340 GeV. We provided the first study for such neutron background at CJPL. A global fit including this measurement shows a power-law coefficient of (0.75
+                    <inline-formula>
+                        <tex-math>
+                            <?CDATA $ \pm $?>
+                        </tex-math>
+                        <inline-graphic xlink:href="cpc_46_8_085001_M3.jpg" xlink:type="simple" />
+                    </inline-formula>
+                    0.02) for the dependence of the neutron yield at the liquid scintillator on muon energy.
+                </p>
+            </abstract>
+            <custom-meta-group>
+                <custom-meta xlink:type="simple">
+                    <meta-name>arxivppt</meta-name>
+                    <meta-value>2108.04010</meta-value>
+                </custom-meta>
+            </custom-meta-group>
+        </article-meta>
+    </front>
+</article>

--- a/tests/units/iop/test_iop_parser.py
+++ b/tests/units/iop/test_iop_parser.py
@@ -125,6 +125,16 @@ def test_journal_doctype_log_error_without_value(shared_datadir, parser):
                 "event": "Country is not found in XML",
                 "log_level": "error",
             },
+            {
+                "class_name": "IOPParser",
+                "event": "Cannot find month of date_published in XML",
+                "log_level": "error",
+            },
+            {
+                "class_name": "IOPParser",
+                "event": "Cannot find day of date_published in XML",
+                "log_level": "error",
+            },
         ]
 
 
@@ -186,6 +196,16 @@ def test_realted_article_dois_log_error_without_value(shared_datadir, parser):
             {
                 "class_name": "IOPParser",
                 "event": "Country is not found in XML",
+                "log_level": "error",
+            },
+            {
+                "class_name": "IOPParser",
+                "event": "Cannot find month of date_published in XML",
+                "log_level": "error",
+            },
+            {
+                "class_name": "IOPParser",
+                "event": "Cannot find day of date_published in XML",
                 "log_level": "error",
             },
         ]
@@ -251,6 +271,16 @@ def test_no_arxiv_eprints_value_log_error_without_value(shared_datadir, parser):
                 "event": "Country is not found in XML",
                 "log_level": "error",
             },
+            {
+                "class_name": "IOPParser",
+                "event": "Cannot find month of date_published in XML",
+                "log_level": "error",
+            },
+            {
+                "class_name": "IOPParser",
+                "event": "Cannot find day of date_published in XML",
+                "log_level": "error",
+            },
         ]
 
 
@@ -299,6 +329,16 @@ def test_wrong_arxiv_eprints_value_log_error_without_value(shared_datadir, parse
             {
                 "class_name": "IOPParser",
                 "event": "Country is not found in XML",
+                "log_level": "error",
+            },
+            {
+                "class_name": "IOPParser",
+                "event": "Cannot find month of date_published in XML",
+                "log_level": "error",
+            },
+            {
+                "class_name": "IOPParser",
+                "event": "Cannot find day of date_published in XML",
                 "log_level": "error",
             },
         ]
@@ -388,7 +428,25 @@ def test_wrong_page_nr_value_log(shared_datadir, parser):
                 "event": "Country is not found in XML",
                 "log_level": "error",
             },
+            {
+                "class_name": "IOPParser",
+                "event": "Cannot find month of date_published in XML",
+                "log_level": "error",
+            },
+            {
+                "class_name": "IOPParser",
+                "event": "Cannot find day of date_published in XML",
+                "log_level": "error",
+            },
         ]
+
+
+def test_date_published(shared_datadir, parser):
+    content = (shared_datadir / "all_fields.xml").read_text()
+    article = ET.fromstring(content)
+    parsed_article = parser._publisher_specific_parsing(article)
+    assert parsed_article["date_published"] == "2022-08-01"
+    assert parsed_article["journal_year"] == 2022
 
 
 def test_authors(shared_datadir, parser):
@@ -753,6 +811,29 @@ def test_authors(shared_datadir, parser):
 
 def test_no_authors(shared_datadir, parser):
     content = (shared_datadir / "no_authors.xml").read_text()
+    article = ET.fromstring(content)
+    with raises(RequiredFieldNotFoundExtractionError):
+        parser._publisher_specific_parsing(article)
+
+
+def test_no_month_published(shared_datadir, parser):
+    content = (shared_datadir / "no_month_published.xml").read_text()
+    article = ET.fromstring(content)
+    parsed_article = parser._publisher_specific_parsing(article)
+    assert parsed_article["journal_year"] == 2022
+    assert parsed_article["date_published"] == "2022"
+
+
+def test_no_day_published(shared_datadir, parser):
+    content = (shared_datadir / "no_day_published.xml").read_text()
+    article = ET.fromstring(content)
+    parsed_article = parser._publisher_specific_parsing(article)
+    assert parsed_article["date_published"] == "2022-08"
+    assert parsed_article["journal_year"] == 2022
+
+
+def test_no_year_published(shared_datadir, parser):
+    content = (shared_datadir / "no_year_published.xml").read_text()
     article = ET.fromstring(content)
     with raises(RequiredFieldNotFoundExtractionError):
         parser._publisher_specific_parsing(article)


### PR DESCRIPTION
* parsed date published
* parsed year of date published as separate field, because this field is required
* added tests which are covering date_published and journal_year (which is a year from date_published)
* ref: ref: cern-sis/issues-scoap3#98