### PR TITLE
gh-actions: bump versions

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -34,10 +34,10 @@ jobs:
     outputs:
       image-id: ${{ steps.build.outputs.image-id }}
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
-      - uses: cern-sis/gh-workflows/.github/actions/docker-build@v6.5
+      - uses: cern-sis/gh-workflows/.github/actions/docker-build@v7.0.0
         id: build
         with:
           image: ${{ inputs.image }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send event
-        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v6.3.1
+        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v7.0.0
         with:
           event-type: release
           repo: cern-sis/kubernetes-airflow

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -27,8 +27,8 @@ jobs:
     outputs:
       airflow: ${{ steps.filter.outputs.airflow }}
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           base: ${{ github.ref }}
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send event
-        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v6.3.1
+        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v7.0.0
         with:
           event-type: update
           repo: cern-sis/kubernetes-airflow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
       - name: Registry login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: registry.cern.ch
           username: ${{ secrets.HARBOR_USERNAME }}

--- a/.github/workflows/trigger-dev-build-and-push.yml
+++ b/.github/workflows/trigger-dev-build-and-push.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send event
-        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v6.3.1
+        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v7.0.0
         with:
           event-type: update
           repo: cern-sis/kubernetes-airflow


### PR DESCRIPTION
GitHub Actions has deprecated NodeJS 20 actions.

See more at https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/