### PR TITLE
workflows: reduced inconsistency with start/from dates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM apache/airflow:2.6.0-python3.10
 
-ENV PYTHONBUFFERED=0 
+ENV PYTHONBUFFERED=0
 ENV AIRFLOW_UID=501
 
 COPY requirements.txt ./requirements.txt
@@ -11,4 +11,4 @@ RUN pip install --upgrade pip &&\
     pip install --no-cache-dir --upgrade setuptools==59.1.1 &&\
     pip install --no-cache-dir --upgrade wheel &&\
     pip install --no-cache-dir --user -r requirements.txt -r requirements-test.txt
-    
+

--- a/dags/aps/aps.py
+++ b/dags/aps/aps.py
@@ -15,7 +15,7 @@ from common.utils import set_harvesting_interval
 @dag(
     start_date=pendulum.today("UTC").add(days=-1),
     schedule="@hourly",
-    params={"start_date": None, "until_date": None, "record_doi": None},
+    params={"from_date": None, "until_date": None, "record_doi": None},
 )
 def aps_fetch_api():
     @task()
@@ -25,7 +25,7 @@ def aps_fetch_api():
     @task()
     def save_json_in_s3(dates: dict, repo: IRepository = APSRepository()):
         parameters = APSParams(
-            from_date=dates["start_date"],
+            from_date=dates["from_date"],
             until_date=dates["until_date"],
         ).get_params()
         rest_api = APSApiClient(

--- a/dags/common/utils.py
+++ b/dags/common/utils.py
@@ -24,20 +24,20 @@ logger = get_logger()
 def set_harvesting_interval(repo, **kwargs):
     if (
         "params" in kwargs
-        and kwargs["params"].get("start_date")
+        and kwargs["params"].get("from_date")
         and kwargs["params"].get("until_date")
     ):
         return {
-            "start_date": kwargs["params"]["start_date"],
+            "from_date": kwargs["params"]["from_date"],
             "until_date": kwargs["params"]["until_date"],
         }
-    start_date = (
-        kwargs.get("params", {}).get("start_date")
+    from_date = (
+        kwargs.get("params", {}).get("from_date")
         or repo.find_the_last_uploaded_file_date()
     )
     until_date = datetime.date.today().strftime("%Y-%m-%d")
     return {
-        "start_date": (start_date or until_date),
+        "from_date": (from_date or until_date),
         "until_date": until_date,
     }
 

--- a/dags/hindawi/hindawi.py
+++ b/dags/hindawi/hindawi.py
@@ -14,7 +14,7 @@ from hindawi.utils import save_file_in_s3, split_xmls, trigger_file_processing_D
 @dag(
     start_date=pendulum.today("UTC").add(days=-1),
     schedule="30 */3 * * *",
-    params={"start_date": None, "until_date": None, "record_doi": None},
+    params={"from_date": None, "until_date": None, "record_doi": None},
 )
 def hindawi_fetch_api():
     @task()
@@ -25,7 +25,7 @@ def hindawi_fetch_api():
     def save_xml_in_s3(dates: dict, repo: IRepository = HindawiRepository(), **kwargs):
         record = kwargs["params"]["record_doi"]
         parameters = HindawiParams(
-            from_date=dates["start_date"], until_date=dates["until_date"], record=record
+            from_date=dates["from_date"], until_date=dates["until_date"], record=record
         ).get_params()
         rest_api = HindawiApiClient(
             base_url=os.getenv("HINDAWI_API_BASE_URL", "https://www.hindawi.com")

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ bleach==4.1.0
 inspire-utils==3.0.25
 backoff==2.0.1
 idutils==1.1.13
+pydantic==1.10.11

--- a/tests/integration/aps/test_utils.py
+++ b/tests/integration/aps/test_utils.py
@@ -27,14 +27,14 @@ def test_dag_loaded(dag: DAG):
 @pytest.mark.vcr
 def test_aps_fetch_api(dag: DAG):
     dates = {
-        "start_date": "2022-02-05",
+        "from_date": "2022-02-05",
         "until_date": "2022-03-05",
     }
     repo = APSRepository()
     repo.delete_all()
     assert len(repo.find_all()) == 0
     parameters = APSParams(
-        from_date=dates["start_date"],
+        from_date=dates["from_date"],
         until_date=dates["until_date"],
     ).get_params()
     aps_api_client = APSApiClient()
@@ -53,7 +53,7 @@ def test_dag_run(dag: DAG):
     dag.clear()
     dag.test(
         run_conf={
-            "start_date": "2022-02-05",
+            "from_date": "2022-02-05",
             "until_date": "2022-03-05",
         }
     )

--- a/tests/integration/common/test_rest_api_service.py
+++ b/tests/integration/common/test_rest_api_service.py
@@ -5,11 +5,11 @@ from aps.aps_params import APSParams
 from common.request import Request
 
 dates = {
-    "start_date": "2022-02-05",
+    "from_date": "2022-02-05",
     "until_date": "2022-03-05",
 }
 parameters = APSParams(
-    from_date=dates["start_date"], until_date=dates["until_date"]
+    from_date=dates["from_date"], until_date=dates["until_date"]
 ).get_params()
 
 exptected_params = {

--- a/tests/units/aps/test_utils.py
+++ b/tests/units/aps/test_utils.py
@@ -41,7 +41,7 @@ class MockedAPSApiClient:
 def test_set_APS_harvesting_interval(repo=MockedRepo()):
     today = date.today().strftime("%Y-%m-%d")
     expected_days = {
-        "start_date": today,
+        "from_date": today,
         "until_date": today,
     }
     dates = set_harvesting_interval(repo)

--- a/tests/units/hindawi/test_hindawi_utils.py
+++ b/tests/units/hindawi/test_hindawi_utils.py
@@ -32,7 +32,7 @@ class MockedHindawiApiClient:
 def test_set_Hindawi_harvesting_interval(repo=MockedRepo()):
     today = date.today().strftime("%Y-%m-%d")
     expected_days = {
-        "start_date": today,
+        "from_date": today,
         "until_date": today,
     }
     dates = set_harvesting_interval(repo)


### PR DESCRIPTION
* Change start_date to from_date in kwargs to have it consistent with API params.
* ref: https://github.com/cern-sis/issues-scoap3/issues/171