### PR TITLE
global: update airflow version and add custom es provider

### DIFF
--- a/base-images/airflow/Dockerfile
+++ b/base-images/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/docker.io/apache/airflow:3.1.5-python3.12 AS base
+FROM registry.cern.ch/docker.io/apache/airflow:slim-3.1.8-python3.12 AS base
 USER root
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -12,9 +12,11 @@ WORKDIR /opt/airflow
 
 ENV PYTHONBUFFERED=0
 
-COPY base-images/airflow/requirements/requirements.txt ./requirements.txt
-COPY base-images/airflow/requirements/requirements-test.txt ./requirements-test.txt
-COPY base-images/airflow/requirements/requirements-airflow.txt ./requirements-airflow.txt
+
+
+COPY --chown=airflow:0 base-images/airflow/requirements/requirements.txt ./requirements.txt
+COPY --chown=airflow:0 base-images/airflow/requirements/requirements-test.txt ./requirements-test.txt
+COPY --chown=airflow:0 base-images/airflow/requirements/requirements-airflow.txt ./requirements-airflow.txt
 
 RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools wheel

--- a/base-images/airflow/requirements/requirements-airflow.txt
+++ b/base-images/airflow/requirements/requirements-airflow.txt
@@ -1,7 +1,7 @@
 # Add some requirmenets needed for the helm chart to function
--c https://raw.githubusercontent.com/apache/airflow/constraints-3.1.5/constraints-3.12.txt
-apache-airflow[celery, postgres, redis, cncf.kubernetes, sentry, amazon]==3.1.5
+-c https://raw.githubusercontent.com/apache/airflow/constraints-3.1.8/constraints-3.12.txt
+apache-airflow[celery, postgres, redis, cncf.kubernetes, sentry, amazon, fab]==3.1.8
 apache-airflow-providers-fab
-connexion[flask]<3.0
 flask-appbuilder
 flask-session
+git+https://github.com/cern-sis/airflow-elasticsearch-provider


### PR DESCRIPTION
Updates airflow base image to 3.1.8 and adds custom es provider which works with our opensearch

ref: https://github.com/cern-sis/issues-scoap3/issues/500