### PR TITLE
Use `PAT_FIRE_EVENTS_ON_CERN_SIS_KUBERNETES` for firing dispatch on k8s repository

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -72,10 +72,10 @@ jobs:
   Deploy:
     needs: [Build]
     uses: cern-sis/gh-workflows/.github/workflows/deploy-qa.yml@main
-    secrets: inherit
     with:
       project: scoap3
       application: scoap3-workflows
       namespace: scoap3-qa
       image: registry.cern.ch/cern-sis/workflows
+      PAT: ${{ secrets.PAT_FIRE_EVENTS_ON_CERN_SIS_KUBERNETES }}
  

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -77,5 +77,6 @@ jobs:
       application: scoap3-workflows
       namespace: scoap3-qa
       image: registry.cern.ch/cern-sis/workflows
+    secrets:
       PAT: ${{ secrets.PAT_FIRE_EVENTS_ON_CERN_SIS_KUBERNETES }}
  


### PR DESCRIPTION
Use the token instead of inheriting secrets, which is failing.