### PR TITLE
fix: fix _get_text_value for xml parser

### DIFF
--- a/dags/common/parsing/xml_extractors.py
+++ b/dags/common/parsing/xml_extractors.py
@@ -19,6 +19,7 @@ class TextExtractor(IExtractor):
         extra_function=lambda s: s,
         prefixes=None,
         all_content_between_tags=False,
+        use_itertext=False,
         remove_tags=False,
     ):
         super().__init__(destination)
@@ -30,11 +31,19 @@ class TextExtractor(IExtractor):
         self.default_value = default_value
         self.extra_function = extra_function
         self.all_content_between_tags = all_content_between_tags
+        self.use_itertext = use_itertext
         self.remove_tags = remove_tags
 
     def _get_text_value(self, raw_value):
         try:
-            return raw_value.text
+            return raw_value.text.strip()
+        except AttributeError:
+            logger.error("%s is not found in XML", self.destination)
+            return
+
+    def _get_itertext_value(self, node):
+        try:
+            return "".join(node.itertext()).strip()
         except AttributeError:
             logger.error("%s is not found in XML", self.destination)
             return
@@ -80,6 +89,8 @@ class TextExtractor(IExtractor):
 
         if self.all_content_between_tags:
             value = self._get_content_as_text_value(node)
+        elif self.use_itertext:
+            value = self._get_itertext_value(node)
         else:
             value = self._get_text_value(node)
         processed_value = self._process_text_with_extra_function(value)

--- a/dags/springer/parser.py
+++ b/dags/springer/parser.py
@@ -58,6 +58,8 @@ class SpringerParser(IParser):
             TextExtractor(
                 "title",
                 "./Journal/Volume/Issue/Article/ArticleInfo/ArticleTitle",
+                required=True,
+                use_itertext=True,
             ),
             CustomExtractor("authors", self._get_authors),
             TextExtractor(

--- a/tests/units/springer/test_parser.py
+++ b/tests/units/springer/test_parser.py
@@ -68,10 +68,8 @@ def test_weird_titles(parsed_articles):
     parsed_titles = sorted([a.get("title") for a in parsed_articles])
     expected_results = sorted(
         [
-            " $$(g-2)_{e,\\mu }$$ anomalies and decays $$h\\rightarrow e_a e_b$$ , "
-            "$$Z\\rightarrow e_ae_b$$ , and $$e_b\\rightarrow e_a \\gamma $$ in a two "
-            "Higgs doublet model with inverse seesaw neutrinos",
-            " $$\\Lambda $$ polarization in very high energy heavy ion collisions as a probe of the quark–gluon plasma formation and properties",
+            "$$(g-2)_{e,\\mu }$$ anomalies and decays $$h\\rightarrow e_a e_b$$ , $$Z\\rightarrow e_ae_b$$ , and $$e_b\\rightarrow e_a \\gamma $$ in a two Higgs doublet model with inverse seesaw neutrinos",
+            "$$\\Lambda $$ polarization in very high energy heavy ion collisions as a probe of the quark–gluon plasma formation and properties",
             "A strategy for a general search for new phenomena using data-derived signal regions and its application within the ATLAS experiment",
             "Measurement of the inclusive branching fractions for $${B}_{s}^{0}$$ decays into $\\textit{D}$ mesons via hadronic tagging",
             "Quasi-normal modes of slowly-rotating Johannsen black holes",


### PR DESCRIPTION
fixes a parsing issue which leads to some title fields staying empty, see https://github.com/cern-sis/issues-scoap3/issues/483 for examples.

The `.text` attribute used before only returns the text directly inside the element before the first child. This is in general not what we want and also leads to the return value None in cases like:
```
<ArticleTitle>
  <Emphasis>stanhf</Emphasis>: <Emphasis>HistFactory</Emphasis>
  models in the probabilistic programming language
  <Emphasis>Stan</Emphasis>
</ArticleTitle>
```