### PR TITLE
use if condition only for pushing images to registry

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_IMAGE: registry.cern.ch/cern-sis/workflows:${{ github.sha }}
-    if: ${{ github.event_name == 'push' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -60,12 +59,14 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
+        if: ${{ github.event_name == 'push' }}
         with:
           registry: registry.cern.ch
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_PASSWORD }}
 
       - name: Push
+        if: ${{ github.event_name == 'push' }}
         run: |
           docker push $DOCKER_IMAGE
 


### PR DESCRIPTION
Maybe we can use a composite action for pushing the image to registry to avoid repetitions?

Signed-off-by: jimil749 <jimildesai42@gmail.com>