### PR TITLE
fix(OUP): parse pdfa path with .extracted

### DIFF
--- a/dags/common/scoap3_s3.py
+++ b/dags/common/scoap3_s3.py
@@ -12,12 +12,13 @@ FILE_EXTENSIONS = {"pdf": ".pdf", "xml": ".xml", "pdfa": ".pdf"}
 
 
 def update_filename_extension(filename, type):
+    if type == "pdfa":
+        return filename.replace(".pdf", "_a.pdf")
+
     extension = FILE_EXTENSIONS.get(type, "")
     if filename.endswith(extension):
         return filename
     elif extension:
-        if type == "pdfa":
-            extension = ".a-2b.pdf"
         return f"{filename}{extension}"
 
 


### PR DESCRIPTION
e.g in the end, the file will be copied from:

extracted/May/8-May-25/ptep_iss_2025_5_part1.archival/ptaf056.pdf

instead of

extracted/May/8-May-25/ptep_iss_2025_5_part1_archival/ptaf056.pdf