### PR TITLE
fix(OUP): parse pdfa path with .extracted

### DIFF
--- a/dags/oup/parser.py
+++ b/dags/oup/parser.py
@@ -276,7 +276,7 @@ class OUPParser(IParser):
         dir_path = os.path.dirname(self.file_path)
         file_name = os.path.basename(self.file_path).split(".")[0]
         pdf_dir_path = dir_path.replace("xml", "pdf")
-        pdfa_dir_path = dir_path.replace(".xml", "_archival")
+        pdfa_dir_path = dir_path.replace(".xml", ".archival")
         pdf_path = os.path.join(pdf_dir_path, f"{file_name}.pdf")
         pdfa_path = os.path.join(pdfa_dir_path, f"{file_name}.pdf")
 


### PR DESCRIPTION
e.g in the end, the file will be copied from:

`extracted/May/8-May-25/ptep_iss_2025_5_part1.archival/ptaf056.pdf`

instead of

`extracted/May/8-May-25/ptep_iss_2025_5_part1_archival/ptaf056.pdf`

ref: https://github.com/cern-sis/issues-scoap3/issues/442