### PR TITLE
workflows: changed pysftp to paramiko

### DIFF
--- a/dags/common/utils.py
+++ b/dags/common/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import re
+from stat import S_ISDIR, S_ISREG
 
 from common.exceptions import UnknownFileExtension
 from structlog import get_logger
@@ -86,3 +87,13 @@ def find_extension(file):
     elif file.endswith(".pdf"):
         return "pdf"
     raise UnknownFileExtension(file)
+
+
+def walk_sftp(sftp, remotedir, paths):
+    for entry in sftp.listdir_attr(remotedir):
+        remotepath = remotedir + "/" + entry.filename
+        mode = entry.st_mode
+        if S_ISDIR(mode):
+            walk_sftp(sftp=sftp, remotedir=remotepath, paths=paths)
+        elif S_ISREG(mode):
+            paths.append(remotepath)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ botocore==1.24.39
 busypie==0.4.5
 dags==0.2.1
 mypy_boto3_s3==1.21.34
-pysftp==0.2.9
+paramiko==2.9.2
 pytest==7.1.0
 PyYAML==6.0
 furl==2.1.3

--- a/tests/units/common/test_sftp.py
+++ b/tests/units/common/test_sftp.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from common.sftp_service import DirectoryNotFoundException, SFTPService
-from pysftp import Connection
+from paramiko import SFTPClient
 from pytest import raises
 
 
@@ -13,7 +13,7 @@ def test_connect():
     assert initiate_sftp_service() is not None
 
 
-@patch.object(Connection, attribute="isdir", return_value=False)
+@patch.object(SFTPClient, attribute="stat", side_effect=FileNotFoundError)
 def test_connect_should_crash(connection_mock: MagicMock, *args):
     def initiate_sftp_service():
         with SFTPService():

--- a/tests/units/iop/test_iop_sftp.py
+++ b/tests/units/iop/test_iop_sftp.py
@@ -2,12 +2,13 @@ from iop.sftp_service import IOPSFTPService
 
 
 def test_iop_sftp_path():
-    files = []
     with IOPSFTPService() as sftp:
         files = sftp.list_files()
-    assert files == [
-        "2022-07-30T03_02_01_content.zip",
-        "2022-09-01T03_01_40_content.zip",
-        "2022-09-03T03_01_49_content.zip",
-        "2022-09-24T03_01_43_content.zip",
-    ]
+    assert sorted(files) == sorted(
+        [
+            "2022-07-30T03_02_01_content.zip",
+            "2022-09-01T03_01_40_content.zip",
+            "2022-09-03T03_01_49_content.zip",
+            "2022-09-24T03_01_43_content.zip",
+        ]
+    )


### PR DESCRIPTION
* Pysftp library is not maintained since 2016.
* Filed download with patamiko is 3 times faster comparing with pysftp.
* Changed pysftp to paramiko for sftp connection.
* ref: https://github.com/cern-sis/issues-scoap3/issues/123