### PR TITLE
workflows: ConnectionError and HTTPError catching in Request class

### DIFF
--- a/dags/common/request.py
+++ b/dags/common/request.py
@@ -32,7 +32,10 @@ class Request:
                     path_segments={self.path_segments}>"
 
     @backoff.on_exception(
-        backoff.expo, requests.exceptions.RequestException, max_time=60, max_tries=3
+        backoff.expo,
+        (requests.exceptions.RequestException, requests.exceptions.HTTPError),
+        max_time=60,
+        max_tries=3,
     )
     def get_response(self):
         url_base_obj = furl(self.base_url)


### PR DESCRIPTION
* APS files processing dag: caught ConnectionError error while calling arxiv.org API;
* Hindawi fetching files from API dag: caught HTTPError 504 Server Error: Gateway Time-out for url;
* ref: https://github.com/cern-sis/issues-scoap3/issues/111;