### PR TITLE
#358 ui: fix buggy display of links in the author's affiliations in article detailed

### DIFF
--- a/dags/aps/parser.py
+++ b/dags/aps/parser.py
@@ -97,11 +97,27 @@ class APSParser(IParser):
             if author["type"] == "Person"
         ]
 
+
+    def extract_organization_and_ror(self, text):
+        pattern = r'<a href="([^"]+)">(.*?)</a>'
+        
+        ror_url = None
+        
+        def replace_and_capture(match):
+            nonlocal ror_url
+            ror_url = match.group(1)
+            return match.group(2)
+        
+        modified_text = re.sub(pattern, replace_and_capture, text)
+        
+        return modified_text, ror_url
+
     def _get_affiliations(self, article, affiliationIds):
         parsed_affiliations = [
             {
                 "value": affiliation["name"],
-                "organization": (",").join(affiliation["name"].split(",")[:-1]),
+                "organization": self.extract_organization_and_ror(affiliation["name"])[0],
+                "ror": self.extract_organization_and_ror(affiliation["name"])[1],
             }
             for affiliation in article["affiliations"]
             if affiliation["id"] in affiliationIds

--- a/tests/units/aps/data/json_response_content.json
+++ b/tests/units/aps/data/json_response_content.json
@@ -38,11 +38,11 @@
       ],
       "affiliations": [
         {
-          "name": "Department of Physics, University of Oregon, Eugene, Oregon 97403, USA",
+          "name": "Department of Physics and Astronomy, <a href=\"https://ror.org/02vm5rt34\">Vanderbilt University</a>, Nashville, Tennessee 37240, USA",
           "id": "a1"
         },
         {
-          "name": "Department of Physics, Tsinghua University, Beijing 100084",
+          "name": "Department of Physics and Astronomy, <a href=\"https://ror.org/02vm5rt34\">Vanderbilt University</a>, Nashville, Tennessee 37240, USA",
           "id": "a2"
         }
       ],
@@ -179,7 +179,7 @@
       ],
       "affiliations": [
         {
-          "name": "Department of Physics, University of Toronto, Toronto, Ontario, Canada M5S1A7",
+          "name": "Department of Physics and Astronomy, <a href=\"https://ror.org/02vm5rt34\">Vanderbilt University</a>, Nashville, Tennessee 37240, USA",
           "id": "a1"
         }
       ],

--- a/tests/units/aps/test_aps_parser.py
+++ b/tests/units/aps/test_aps_parser.py
@@ -61,9 +61,9 @@ def parsed_articles(parser, articles):
                         "surname": "Wu",
                         "affiliations": [
                             {
-                                "value": "Department of Physics, University of Oregon, Eugene, Oregon 97403, USA",
-                                "organization": "Department of Physics, University of Oregon, Eugene, Oregon 97403",
-                                # "country": "USA",
+                                "value": "Department of Physics and Astronomy, <a href=\"https://ror.org/02vm5rt34\">Vanderbilt University</a>, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "ror": "https://ror.org/02vm5rt34"
                             }
                         ],
                     },
@@ -73,9 +73,9 @@ def parsed_articles(parser, articles):
                         "surname": "Turner",
                         "affiliations": [
                             {
-                                "value": "Department of Physics, University of Oregon, Eugene, Oregon 97403, USA",
-                                "organization": "Department of Physics, University of Oregon, Eugene, Oregon 97403",
-                                # "country": "USA",
+                                "value": "Department of Physics and Astronomy, <a href=\"https://ror.org/02vm5rt34\">Vanderbilt University</a>, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "ror": "https://ror.org/02vm5rt34"
                             }
                         ],
                     },
@@ -85,9 +85,9 @@ def parsed_articles(parser, articles):
                         "surname": "Wang",
                         "affiliations": [
                             {
-                                "value": "Department of Physics, University of Oregon, Eugene, Oregon 97403, USA",
-                                "organization": "Department of Physics, University of Oregon, Eugene, Oregon 97403",
-                                # "country": "USA",
+                                "value": "Department of Physics and Astronomy, <a href=\"https://ror.org/02vm5rt34\">Vanderbilt University</a>, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "ror": "https://ror.org/02vm5rt34"
                             }
                         ],
                     },
@@ -97,9 +97,9 @@ def parsed_articles(parser, articles):
                         "surname": "Borel",
                         "affiliations": [
                             {
-                                "value": "Department of Physics, Tsinghua University, Beijing 100084",
-                                "organization": "Department of Physics, Tsinghua University",
-                                # "country": "China",
+                                "value": "Department of Physics and Astronomy, <a href=\"https://ror.org/02vm5rt34\">Vanderbilt University</a>, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "ror": "https://ror.org/02vm5rt34"
                             }
                         ],
                     },
@@ -111,9 +111,9 @@ def parsed_articles(parser, articles):
                         "surname": "Boudjada",
                         "affiliations": [
                             {
-                                "value": "Department of Physics, University of Toronto, Toronto, Ontario, Canada M5S1A7",
-                                "organization": "Department of Physics, University of Toronto, Toronto, Ontario",
-                                # "country": "Canada",
+                                "value": "Department of Physics and Astronomy, <a href=\"https://ror.org/02vm5rt34\">Vanderbilt University</a>, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "ror": "https://ror.org/02vm5rt34"
                             }
                         ],
                     },
@@ -123,9 +123,9 @@ def parsed_articles(parser, articles):
                         "surname": "Buessen",
                         "affiliations": [
                             {
-                                "value": "Department of Physics, University of Toronto, Toronto, Ontario, Canada M5S1A7",
-                                "organization": "Department of Physics, University of Toronto, Toronto, Ontario",
-                                # "country": "Canada",
+                                "value": "Department of Physics and Astronomy, <a href=\"https://ror.org/02vm5rt34\">Vanderbilt University</a>, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "ror": "https://ror.org/02vm5rt34"
                             }
                         ],
                     },
@@ -135,9 +135,9 @@ def parsed_articles(parser, articles):
                         "surname": "Paramekanti",
                         "affiliations": [
                             {
-                                "value": "Department of Physics, University of Toronto, Toronto, Ontario, Canada M5S1A7",
-                                "organization": "Department of Physics, University of Toronto, Toronto, Ontario",
-                                # "country": "Canada",
+                                "value": "Department of Physics and Astronomy, <a href=\"https://ror.org/02vm5rt34\">Vanderbilt University</a>, Nashville, Tennessee 37240, USA",
+                                "organization": "Department of Physics and Astronomy, Vanderbilt University, Nashville, Tennessee 37240, USA",
+                                "ror": "https://ror.org/02vm5rt34"
                             }
                         ],
                     },


### PR DESCRIPTION
Altered APS parser in order to add ror field.

Issue #358 (https://github.com/cern-sis/issues-scoap3/issues/358)